### PR TITLE
Update elasticsearch 0.90.7 to 0.90.13 (updates lucene 4.5.1 to 4.6.1)

### DIFF
--- a/molgenis-search-elasticsearch/pom.xml
+++ b/molgenis-search-elasticsearch/pom.xml
@@ -22,7 +22,7 @@
         <dependency>
     		<groupId>org.elasticsearch</groupId>
     		<artifactId>elasticsearch</artifactId>
-    		<version>0.90.7</version>
+    		<version>0.90.13</version>
 		</dependency> 
 		<dependency>
 			<groupId>org.springframework</groupId>


### PR DESCRIPTION
- backwards compatible
- Lucene 4.6.1 contains new features required M2589
