### PR TITLE
Show "no result message" if no data items are matched with query

### DIFF
--- a/molgenis-omx-protocolviewer/src/main/resources/js/protocolviewer.js
+++ b/molgenis-omx-protocolviewer/src/main/resources/js/protocolviewer.js
@@ -277,7 +277,7 @@
 		}
 		
 		console.log("searchObservationSets: " + query);
-		searchQuery = query;
+		searchQuery = $.trim(query);
 		
 		searchApi.search(ns.createSearchRequest(), function(searchResponse) {
 			var protocol = restApi.get(protocolUri);


### PR DESCRIPTION
1. show no result message if no data items are matched with query
2. fixed the bug where the second time search did not show any results after nothing was found in first time search. 
