### PR TITLE
Fixed: Catalog manager timeout loading catalogue #2216

### DIFF
--- a/molgenis-omx-protocolviewer/src/main/java/org/molgenis/catalogmanager/CatalogManagerController.java
+++ b/molgenis-omx-protocolviewer/src/main/java/org/molgenis/catalogmanager/CatalogManagerController.java
@@ -97,7 +97,7 @@ public class CatalogManagerController extends MolgenisPluginController
 	 * @return
 	 */
 	@RequestMapping(value = "/activation", params = "activate", method = RequestMethod.POST)
-	public String loadCatalog(@RequestParam(value = "id", required = false) String id, Model model)
+	public synchronized String loadCatalog(@RequestParam(value = "id", required = false) String id, Model model)
 	{
 		try
 		{
@@ -133,7 +133,7 @@ public class CatalogManagerController extends MolgenisPluginController
 	}
 
 	@RequestMapping(value = "/activation", params = "deactivate", method = RequestMethod.POST)
-	public String deactivateCatalog(@RequestParam(value = "id", required = false) String id, Model model)
+	public synchronized String deactivateCatalog(@RequestParam(value = "id", required = false) String id, Model model)
 	{
 		try
 		{


### PR DESCRIPTION
Activate and Deactivate methods are made synchronized.
The problem was calling activate and deactivate after each other without waiting the operation to finish