### PR TITLE
Model extension for DataSetFilter (story #1710)

### DIFF
--- a/molgenis-core/src/main/java/org/molgenis/generators/server/EntityControllerGen.java.ftl
+++ b/molgenis-core/src/main/java/org/molgenis/generators/server/EntityControllerGen.java.ftl
@@ -24,10 +24,12 @@ import org.molgenis.service.${entity.name}Service;
 <#if !field.system && !field.hidden && field.name != "__Type">
 	<#if field.type == "xref" || field.type == "mref">
 		<#if !javaImports?seq_contains("${field.xrefEntity.name}")>
+			<#if (!(field.xrefField??) || !field.xrefField.system) && (!(field.xrefEntity??) || !field.xrefEntity.system)>
 import ${field.xrefEntity.namespace}.${JavaName(field.xrefEntity)};
 import org.molgenis.controller.${JavaName(field.xrefEntity)}Controller.${JavaName(field.xrefEntity)}Response;
 import org.molgenis.service.${field.xrefEntity.name}Service;
-			<#assign javaImports = javaImports + ["${field.xrefEntity.name}"]>
+				<#assign javaImports = javaImports + ["${field.xrefEntity.name}"]>
+			</#if>
 		</#if>
 	</#if>
 </#if>
@@ -67,10 +69,12 @@ public class ${entity.name}Controller
 <#if !field.system && !field.hidden && field.name != "__Type">
 	<#if field.type == "xref" || field.type == "mref">
 		<#if !javaFields?seq_contains("${field.xrefEntity.name}")>
+			<#if (!(field.xrefField??) || !field.xrefField.system) && (!(field.xrefEntity??) || !field.xrefEntity.system)>
 	@Autowired
 	private ${field.xrefEntity.name}Service ${field.xrefEntity.name?uncap_first}Service;
-	
-			<#assign javaFields = javaFields + ["${field.xrefEntity.name}"]>
+		
+				<#assign javaFields = javaFields + ["${field.xrefEntity.name}"]>
+			</#if>
 		</#if>
 	</#if>
 </#if>
@@ -395,8 +399,12 @@ public class ${entity.name}Controller
 			this.href = "/api/v1/${entity.name?lower_case}/" + ${entity.name?uncap_first}.get${field.name?cap_first}();
 		<#elseif !field.system && !field.hidden && field.name != "__Type">
 			<#if field.type == "xref">
-			if (expandFields != null && expandFields.contains("${field.name?uncap_first}")) this.${field.name?uncap_first} = <#if field.nillable>${entity.name?uncap_first}.get${field.name?cap_first}() == null ? null : </#if>new ${field.xrefEntity.name}Response(${entity.name?uncap_first}.get${field.name?cap_first}(), null);
-			else this.${field.name?uncap_first} = <#if field.nillable>${entity.name?uncap_first}.get${field.name?cap_first}() == null ? null : </#if>java.util.Collections.singletonMap("href", "/api/v1/${entity.name?lower_case}/" + ${entity.name?uncap_first}.get${entity.primaryKey.name?cap_first}() + "/${field.name?uncap_first}");	
+				<#if field.xrefField??>
+				this.${field.name?uncap_first} = ${entity.name?uncap_first}.get${field.name?cap_first}_${field.xrefField.name?cap_first}();
+				<#else>
+				if (expandFields != null && expandFields.contains("${field.name?uncap_first}")) this.${field.name?uncap_first} = <#if field.nillable>${entity.name?uncap_first}.get${field.name?cap_first}() == null ? null : </#if>new ${field.xrefEntity.name}Response(${entity.name?uncap_first}.get${field.name?cap_first}(), null);
+				else this.${field.name?uncap_first} = <#if field.nillable>${entity.name?uncap_first}.get${field.name?cap_first}() == null ? null : </#if>java.util.Collections.singletonMap("href", "/api/v1/${entity.name?lower_case}/" + ${entity.name?uncap_first}.get${entity.primaryKey.name?cap_first}() + "/${field.name?uncap_first}");
+				</#if>	
 			<#elseif field.type == "mref">
 			java.util.List<${field.xrefEntity.name}> ${field.xrefEntity.name?uncap_first}Collection = ${entity.name?uncap_first}.get${field.name?cap_first}();
 			if (expandFields != null && expandFields.contains("${field.name?uncap_first}")) this.${field.name?uncap_first} = <#if field.nillable>${field.xrefEntity.name?uncap_first}Collection == null ? null : </#if>_retrieve${entity.name}Mref${field.name?cap_first}(${entity.name?uncap_first}, new EntityCollectionRequest());

--- a/molgenis-core/src/main/java/org/molgenis/generators/server/EntityControllerTestGen.java.ftl
+++ b/molgenis-core/src/main/java/org/molgenis/generators/server/EntityControllerTestGen.java.ftl
@@ -26,8 +26,10 @@ import org.molgenis.service.${entity.name}Service;
 <#if !field.system && !field.hidden && field.name != "__Type">
 	<#if field.type == "xref" || field.type == "mref">
 		<#if !javaImports?seq_contains("${field.xrefEntity.name}")>
+			<#if (!(field.xrefField??) || !field.xrefField.system) && (!(field.xrefEntity??) || !field.xrefEntity.system)>
 import org.molgenis.service.${field.xrefEntity.name}Service;
-			<#assign javaImports = javaImports + ["${field.xrefEntity.name}"]>
+				<#assign javaImports = javaImports + ["${field.xrefEntity.name}"]>
+			</#if>
 		</#if>
 	</#if>
 </#if>
@@ -178,12 +180,14 @@ public class ${entity.name}ControllerTest extends AbstractTestNGSpringContextTes
 <#if !field.system && !field.hidden && field.name != "__Type">
 	<#if field.type == "xref" || field.type == "mref">
 		<#if !javaImports?seq_contains("${field.xrefEntity.name}")>
+			<#if (!(field.xrefField??) || !field.xrefField.system) && (!(field.xrefEntity??) || !field.xrefEntity.system)>
 		@Bean
 		public ${field.xrefEntity.name}Service ${field.xrefEntity.name?uncap_first}Service()
 		{
 			return mock(${field.xrefEntity.name}Service.class);
 		}
-			<#assign javaImports = javaImports + ["${field.xrefEntity.name}"]>
+				<#assign javaImports = javaImports + ["${field.xrefEntity.name}"]>
+			</#if>
 		</#if>
 		
 	</#if>

--- a/molgenis-omx-auth/src/main/java/org/molgenis/omx/filter/decorators/DataSetFilterDecorator.java
+++ b/molgenis-omx-auth/src/main/java/org/molgenis/omx/filter/decorators/DataSetFilterDecorator.java
@@ -1,0 +1,205 @@
+package org.molgenis.omx.filter.decorators;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.molgenis.framework.db.DatabaseAccessException;
+import org.molgenis.framework.db.DatabaseException;
+import org.molgenis.framework.db.Mapper;
+import org.molgenis.framework.db.MapperDecorator;
+import org.molgenis.framework.db.QueryRule;
+import org.molgenis.framework.db.QueryRule.Operator;
+import org.molgenis.io.TupleReader;
+import org.molgenis.io.TupleWriter;
+import org.molgenis.omx.auth.MolgenisUser;
+import org.molgenis.omx.auth.service.MolgenisUserService;
+import org.molgenis.omx.filter.DataSetFilter;
+
+/**
+ * decorator for DataSetFilter, Checks for every read, update and delete
+ * operation if the user requesting the operation matches the user owning the
+ * DataSetFilter on which the operation is requested
+ */
+public class DataSetFilterDecorator<E extends DataSetFilter> extends MapperDecorator<E>
+{
+
+	private MolgenisUserService userService;
+
+	public DataSetFilterDecorator(Mapper<E> generatedMapper)
+	{
+		super(generatedMapper);
+	}
+
+	@Override
+	public int count(QueryRule... rules) throws DatabaseException
+	{
+		rules = addUserRule(rules);
+		return super.count(rules);
+	}
+
+	@Override
+	public List<E> find(QueryRule... rules) throws DatabaseException
+	{
+		rules = addUserRule(rules);
+		return super.find(rules);
+	}
+
+	@Override
+	public void find(TupleWriter writer, QueryRule... rules) throws DatabaseException
+	{
+		rules = addUserRule(rules);
+		super.find(writer, rules);
+	}
+
+	@Override
+	public int update(List<E> entities) throws DatabaseException
+	{
+		checkEntitiesPermission(entities);
+		return super.update(entities);
+	}
+
+	@Override
+	public int remove(List<E> entities) throws DatabaseException
+	{
+		checkEntitiesPermission(entities);
+		return super.remove(entities);
+	}
+
+	@Override
+	public void find(TupleWriter writer, List<String> fieldsToExport, QueryRule[] rules) throws DatabaseException
+	{
+		rules = addUserRule(rules);
+		super.find(writer, fieldsToExport, rules);
+	}
+
+	@Override
+	public String createFindSqlInclRules(QueryRule[] rules) throws DatabaseException
+	{
+		rules = addUserRule(rules);
+		return super.createFindSqlInclRules(rules);
+	}
+
+	@Override
+	public E findById(Object id) throws DatabaseException
+	{
+		MolgenisUser user = getCurrentUser();
+		E entity = super.findById(id);
+		if (!hasEntityPermission(entity) && !user.getSuperuser())
+		{
+			throw new DatabaseAccessException("No permission on DataSetFilter");
+		}
+		return entity;
+	}
+
+	@Override
+	public List<E> findByExample(E example) throws DatabaseException
+	{
+		List<E> entities = super.findByExample(example);
+		List<E> filteredEntities = filterEntities(entities);
+		return filteredEntities;
+	}
+
+	private List<E> filterEntities(List<E> entities) throws DatabaseException
+	{
+		MolgenisUser user = getCurrentUser();
+		List<E> filteredEntities = new ArrayList<E>();
+		if (!user.getSuperuser())
+		{
+			for (DataSetFilter filter : entities)
+			{
+				if (hasEntityPermission(filter))
+				{
+					filteredEntities.add((E) filter);
+				}
+			}
+		}
+		else
+		{
+			filteredEntities = entities;
+		}
+		return filteredEntities;
+	}
+
+	private MolgenisUser getCurrentUser() throws DatabaseException
+	{
+		return getMolgenisUserService().findById(getDatabase().getLogin().getUserId());
+	}
+
+	public MolgenisUserService getMolgenisUserService()
+	{
+		if (userService == null)
+		{
+			userService = MolgenisUserService.getInstance(getDatabase());
+		}
+		return userService;
+	}
+
+	public void setMolgenisUserService(MolgenisUserService service)
+	{
+		this.userService = service;
+	}
+
+	public QueryRule[] addUserRule(QueryRule[] array) throws DatabaseException
+	{
+		MolgenisUser user = getCurrentUser();
+		if (user.getSuperuser())
+		{
+			return array;
+		}
+
+		QueryRule rule = new QueryRule("userId", Operator.EQUALS, user.getId());
+		return addRule(array, rule);
+	}
+
+	public QueryRule[] addRule(QueryRule[] array, QueryRule rule)
+	{
+		QueryRule[] anotherArray = new QueryRule[array.length + 1];
+		System.arraycopy(array, 0, anotherArray, 0, array.length);
+		anotherArray[array.length] = rule;
+
+		return anotherArray;
+	}
+
+	private void checkEntitiesPermission(List<E> entities) throws DatabaseException
+	{
+		MolgenisUser user = getCurrentUser();
+		if (!user.getSuperuser())
+		{
+			for (DataSetFilter filter : entities)
+			{
+				if (!hasEntityPermission(filter))
+				{
+					throw new DatabaseAccessException("No permission on DataSetFilter");
+				}
+			}
+		}
+	}
+
+	private boolean hasEntityPermission(DataSetFilter filter) throws DatabaseException
+	{
+		MolgenisUser user = getCurrentUser();
+		if (!user.getId().equals(filter.getUserId_Id()))
+		{
+			return false;
+		}
+		return true;
+	}
+
+	@Override
+	public int update(TupleReader reader) throws DatabaseException
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public int remove(TupleReader reader) throws DatabaseException
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public List<E> toList(TupleReader reader, int limit) throws DatabaseException
+	{
+		throw new UnsupportedOperationException();
+	}
+}

--- a/molgenis-omx-auth/src/main/resources/model/filter.xml
+++ b/molgenis-omx-auth/src/main/resources/model/filter.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<molgenis name="org.molgenis.omx">
+	<module name="filter">
+		<description>
+			Model extention to make it possible to store a DataSetFilter that is
+			linked to a user
+		</description>
+		<entity name="DataSetFilter" extends="Characteristic"
+			decorator="org.molgenis.omx.filter.decorators.DataSetFilterDecorator">
+			<description>A selection of features that can be stored in the
+				database</description>
+			<field name="UserId" type="xref" xref_entity="MolgenisUser"
+				xref_field="id"/>
+			<field name="DataSet" type="xref" xref_entity="DataSet" />
+		</entity>
+		<entity name="FeatureFilter" implements="Autoid">
+			<description>A Filter on a specific set of values in a Feature</description>
+			<field name="PartOfDataSetFilter" type="xref" xref_entity="DataSetFilter" />
+			<field name="Feature" type="xref" xref_entity="ObservableFeature" />
+			<!-- <field name="Filter" type="xref" xref_entity="ObservableFeatureFilter" 
+				nillable="true"/> -->
+		</entity>
+	</module>
+</molgenis>

--- a/molgenis-omx-auth/src/main/resources/molgenis.properties
+++ b/molgenis-omx-auth/src/main/resources/molgenis.properties
@@ -6,7 +6,8 @@
 # 1. XML ENTITY DESCRIPTION FILES
 ###############################################################
 
-model_database =	model/auth.xml
+model_database =	model/auth.xml,\
+					model/filter.xml
 						
 import_model_database =	model/system.xml,\
 						model/observ.xml

--- a/molgenis-omx-auth/src/test/java/org/molgenis/omx/filter/decorators/DataSetFilterDecoratorTestAdmin.java
+++ b/molgenis-omx-auth/src/test/java/org/molgenis/omx/filter/decorators/DataSetFilterDecoratorTestAdmin.java
@@ -1,0 +1,157 @@
+package org.molgenis.omx.filter.decorators;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.molgenis.framework.db.Database;
+import org.molgenis.framework.db.DatabaseException;
+import org.molgenis.framework.db.Mapper;
+import org.molgenis.framework.db.QueryRule;
+import org.molgenis.framework.db.QueryRule.Operator;
+import org.molgenis.framework.security.Login;
+import org.molgenis.io.TupleWriter;
+import org.molgenis.omx.auth.MolgenisUser;
+import org.molgenis.omx.auth.service.MolgenisUserService;
+import org.molgenis.omx.filter.DataSetFilter;
+import org.molgenis.util.HandleRequestDelegationException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DataSetFilterDecoratorTestAdmin
+{
+	private MolgenisUser user;
+	private DataSetFilterDecorator<DataSetFilter> decorator;
+	private final QueryRule[] rules = new QueryRule[0];
+	private MolgenisUserService userService;
+	private Mapper mapper;
+	private QueryRule[] expectedRules;
+	private TupleWriter writer;
+	private List<String> fieldsToExport;
+	private List<DataSetFilter> allEntities;
+	private List<DataSetFilter> ownEntities;
+	private List<DataSetFilter> otherEntities;
+	private DataSetFilter ownFilter;
+	private DataSetFilter otherFilter;
+	
+	@BeforeMethod
+	public void setUp() throws HandleRequestDelegationException, Exception
+	{
+		allEntities = new ArrayList<DataSetFilter>();
+		ownEntities = new ArrayList<DataSetFilter>();
+		otherEntities = new ArrayList<DataSetFilter>();
+		
+		user = mock(MolgenisUser.class);
+		mapper = mock(Mapper.class);
+		when(mapper.findById(123)).thenReturn(ownFilter);
+		when(mapper.findById(456)).thenReturn(otherFilter);
+		decorator = new DataSetFilterDecorator(mapper);
+		Login login = mock(Login.class);
+		Database database = mock(Database.class);
+		userService = mock(MolgenisUserService.class);
+		
+		when(mapper.getDatabase()).thenReturn(database);
+		when(mapper.findByExample(ownFilter)).thenReturn(allEntities);
+		when(database.getLogin()).thenReturn(login);
+		when(login.getUserId()).thenReturn(1);
+		when(userService.findById(1)).thenReturn(user);
+		when(user.getSuperuser()).thenReturn(true);
+		when(user.getId()).thenReturn(1);
+		
+		decorator.setMolgenisUserService(userService);
+		expectedRules = new QueryRule[1];
+		expectedRules[0] = new QueryRule("userId", Operator.EQUALS, 1);
+		ownFilter = new DataSetFilter();
+		ownFilter.setUserId(1);
+		ownEntities.add(ownFilter);
+		otherFilter = new DataSetFilter();
+		otherFilter.setUserId(2);
+		otherEntities.add(otherFilter);
+		allEntities.add(ownFilter);
+		allEntities.add(otherFilter);
+	}
+
+	@Test
+	public void find() throws DatabaseException
+	{
+		decorator.find(rules);
+		verify(mapper).find(rules);
+	}
+
+	@Test
+	public void count() throws DatabaseException
+	{
+		decorator.find(rules);
+		verify(mapper).find(rules);
+	}
+
+	@Test
+	public void findWithWriter() throws DatabaseException
+	{
+		decorator.find(writer, rules);
+		verify(mapper).find(writer, rules);
+	}
+
+	@Test
+	public void createFindSqlInclRules() throws DatabaseException
+	{
+		decorator.createFindSqlInclRules(rules);
+		verify(mapper).createFindSqlInclRules(rules);
+	}
+
+	@Test
+	public void findWithExport() throws DatabaseException
+	{
+		decorator.find(writer, fieldsToExport, rules);
+		verify(mapper).find(writer, fieldsToExport, rules);
+	}
+
+	@Test
+	public void ownFindByExample() throws DatabaseException
+	{
+		List<DataSetFilter> results = decorator.findByExample(ownFilter);
+		Assert.assertEquals(results, allEntities);	
+	}
+	
+	//read, update, delete own entities, no exceptions expected
+	@Test
+	public void updateOwn() throws DatabaseException
+	{
+		decorator.update(ownEntities);		
+	}
+	
+	@Test
+	public void removeOwn() throws DatabaseException
+	{
+		decorator.remove(ownEntities);		
+	}
+	
+	@Test
+	public void ownFindById() throws DatabaseException
+	{
+		decorator.findById(123);
+	}
+	
+	//update and delete entities owned by another person, exceptions expected
+	@Test()
+	public void updateOther() throws DatabaseException
+	{
+		decorator.update(otherEntities);		
+	}
+	
+	@Test()
+	public void removeOther() throws DatabaseException
+	{
+		decorator.remove(otherEntities);		
+	}
+	
+	@Test()
+	public void otherFindById() throws DatabaseException
+	{
+		decorator.findById(456);
+	}
+}

--- a/molgenis-omx-auth/src/test/java/org/molgenis/omx/filter/decorators/DataSetFilterDecoratorTestUser.java
+++ b/molgenis-omx-auth/src/test/java/org/molgenis/omx/filter/decorators/DataSetFilterDecoratorTestUser.java
@@ -1,0 +1,178 @@
+package org.molgenis.omx.filter.decorators;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.molgenis.framework.db.Database;
+import org.molgenis.framework.db.DatabaseException;
+import org.molgenis.framework.db.Mapper;
+import org.molgenis.framework.db.QueryRule;
+import org.molgenis.framework.db.QueryRule.Operator;
+import org.molgenis.framework.security.Login;
+import org.molgenis.io.TupleReader;
+import org.molgenis.io.TupleWriter;
+import org.molgenis.omx.auth.MolgenisUser;
+import org.molgenis.omx.auth.service.MolgenisUserService;
+import org.molgenis.omx.filter.DataSetFilter;
+import org.molgenis.util.HandleRequestDelegationException;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class DataSetFilterDecoratorTestUser
+{
+	private MolgenisUser user;
+	private DataSetFilterDecorator<DataSetFilter> decorator;
+	private final QueryRule[] rules = new QueryRule[0];
+	private MolgenisUserService userService;
+	private Mapper mapper;
+	private QueryRule[] expectedRules;
+	private TupleWriter writer;
+	private TupleReader reader;
+	private List<String> fieldsToExport;
+	private List<DataSetFilter> allEntities;
+	private List<DataSetFilter> ownEntities;
+	private List<DataSetFilter> otherEntities;
+	private DataSetFilter ownFilter;
+	private DataSetFilter otherFilter;
+
+	@BeforeMethod
+	public void setUp() throws HandleRequestDelegationException, Exception
+	{
+		allEntities = new ArrayList<DataSetFilter>();
+		ownEntities = new ArrayList<DataSetFilter>();
+		otherEntities = new ArrayList<DataSetFilter>();
+
+		user = mock(MolgenisUser.class);
+		mapper = mock(Mapper.class);
+		decorator = new DataSetFilterDecorator(mapper);
+		Login login = mock(Login.class);
+		Database database = mock(Database.class);
+		userService = mock(MolgenisUserService.class);
+
+		when(mapper.getDatabase()).thenReturn(database);
+		when(mapper.findByExample(ownFilter)).thenReturn(allEntities);
+		when(mapper.findById(123)).thenReturn(ownFilter);
+		when(mapper.findById(456)).thenReturn(otherFilter);
+		when(database.getLogin()).thenReturn(login);
+		when(login.getUserId()).thenReturn(1);
+		when(userService.findById(1)).thenReturn(user);
+		when(user.getSuperuser()).thenReturn(false);
+		when(user.getId()).thenReturn(1);
+
+		decorator.setMolgenisUserService(userService);
+		expectedRules = new QueryRule[1];
+		expectedRules[0] = new QueryRule("userId", Operator.EQUALS, 1);
+		ownFilter = new DataSetFilter();
+		ownFilter.setUserId(1);
+		ownEntities.add(ownFilter);
+		otherFilter = new DataSetFilter();
+		otherFilter.setUserId(2);
+		otherEntities.add(otherFilter);
+		allEntities.add(ownFilter);
+		allEntities.add(otherFilter);
+	}
+
+	@Test
+	public void find() throws DatabaseException
+	{
+		decorator.find(rules);
+		verify(mapper).find(expectedRules);
+	}
+
+	@Test
+	public void count() throws DatabaseException
+	{
+		decorator.count(rules);
+		verify(mapper).count(expectedRules);
+	}
+
+	@Test
+	public void findWithWriter() throws DatabaseException
+	{
+		decorator.find(writer, rules);
+		verify(mapper).find(writer, expectedRules);
+	}
+
+	@Test
+	public void createFindSqlInclRules() throws DatabaseException
+	{
+		decorator.createFindSqlInclRules(rules);
+		verify(mapper).createFindSqlInclRules(expectedRules);
+	}
+
+	@Test
+	public void findWithExport() throws DatabaseException
+	{
+		decorator.find(writer, fieldsToExport, rules);
+		verify(mapper).find(writer, fieldsToExport, expectedRules);
+	}
+
+	@Test
+	public void ownFindByExample() throws DatabaseException
+	{
+		List<DataSetFilter> results = decorator.findByExample(ownFilter);
+		Assert.assertEquals(results, ownEntities);
+	}
+
+	// read, update, delete own entities, no exceptions expected
+	@Test
+	public void updateOwn() throws DatabaseException
+	{
+		decorator.update(ownEntities);
+	}
+
+	@Test
+	public void removeOwn() throws DatabaseException
+	{
+		decorator.remove(ownEntities);
+	}
+
+	@Test
+	public void ownFindById() throws DatabaseException
+	{
+		decorator.findById(123);
+	}
+
+	// update and delete entities owned by another person, exceptions expected
+	@Test(expectedExceptions = DatabaseException.class)
+	public void updateOther() throws DatabaseException
+	{
+		decorator.update(otherEntities);
+	}
+
+	@Test(expectedExceptions = DatabaseException.class)
+	public void removeOther() throws DatabaseException
+	{
+		decorator.remove(otherEntities);
+	}
+
+	@Test(expectedExceptions = DatabaseException.class)
+	public void otherFindById() throws DatabaseException
+	{
+		decorator.findById(456);
+	}
+
+	@Test(expectedExceptions = UnsupportedOperationException.class)
+	public void tupleUpdate() throws DatabaseException
+	{
+
+		decorator.update(reader);
+	}
+
+	@Test(expectedExceptions = UnsupportedOperationException.class)
+	public void tupleRemove() throws DatabaseException
+	{
+		decorator.remove(reader);
+	}
+
+	@Test(expectedExceptions = UnsupportedOperationException.class)
+	public void tupleToList() throws DatabaseException
+	{
+		decorator.toList(reader, -1);
+	}
+}


### PR DESCRIPTION
- extension to the model (filter.xml)
- decorator for the dataSetFilter entity (new entity introduced by the model extension) + tests
- changes to the entityController to make the relation between DataSetFilter and MolgenisUser possible without exposing all the MolgenisUser fields
