### PR TITLE
Updated datasetDeleter to fix some bugs

### DIFF
--- a/molgenis-app-omx/src/test/java/org/molgenis/omx/datasetdeleter/DataSetDeleterServiceImplTest.java
+++ b/molgenis-app-omx/src/test/java/org/molgenis/omx/datasetdeleter/DataSetDeleterServiceImplTest.java
@@ -46,7 +46,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 	private static Protocol protocol1;
 	private static Protocol protocol2;
 	private static Protocol protocol3;
-	private static List<Protocol> allProtocols;
+	private static List<Entity> allEntities;
 	private static List<Protocol> subProtocols;
 	private static ObservationSet observationSet0;
 	private static ObservationSet observationSet1;
@@ -117,7 +117,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 	{
 		features0 = new ArrayList<ObservableFeature>();
 		features1 = new ArrayList<ObservableFeature>();
-		allProtocols = new ArrayList<Protocol>();
+		allEntities = new ArrayList<Entity>();
 		subProtocols = new ArrayList<Protocol>();
 		subProtocols1 = new ArrayList<Protocol>();
 		categories = new ArrayList<Category>();
@@ -157,10 +157,10 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 		protocol3.setSubprotocols(subProtocols1);
 		protocol3.setId(3);
 
-		allProtocols.add(protocol0);
-		allProtocols.add(protocol1);
-		allProtocols.add(protocol2);
-		allProtocols.add(protocol3);
+		allEntities.add(protocol0);
+		allEntities.add(protocol1);
+		allEntities.add(protocol2);
+		allEntities.add(protocol3);
 
 		subProtocols.add(protocol0);
 
@@ -169,7 +169,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 		protocolUsed.setIdentifier("protocolUsed_identifier");
 		protocolUsed.setId(100);
 		protocolUsed.setSubprotocols(subProtocols);
-		allProtocols.add(protocolUsed);
+		allEntities.add(protocolUsed);
 
 		dataset = new DataSet();
 		dataset.setId(0);
@@ -240,14 +240,14 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 	@Test
 	public void countReferringProtocolsSingleReferences()
 	{
-		int result = dataSetDeleterServiceImpl.countReferringProtocols(protocol0, allProtocols);
+		int result = dataSetDeleterServiceImpl.countReferringEntities(protocol0, allEntities);
 		assertEquals(1, result);
 	}
 
 	@Test
 	public void countReferringProtocolMultipleReferences()
 	{
-		int result = dataSetDeleterServiceImpl.countReferringProtocols(protocol1, allProtocols);
+		int result = dataSetDeleterServiceImpl.countReferringEntities(protocol1, allEntities);
 		assertEquals(2, result);
 	}
 
@@ -257,7 +257,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 		when(dataService.findOne(DataSet.ENTITY_NAME,
 				new QueryImpl().eq(DataSet.IDENTIFIER, "dataset1"))).thenReturn(dataset);
 		
-		dataSetDeleterServiceImpl.delete("dataset1", true);
+		dataSetDeleterServiceImpl.deleteMetadata("dataset1");
 		verify(dataService).delete(DataSet.ENTITY_NAME, dataset);
 	}
 
@@ -267,7 +267,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 		when(dataService.findOne(DataSet.ENTITY_NAME,
 				new QueryImpl().eq(DataSet.IDENTIFIER, "dataset1"))).thenReturn(dataset);
 		
-		dataSetDeleterServiceImpl.delete("dataset1", false);
+		dataSetDeleterServiceImpl.deleteData("dataset1");
 		verify(dataService, Mockito.times(0)).delete(DataSet.ENTITY_NAME, dataset);
 	}
 
@@ -295,7 +295,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 	@Test
 	public void deleteFeatures()
 	{
-		dataSetDeleterServiceImpl.deleteFeatures(features0, allProtocols);
+		dataSetDeleterServiceImpl.deleteFeatures(features0, allEntities);
 		verify(dataService, Mockito.atLeastOnce()).delete(eq(ObservableFeature.ENTITY_NAME), captorFeatures.capture());
 		assertEquals("feature0", captorFeatures.getValue().get(0).getIdentifier());
 		assertEquals(1, captorFeatures.getValue().size());
@@ -304,7 +304,7 @@ public class DataSetDeleterServiceImplTest extends AbstractTestNGSpringContextTe
 	@Test
 	public void deleteProtocol()
 	{
-		dataSetDeleterServiceImpl.deleteProtocol(protocolUsed, allProtocols);
+		dataSetDeleterServiceImpl.deleteProtocol(protocolUsed, allEntities);
 		verify(dataService).delete(Protocol.ENTITY_NAME, protocolUsed);
 		verify(dataService).delete(Protocol.ENTITY_NAME, subProtocols);
 		verify(dataService, Mockito.times(0)).delete(Protocol.ENTITY_NAME, protocol1);

--- a/molgenis-omx-core/src/main/java/org/molgenis/omx/datasetdeleter/DataSetDeleterController.java
+++ b/molgenis-omx-core/src/main/java/org/molgenis/omx/datasetdeleter/DataSetDeleterController.java
@@ -56,7 +56,10 @@ public class DataSetDeleterController extends MolgenisPluginController
 			@RequestParam(value = "deletemetadata", required = false) Boolean deleteMetaData) throws DatabaseException
 	{
 		boolean doDeleteMetaData = deleteMetaData != null ? deleteMetaData.booleanValue() : false;
-		DataSet dataSet = dataSetDeleterService.delete(dataSetIdentifier, doDeleteMetaData);
-		return dataSet.getName();
+		String dataSetName = dataSetDeleterService.deleteData(dataSetIdentifier);
+		if(doDeleteMetaData){
+			dataSetDeleterService.deleteMetadata(dataSetIdentifier);
+		}
+		return dataSetName;
 	}
 }

--- a/molgenis-omx-core/src/main/java/org/molgenis/omx/datasetdeleter/DataSetDeleterService.java
+++ b/molgenis-omx-core/src/main/java/org/molgenis/omx/datasetdeleter/DataSetDeleterService.java
@@ -5,5 +5,6 @@ import org.molgenis.omx.observ.DataSet;
 
 public interface DataSetDeleterService
 {
-	DataSet delete(String dataSetIdentifier, boolean deleteMetaData) throws DatabaseException;
+	String deleteData(String dataSetIdentifier);
+	boolean deleteMetadata(String dataSetIdentifier);
 }

--- a/molgenis-omx-core/src/main/java/org/molgenis/omx/datasetdeleter/DataSetDeleterServiceImpl.java
+++ b/molgenis-omx-core/src/main/java/org/molgenis/omx/datasetdeleter/DataSetDeleterServiceImpl.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.molgenis.data.DataService;
-import org.molgenis.data.MolgenisDataException;
+import org.molgenis.data.Entity;
 import org.molgenis.data.support.QueryImpl;
 import org.molgenis.omx.observ.Category;
 import org.molgenis.omx.observ.Characteristic;
@@ -35,23 +35,34 @@ public class DataSetDeleterServiceImpl implements DataSetDeleterService
 	}
 
 	@Override
-	@Transactional(rollbackFor = MolgenisDataException.class)
-	public DataSet delete(String dataSetIdentifier, boolean deleteMetaData)
+	@Transactional
+	public String deleteData(String dataSetIdentifier)
+	{
+		DataSet dataSet = dataService.findOne(DataSet.ENTITY_NAME,
+				new QueryImpl().eq(DataSet.IDENTIFIER, dataSetIdentifier));
+		deleteData(dataSet);
+		searchService.deleteDocumentsByType(dataSet.getIdentifier());
+
+		return dataSet.getName();
+	}
+	
+	@Override
+	@Transactional
+	public boolean deleteMetadata(String dataSetIdentifier)
 	{
 		DataSet dataSet = dataService.findOne(DataSet.ENTITY_NAME,
 				new QueryImpl().eq(DataSet.IDENTIFIER, dataSetIdentifier));
 
-		deleteData(dataSet);
-		if (deleteMetaData)
-		{
-			List<Protocol> allProtocols = dataService.findAllAsList(Protocol.ENTITY_NAME, new QueryImpl());
+			List<Entity> entitiesList = dataService.findAllAsList(ObservedValue.ENTITY_NAME, new QueryImpl());
+			entitiesList.addAll(dataService.findAllAsList(Protocol.ENTITY_NAME, new QueryImpl()));
+			entitiesList.addAll(dataService.findAllAsList(DataSet.ENTITY_NAME, new QueryImpl()));
+			entitiesList.remove(dataSet);
+			
 			Protocol protocolUsed = dataSet.getProtocolUsed();
 			dataService.delete(DataSet.ENTITY_NAME, dataSet);
-			deleteProtocol(protocolUsed, allProtocols);
-		}
-		searchService.deleteDocumentsByType(dataSet.getIdentifier());
-
-		return dataSet;
+			deleteProtocol(protocolUsed, entitiesList);
+		
+		return true;
 	}
 
 	/**
@@ -98,42 +109,48 @@ public class DataSetDeleterServiceImpl implements DataSetDeleterService
 	 * @param the
 	 *            protocols that should be deleted
 	 */
-	List<Protocol> deleteProtocol(Protocol protocol, List<Protocol> allProtocols)
+	List<Entity> deleteProtocol(Protocol protocol, List<Entity> entitiesList)
 	{
 		boolean deleteInBatch = true;
-		List<Protocol> subprotocols = protocol.getSubprotocols();
+		List<Protocol> subprotocolsToDelete = protocol.getSubprotocols();
+		List<Protocol> subprotocolsToKeep = new ArrayList<Protocol>();
+		
 		// check if any of the subprotocols had subprotocols of its own
-		for (Protocol subprotocol : subprotocols)
+		for (Protocol subprotocol : subprotocolsToDelete)
 		{
 			if (subprotocol.getSubprotocols().size() > 0) deleteInBatch = false;
 		}
-		for (Protocol subprotocol : subprotocols)
+		for (Protocol subprotocol : subprotocolsToDelete)
 		{
-			int superprotocolcount = countReferringProtocols(subprotocol, allProtocols);
-			// only delete if there is only one parent protocol
-			if (superprotocolcount <= 1)
+			int superprotocolcount = countReferringEntities(subprotocol, entitiesList);
+			if (superprotocolcount == 1)
 			{
 				if (!deleteInBatch)
 				{
-					allProtocols = deleteProtocol(subprotocol, allProtocols);
+					entitiesList = deleteProtocol(subprotocol, entitiesList);
 				}
 				else
 				{
-					List<ObservableFeature> features = subprotocol.getFeatures();
-					deleteFeatures(features, allProtocols);
+					List<ObservableFeature> subFeatures = subprotocol.getFeatures();
+					deleteFeatures(subFeatures, entitiesList);
 				}
 			}
+			else
+			{
+				subprotocolsToKeep.add(subprotocol);
+			}
 		}
-		List<ObservableFeature> features = protocol.getFeatures();
 		if (deleteInBatch)
 		{
-			dataService.delete(Protocol.ENTITY_NAME, subprotocols);
-			allProtocols.removeAll(subprotocols);
+			subprotocolsToDelete.removeAll(subprotocolsToKeep);
+			dataService.delete(Protocol.ENTITY_NAME, subprotocolsToDelete);
+			entitiesList.removeAll(subprotocolsToDelete);
 		}
-		dataService.delete(Protocol.ENTITY_NAME, protocol);
-		deleteFeatures(features, allProtocols);
-		allProtocols.remove(protocol);
-		return allProtocols;
+			List<ObservableFeature> features = protocol.getFeatures();
+			dataService.delete(Protocol.ENTITY_NAME, protocol);
+			entitiesList.remove(protocol);
+			deleteFeatures(features, entitiesList);
+		return entitiesList;
 	}
 
 	/**
@@ -144,7 +161,7 @@ public class DataSetDeleterServiceImpl implements DataSetDeleterService
 	 * @param the
 	 *            features that should be deleted
 	 */
-	void deleteFeatures(List<ObservableFeature> features, List<Protocol> allProtocols)
+	void deleteFeatures(List<ObservableFeature> features, List<Entity> entitiesList)
 	{
 		List<ObservableFeature> removableFeatures = new ArrayList<ObservableFeature>();
 
@@ -154,8 +171,8 @@ public class DataSetDeleterServiceImpl implements DataSetDeleterService
 					new QueryImpl().eq(Category.OBSERVABLEFEATURE, feature));
 			deleteCategories(categories);
 
-			int protocolcount = countReferringProtocols(feature, allProtocols);
-			if (protocolcount <= 1)
+			int entityCount = countReferringEntities(feature, entitiesList);
+			if (entityCount <= 1)
 			{
 				removableFeatures.add(feature);
 			}
@@ -194,18 +211,40 @@ public class DataSetDeleterServiceImpl implements DataSetDeleterService
 	 * 
 	 * @return the number of referring protocols
 	 */
-	int countReferringProtocols(Characteristic characteristic, List<Protocol> allProtocols)
+	int countReferringEntities(Characteristic characteristic, List<Entity> entitiesList)
 	{
-		int protocolcount = 0;
+		int entityCount = 0;
 		Class<? extends Characteristic> clazz = characteristic.getClass();
-		for (Protocol p : allProtocols)
+
+		for (Entity entity : entitiesList)
 		{
-			if ((clazz.equals(ObservableFeature.class) && p.getFeatures().contains(characteristic) || (clazz
-					.equals(Protocol.class) && p.getSubprotocols().contains(characteristic))))
+			if (entity.getClass().equals(Protocol.class))
 			{
-				protocolcount++;
+				Protocol protocol = (Protocol) entity;
+				if ((clazz.equals(ObservableFeature.class) && protocol.getFeatures().contains(characteristic) || (clazz
+						.equals(Protocol.class) && protocol.getSubprotocols().contains(characteristic))))
+				{
+					entityCount++;
+				}
+			}
+			if (entity.getClass().equals(DataSet.class))
+			{
+				DataSet dataSet = (DataSet) entity;
+				if ((clazz.equals(Protocol.class) && dataSet.getProtocolUsed().getIdentifier()
+						.equals(characteristic.getIdentifier())))
+				{
+					entityCount++;
+				}
+			}
+			if (entity.getClass().equals(ObservedValue.class))
+			{
+				ObservedValue value = (ObservedValue) entity;			
+				if (clazz.equals(ObservableFeature.class) && value.getFeature().equals(characteristic))
+				{
+					entityCount++;
+				}
 			}
 		}
-		return protocolcount;
+		return entityCount;
 	}
 }


### PR DESCRIPTION
exporter should be datasetDeleter in the commit message.

fixes voor bugs  #906 and #926.

Not all metadata is removed, this behaviour is not introduced neither is it fixed in this commit, a new issue is in place to report this behaviour. (#973)
