### PR TITLE
Eclipse code formatting: comment width 80 --> 120

### DIFF
--- a/eclipse-java-molgenis-style.xml
+++ b/eclipse-java-molgenis-style.xml
@@ -524,7 +524,7 @@
 			id="org.eclipse.jdt.core.formatter.comment.format_javadoc_comments"
 			value="true" />
 		<setting id="org.eclipse.jdt.core.formatter.comment.line_length"
-			value="80" />
+			value="120" />
 		<setting
 			id="org.eclipse.jdt.core.formatter.blank_lines_between_import_groups"
 			value="1" />


### PR DESCRIPTION
Update comment width from 80 to 120, similar to code line width
