### PR TITLE
Fixed: Model details anchors create unknown model warnings when reloaded #2148

### DIFF
--- a/molgenis-model-registry/src/main/resources/js/standardsregistry.js
+++ b/molgenis-model-registry/src/main/resources/js/standardsregistry.js
@@ -172,8 +172,16 @@
 		countTemplate = Handlebars.compile($("#count-template").html());
 		modelTemplate = Handlebars.compile($("#model-template").html());
 		
-		if(window.location.hash) {
-			showPackageDetails(window.location.hash.substring(1));
+		if(window.location.search) {
+			var query = window.location.search.substring(1);
+			var pairs, keyValuePair = [];
+			if(query !== undefined){
+				pairs = query.split('&');
+				jQuery.each(pairs,function(indexInArray, value){
+					var keyValuePair = value.split('='); 
+					if('package' === keyValuePair[0]) {showPackageDetails(keyValuePair[1]);}
+				});
+			}
 		}
 		
 		$(document).on('click', '#zoom-in', function() {

--- a/molgenis-model-registry/src/main/resources/templates/view-standardsregistry.ftl
+++ b/molgenis-model-registry/src/main/resources/templates/view-standardsregistry.ftl
@@ -64,7 +64,7 @@
         {{/if}}
         <form class="form-inline">
             <div class="form-group">
-        	   <a class="btn btn-primary details-btn" href="#" role="button">View Model Details</a>
+        	   <a class="btn btn-primary details-btn" href="?package={{package.name}}#" role="button">View Model Details</a>
         	</div>
             <div class="form-group{{#unless entities.length}} hidden{{/unless}}">
                 <div class="input-group select2-bootstrap-append entity-select-control">


### PR DESCRIPTION
Model details anchors create unknown model warnings when reloaded #2148
1. added the 'package' param and the value into the url
2. when loading from the omnibox the page it will be redirected to the
details page with the requested package name