### PR TITLE
Fix #2078 Activation URL always connects with HTTP

### DIFF
--- a/molgenis-security/src/main/java/org/molgenis/security/account/AccountController.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/AccountController.java
@@ -137,7 +137,9 @@ public class AccountController
 		}
 		else
 		{
-			activationUri = request.getScheme() + "://" + request.getHeader("X-Forwarded-Host") + URI + "/activate";
+			String scheme = request.getHeader("X-Forwarded-Proto");
+			if (scheme == null) scheme = request.getScheme();
+			activationUri = scheme + "://" + request.getHeader("X-Forwarded-Host") + URI + "/activate";
 		}
 		accountService.createUser(molgenisUser, activationUri);
 


### PR DESCRIPTION
See http://www.nczonline.net/blog/2012/08/08/setting-up-apache-as-a-ssl-front-end-for-play/
