### PR TITLE
Show group in two more dialogs instead of description.

### DIFF
--- a/molgenis-omx-protocolviewer/src/main/resources/templates/orderdata-modal.ftl
+++ b/molgenis-omx-protocolviewer/src/main/resources/templates/orderdata-modal.ftl
@@ -83,14 +83,14 @@
 								});	
 							}
 							var table = $('<table id="orderdata-selection-table" class="table table-striped table-condensed listtable"></table>');
-	                        table.append($('<thead><tr><th>Variable</th><th>Description</th><th>Remove</th></tr></thead>'));
+	                        table.append($('<thead><tr><th>Variable</th><th>Group</th><th>Remove</th></tr></thead>'));
 	                        var body = $('<tbody>');
 	
 	                        $.each(selection.items, function (i, item) {
 	                        	var protocol = molgenis.Catalog.getProtocol(item.protocol);
 	                            var row = $('<tr>');
 	                            row.append('<td>' + protocol.Name + '</td>');
-	                            row.append('<td>' + (protocol.description ? molgenis.i18n.get(protocol.description) : '') + '</td>');
+	                            row.append('<td>' + (this.group ? this.group.map(window.htmlEscape).join(' &rarr; ') : '') + '</td>');
 	
 	                            var deleteCol = $('<td class="center">');
 	                            var deleteBtn = $('<i class="icon-remove"></i>');

--- a/molgenis-omx-protocolviewer/src/main/resources/templates/orderdetails-modal.ftl
+++ b/molgenis-omx-protocolviewer/src/main/resources/templates/orderdetails-modal.ftl
@@ -11,13 +11,13 @@
         <table class="table table-striped table-condensed listtable">
             <thead>
             <th>Variable</th>
-            <th>Description</th>
+            <th>Group</th>
             </thead>
             <tbody>
             <#list order.items as item>
             <tr>
                 <td><#if item.name??>${item.name}</#if></td>
-                <td><#if item.description??>${i18n.get(item.description)}</#if></td>
+                <td><#if item.group??><#list item.group as group>${group}<#if group_has_next> &rarr; </#if></#list></#if></td>
             </tr>
             </#list>
             </tbody>


### PR DESCRIPTION
The modal dialogs
Submit Study Request (shown when you push the submit button in the catalog plugin)
and Submission Details (shown when you push (view submissions, view) in the catalog plugin)
should probably also show the new description.