### PR TITLE
Fix popovers increasing the container height 

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/jquery.molgenis.table.js
+++ b/molgenis-core-ui/src/main/resources/js/jquery.molgenis.table.js
@@ -167,7 +167,7 @@
 		}
 		container.html(items);
 
-		$('.show-popover').popover({trigger:'hover', placement: 'bottom'});
+		$('.show-popover').popover({trigger:'hover', placement: 'bottom', container: 'body'});
 	}
 
 	/**


### PR DESCRIPTION
Popovers existed in the same div as their triggers, activating scrollbars by increasing the height. Added container: body to popovers fixes this, by letting it sit ontop of all other elements.
