### PR TITLE
Fix #1043 : Indexer indexes protocols/categories with DataSet instead of Protocol id

### DIFF
--- a/molgenis-omx-core/src/main/java/org/molgenis/omx/search/AsyncDataSetsIndexer.java
+++ b/molgenis-omx-core/src/main/java/org/molgenis/omx/search/AsyncDataSetsIndexer.java
@@ -65,9 +65,9 @@ public class AsyncDataSetsIndexer implements DataSetsIndexer, InitializingBean
 			{
 				searchService.indexRepository(new DataSetMatrixRepository(dataService, dataSet.getIdentifier()));
 				searchService.indexRepository(new ProtocolTreeRepository(dataSet.getProtocolUsed(), dataService,
-						"protocolTree-" + dataSet.getId()));
-				searchService.indexRepository(new CategoryRepository(dataSet.getProtocolUsed(), dataSet.getId(),
-						dataService));
+						"protocolTree-" + dataSet.getProtocolUsed().getId()));
+				searchService.indexRepository(new CategoryRepository(dataSet.getProtocolUsed(), dataSet
+						.getProtocolUsed().getId(), dataService));
 			}
 		}
 		catch (Exception e)


### PR DESCRIPTION
Fix #1043
