### PR TITLE
Update to 1.3.0-SNAPSHOT.

### DIFF
--- a/molgenis-annotators/pom.xml
+++ b/molgenis-annotators/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-annotators</artifactId>
 	<packaging>jar</packaging>
@@ -12,32 +12,32 @@
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-omx-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-csv</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-omx</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.springframework</groupId>
@@ -55,7 +55,7 @@
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-annotators</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 	</dependencies>
 </project>

--- a/molgenis-app-omx/pom.xml
+++ b/molgenis-app-omx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-app-omx</artifactId>
 	<packaging>war</packaging>
@@ -122,22 +122,22 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.security</groupId>
@@ -152,42 +152,42 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-biobankconnect</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-dataexplorer</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-protocolviewer</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-excel</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-csv</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-disease-matcher</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-googlespreadsheet</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>servlet-api</artifactId>
@@ -198,72 +198,72 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-jpa</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>		
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-omx</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-r</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-annotators</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-mutationdb</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-annotators</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-charts</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-rest</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-merge</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-vcf</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-mysql</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
          <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-import</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
          <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-catalogue</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-elasticsearch</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
@@ -280,12 +280,12 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-das</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-model-registry</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>

--- a/molgenis-catalogue/pom.xml
+++ b/molgenis-catalogue/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>molgenis</artifactId>
         <groupId>org.molgenis</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,17 +15,17 @@
     	<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-core-ui</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 </project>

--- a/molgenis-charts/pom.xml
+++ b/molgenis-charts/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 	  <groupId>org.molgenis</groupId>
 	  <artifactId>molgenis</artifactId>
-	  <version>1.2.0</version>
+	  <version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-charts</artifactId>
 	<packaging>jar</packaging>
@@ -11,17 +11,17 @@
       	<dependency>
       		<groupId>org.molgenis</groupId>
 	  		<artifactId>molgenis-core</artifactId>
-	  		<version>1.2.0</version>
+	  		<version>${project.version}</version>
       	</dependency>
       	<dependency>
       		<groupId>org.molgenis</groupId>
 	  		<artifactId>molgenis-core-ui</artifactId>
-	  		<version>1.2.0</version>
+	  		<version>${project.version}</version>
       	</dependency>
       	<dependency>
       		<groupId>org.molgenis</groupId>
 	  		<artifactId>molgenis-data</artifactId>
-	  		<version>1.2.0</version>
+	  		<version>${project.version}</version>
       	</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/molgenis-core-ui/pom.xml
+++ b/molgenis-core-ui/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-core-ui</artifactId>
 	<packaging>jar</packaging>
@@ -71,27 +71,27 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-csv</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-elasticsearch</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/molgenis-core/pom.xml
+++ b/molgenis-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 	  <groupId>org.molgenis</groupId>
 	  <artifactId>molgenis</artifactId>
-	  <version>1.2.0</version>
+	  <version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-core</artifactId>
 	<packaging>jar</packaging>

--- a/molgenis-data-annotators/pom.xml
+++ b/molgenis-data-annotators/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-annotators</artifactId>
 	<packaging>jar</packaging>
@@ -12,32 +12,32 @@
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-omx-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-csv</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-omx</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.springframework</groupId>

--- a/molgenis-data-csv/pom.xml
+++ b/molgenis-data-csv/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-csv</artifactId>
 
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>net.sf.opencsv</groupId>

--- a/molgenis-data-elasticsearch/pom.xml
+++ b/molgenis-data-elasticsearch/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-elasticsearch</artifactId>
 	
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
         <dependency>
             <groupId>org.elasticsearch</groupId>

--- a/molgenis-data-examples/pom.xml
+++ b/molgenis-data-examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>molgenis</artifactId>
         <groupId>org.molgenis</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,12 +15,12 @@
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-csv</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/molgenis-data-excel/pom.xml
+++ b/molgenis-data-excel/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-excel</artifactId>
 
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.poi</groupId>

--- a/molgenis-data-googlespreadsheet/pom.xml
+++ b/molgenis-data-googlespreadsheet/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-googlespreadsheet</artifactId>
 
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.gdata</groupId>

--- a/molgenis-data-import/pom.xml
+++ b/molgenis-data-import/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-import</artifactId>
 	<packaging>jar</packaging>
@@ -50,22 +50,22 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-jpa</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/molgenis-data-jpa/pom.xml
+++ b/molgenis-data-jpa/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-jpa</artifactId>
 
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		 <!-- database hibernate, connectionpool, driver -->
 		<dependency>
@@ -39,7 +39,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-excel</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/molgenis-data-merge/pom.xml
+++ b/molgenis-data-merge/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-merge</artifactId>
 	<packaging>jar</packaging>
@@ -11,12 +11,12 @@
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-elasticsearch</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
          <dependency>
             <groupId>org.apache.commons</groupId>

--- a/molgenis-data-mysql/pom.xml
+++ b/molgenis-data-mysql/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>molgenis</artifactId>
         <groupId>org.molgenis</groupId>
-        <version>1.2.0</version>
+        <version>1.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,17 +15,17 @@
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-excel</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
          <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-security</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.molgenis</groupId>

--- a/molgenis-data-omx/pom.xml
+++ b/molgenis-data-omx/pom.xml
@@ -4,35 +4,35 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-omx</artifactId>
 	<dependencies>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-excel</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-elasticsearch</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>hsqldb</groupId>

--- a/molgenis-data-rest/pom.xml
+++ b/molgenis-data-rest/pom.xml
@@ -4,34 +4,34 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-rest</artifactId>
 	<dependencies>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-csv</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/molgenis-data-vcf/pom.xml
+++ b/molgenis-data-vcf/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data-vcf</artifactId>
 
@@ -12,12 +12,12 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-merge</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>nl.systemsgenetics</groupId>

--- a/molgenis-data/pom.xml
+++ b/molgenis-data/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-data</artifactId>
 	<packaging>jar</packaging>
@@ -11,12 +11,12 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		 <dependency>
             <groupId>org.apache.commons</groupId>

--- a/molgenis-disease-matcher/pom.xml
+++ b/molgenis-disease-matcher/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-disease-matcher</artifactId>
 
@@ -50,22 +50,22 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-csv</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-jpa</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>commons-cli</groupId>

--- a/molgenis-js/pom.xml
+++ b/molgenis-js/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-js</artifactId>
 
@@ -12,7 +12,7 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>rhino</groupId>

--- a/molgenis-model-registry/pom.xml
+++ b/molgenis-model-registry/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-model-registry</artifactId>
 	<packaging>jar</packaging>
@@ -51,17 +51,17 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/molgenis-mutationdb/pom.xml
+++ b/molgenis-mutationdb/pom.xml
@@ -5,11 +5,10 @@
   <parent>
     <groupId>org.molgenis</groupId>
     <artifactId>molgenis</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
   </parent>
   <groupId>org.molgenis</groupId>
   <artifactId>molgenis-mutationdb</artifactId>
-  <version>1.2.0</version>
   <name>molgenis-mutationdb</name>
   <url>http://maven.apache.org</url>
   <properties>
@@ -19,22 +18,22 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-mysql</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.springframework</groupId>

--- a/molgenis-omx-biobankconnect/pom.xml
+++ b/molgenis-omx-biobankconnect/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 	    <groupId>org.molgenis</groupId>
 	    <artifactId>molgenis</artifactId>
-	    <version>1.2.0</version>
+	    <version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-omx-biobankconnect</artifactId>
 	<packaging>jar</packaging>
@@ -37,62 +37,62 @@
 		<dependency>
         	<groupId>org.molgenis</groupId>
             <artifactId>molgenis-omx-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-elasticsearch</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		 <dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-rest</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-csv</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-omx</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-excel</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-omx-dataexplorer</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-js</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.springframework</groupId>

--- a/molgenis-omx-core/pom.xml
+++ b/molgenis-omx-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-omx-core</artifactId>
 	<packaging>jar</packaging>
@@ -51,22 +51,22 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-jpa</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-elasticsearch</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/molgenis-omx-das/pom.xml
+++ b/molgenis-omx-das/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 	  <groupId>org.molgenis</groupId>
 	  <artifactId>molgenis</artifactId>
-	  <version>1.2.0</version>
+	  <version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-omx-das</artifactId>
 	<packaging>jar</packaging>
@@ -61,7 +61,7 @@
         <dependency>
                 <groupId>org.molgenis</groupId>
                 <artifactId>molgenis-omx-core</artifactId>
-                <version>1.2.0</version>
+                <version>${project.version}</version>
         </dependency>
 		<dependency>
 		    <groupId>uk.ac.ebi.mydas</groupId>

--- a/molgenis-omx-dataexplorer/pom.xml
+++ b/molgenis-omx-dataexplorer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-omx-dataexplorer</artifactId>
 	<packaging>jar</packaging>
@@ -22,32 +22,32 @@
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-omx-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-csv</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-omx</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core-ui</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 		    <groupId>org.springframework</groupId>

--- a/molgenis-omx-protocolviewer/pom.xml
+++ b/molgenis-omx-protocolviewer/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-omx-protocolviewer</artifactId>
 	<packaging>jar</packaging>
@@ -55,32 +55,32 @@
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-core-ui</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
 		<dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-omx-core</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-security</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data-excel</artifactId>
-            <version>1.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
     		<groupId>org.springframework</groupId>

--- a/molgenis-r/pom.xml
+++ b/molgenis-r/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-r</artifactId>
 
@@ -12,17 +12,17 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-scripts</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/molgenis-scripts/pom.xml
+++ b/molgenis-scripts/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-scripts</artifactId>
 	
@@ -12,17 +12,17 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-mysql</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/molgenis-security-core/pom.xml
+++ b/molgenis-security-core/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-security-core</artifactId>
 	<packaging>jar</packaging>

--- a/molgenis-security/pom.xml
+++ b/molgenis-security/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.molgenis</groupId>
 		<artifactId>molgenis</artifactId>
-		<version>1.2.0</version>
+		<version>1.3.0-SNAPSHOT</version>
 	</parent>
 	<artifactId>molgenis-security</artifactId>
 	<packaging>jar</packaging>
@@ -47,17 +47,17 @@
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-security-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-core</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.molgenis</groupId>
 			<artifactId>molgenis-data-jpa</artifactId>
-			<version>1.2.0</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.annotation</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>org.molgenis</groupId>
     <artifactId>molgenis</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <!-- More Project Information -->


### PR DESCRIPTION
Use ${project.version} for dependencies on other molgenis subprojects.
