### PR TITLE
Create JAXBContext only once (story #1962)

### DIFF
--- a/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/catalogue/GenericLayerCatalogueLoaderService.java
+++ b/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/catalogue/GenericLayerCatalogueLoaderService.java
@@ -46,6 +46,22 @@ public class GenericLayerCatalogueLoaderService implements CatalogLoaderService
 {
 	private static final Logger logger = Logger.getLogger(GenericLayerCatalogueLoaderService.class);
 
+	private static final JAXBContext JAXB_CONTEXT_VALUESETS;
+	private static final JAXBContext JAXB_CONTEXT_ORGANIZER;
+
+	static
+	{
+		try
+		{
+			JAXB_CONTEXT_VALUESETS = JAXBContext.newInstance(ValueSets.class);
+			JAXB_CONTEXT_ORGANIZER = JAXBContext.newInstance(REPCMT000100UV01Organizer.class);
+		}
+		catch (JAXBException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
 	private final Database database;
 	private final GenericLayerCatalogService genericLayerCatalogService;
 	private final GenericLayerResourceManagerService resourceManagerService;
@@ -168,8 +184,7 @@ public class GenericLayerCatalogueLoaderService implements CatalogLoaderService
 		ValueSets valueSets;
 		try
 		{
-			JAXBContext jaxbContext = JAXBContext.newInstance(ValueSets.class);
-			Unmarshaller um = jaxbContext.createUnmarshaller();
+			Unmarshaller um = JAXB_CONTEXT_VALUESETS.createUnmarshaller();
 			valueSets = um.unmarshal((Node) valueSetsResult.getAny(), ValueSets.class).getValue();
 		}
 		catch (JAXBException e)
@@ -226,8 +241,7 @@ public class GenericLayerCatalogueLoaderService implements CatalogLoaderService
 		REPCMT000100UV01Organizer catalog;
 		try
 		{
-			JAXBContext jaxbContext = JAXBContext.newInstance(REPCMT000100UV01Organizer.class);
-			Unmarshaller um = jaxbContext.createUnmarshaller();
+			Unmarshaller um = JAXB_CONTEXT_ORGANIZER.createUnmarshaller();
 			catalog = um.unmarshal((Node) catalogResult.getAny(), REPCMT000100UV01Organizer.class).getValue();
 		}
 		catch (JAXBException e)

--- a/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/resourcemanager/GenericLayerResourceManagerService.java
+++ b/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/resourcemanager/GenericLayerResourceManagerService.java
@@ -44,6 +44,20 @@ public class GenericLayerResourceManagerService
 {
 	private static final Logger LOG = Logger.getLogger(GenericLayerResourceManagerService.class);
 
+	private static final JAXBContext JAXB_CONTEXT_ATOM;
+
+	static
+	{
+		try
+		{
+			JAXB_CONTEXT_ATOM = JAXBContext.newInstance("org.molgenis.atom");
+		}
+		catch (JAXBException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+	
 	private final HttpClient httpClient;
 	private final String resourceManagerServiceUrl;
 	private final GenericLayerDataBinder genericLayerDataBinder;
@@ -231,8 +245,7 @@ public class GenericLayerResourceManagerService
 
 	private FeedType getFeed(String uri) throws JAXBException, IOException
 	{
-		JAXBContext jaxbContext = JAXBContext.newInstance("org.molgenis.atom");
-		Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+		Unmarshaller jaxbUnmarshaller = JAXB_CONTEXT_ATOM.createUnmarshaller();
 
 		HttpGet httpGet = new HttpGet(resourceManagerServiceUrl + uri);
 		InputStream xmlStream = null;

--- a/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/studydefinition/GenericLayerDataQueryService.java
+++ b/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/studydefinition/GenericLayerDataQueryService.java
@@ -53,6 +53,20 @@ public class GenericLayerDataQueryService
 {
 	private static final Logger logger = Logger.getLogger(GenericLayerResourceManagerService.class);
 
+	private static final JAXBContext JAXB_CONTEXT_ACT_CATEGORY;
+
+	static
+	{
+		try
+		{
+			JAXB_CONTEXT_ACT_CATEGORY = JAXBContext.newInstance(REPCMT000400UV01ActCategory.class);
+		}
+		catch (JAXBException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+	
 	@Autowired
 	private HttpClient httpClient;
 	@Autowired
@@ -99,8 +113,7 @@ public class GenericLayerDataQueryService
 				if (statusCode < 200 || statusCode > 299) throw new IOException(
 						"Error persisting study definition (statuscode " + statusCode + ")");
 				xmlStream = response.getEntity().getContent();
-				JAXBContext jaxbContext = JAXBContext.newInstance(REPCMT000400UV01ActCategory.class);
-				actCategory = jaxbContext.createUnmarshaller()
+				actCategory = JAXB_CONTEXT_ACT_CATEGORY.createUnmarshaller()
 						.unmarshal(new StreamSource(xmlStream), REPCMT000400UV01ActCategory.class).getValue();
 			}
 			catch (RuntimeException e)

--- a/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/utils/GenericLayerDataBinder.java
+++ b/molgenis-app-lifelines/src/main/java/org/molgenis/lifelines/utils/GenericLayerDataBinder.java
@@ -10,6 +10,20 @@ import org.molgenis.hl7.POQMMT000001UVQualityMeasureDocument;
 
 public class GenericLayerDataBinder
 {
+	private static final JAXBContext JAXB_CONTEXT_QUALITY_MEASURE_DOCUMENT;
+
+	static
+	{
+		try
+		{
+			JAXB_CONTEXT_QUALITY_MEASURE_DOCUMENT = JAXBContext.newInstance(POQMMT000001UVQualityMeasureDocument.class);
+		}
+		catch (JAXBException e)
+		{
+			throw new RuntimeException(e);
+		}
+	}
+
 	private final Schema eMeasureSchema;
 
 	public GenericLayerDataBinder(Schema eMeasureSchema)
@@ -20,16 +34,14 @@ public class GenericLayerDataBinder
 
 	public Marshaller createQualityMeasureDocumentMarshaller() throws JAXBException
 	{
-		JAXBContext jaxbContext = JAXBContext.newInstance(POQMMT000001UVQualityMeasureDocument.class);
-		Marshaller jaxbMarshaller = jaxbContext.createMarshaller();
+		Marshaller jaxbMarshaller = JAXB_CONTEXT_QUALITY_MEASURE_DOCUMENT.createMarshaller();
 		jaxbMarshaller.setSchema(eMeasureSchema);
 		return jaxbMarshaller;
 	}
 
 	public Unmarshaller createQualityMeasureDocumentUnmarshaller() throws JAXBException
 	{
-		JAXBContext jaxbContext = JAXBContext.newInstance(POQMMT000001UVQualityMeasureDocument.class);
-		Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
+		Unmarshaller jaxbUnmarshaller = JAXB_CONTEXT_QUALITY_MEASURE_DOCUMENT.createUnmarshaller();
 		jaxbUnmarshaller.setSchema(eMeasureSchema);
 		return jaxbUnmarshaller;
 	}


### PR DESCRIPTION
Solve performance bottleneck, only create each JAXBContext once (JAXBContext is thread safe)
