### PR TITLE
Fix #2314 Static content save btn disabled

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/staticcontent.edit.js
+++ b/molgenis-core-ui/src/main/resources/js/staticcontent.edit.js
@@ -14,7 +14,7 @@
 		    toolbar: "insertfile undo redo | styleselect fontselect fontsizeselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | link",
 		    setup : function(ed) {
 	            ed.on('change', function(e) {
-	            	$('#submitBtn').removeProp('disabled');
+	            	$('#submitBtn').prop('disabled', true);
 	            });
             }
 		});


### PR DESCRIPTION
See note in http://api.jquery.com/removeProp/:
Note: Do not use this method to remove native properties such as checked, disabled, or selected. This will remove the property completely and, once removed, cannot be added again to element. Use .prop() to set these properties to false instead.