### PR TITLE
Added a warning to the googleSearch regex parsing, if start position is ...

### DIFF
--- a/molgenis-omx-dataexplorer/src/main/resources/js/dataexplorer.js
+++ b/molgenis-omx-dataexplorer/src/main/resources/js/dataexplorer.js
@@ -165,7 +165,7 @@
 						
 						if(parseInt(startPosition, 10) > parseInt(stopPosition, 10)) {
 							molgenis.createAlert([{message: 'Start is greater then stop, please check your input'}], 'warning');
-						}else {
+						}else{
 							$('.alerts').empty();
 						}
 						


### PR DESCRIPTION
...bigger then stop position. Searching again with a correct term will remove the warning.
