### PR TITLE
Disease Matcher - more bug fixes

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/jquery.molgenis.table.js
+++ b/molgenis-core-ui/src/main/resources/js/jquery.molgenis.table.js
@@ -498,6 +498,7 @@
 				if(value !== editValue) {
 					restApi.update(cell.data('id'), editValue, {
 						success: function() {
+							settings.onDataChange();
 							value = editValue;
 							settings.data.items[row][attribute.name] = value;
 							cell.addClass('edited');
@@ -513,6 +514,7 @@
 				if(value !== editValue) {
 					restApi.update(cell.data('id'), editValue, {
 						success: function() {
+							settings.onDataChange();
 							if (editValue === '')
 								delete entity[attribute.name];
 							else {
@@ -532,6 +534,7 @@
 					if(value !== editValue) {
 						restApi.update(cell.data('id'), editValue, {
 							success: function() {
+								settings.onDataChange();
 								settings.data.items[row][attribute.name] = editValue;
 								cell.removeClass('invalid-input').addClass('edited');
 							}
@@ -551,6 +554,7 @@
 						var editValue = $.map(data, function(val){ return restApi.getPrimaryKeyFromHref(val.href);});
 						restApi.update(cell.data('id'), editValue, {
 							success: function() {
+								settings.onDataChange();
 								entity[attribute.name].total = data.length;
 								entity[attribute.name].items = data;
 								cell.addClass('edited');
@@ -575,6 +579,7 @@
 	            		editValue = editValue !== '' ? restApi.getPrimaryKeyFromHref(editValue) : ''; 
 						restApi.update(cell.data('id'), editValue, {
 							success: function() {
+								settings.onDataChange();
 								if (editValue === '')
 									delete entity[attribute.name];
 								else {
@@ -595,6 +600,7 @@
 				if(value !== editValue) {
 					restApi.update(cell.data('id'), editValue, {
 						success: function() {
+							settings.onDataChange();
 							value = editValue;
 							settings.data.items[row][attribute.name] = value;
 							cell.addClass('edited');
@@ -864,6 +870,7 @@
 		'attributes' : null,
 		'query' : null,
 		'editable' : false,
-		'rowClickable': false
+		'rowClickable': false,
+		'onDataChange': function(){}
 	};
 }($, window.top.molgenis = window.top.molgenis || {}));

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
@@ -29,6 +29,13 @@
     var genomeBrowserSettings = {};
     var featureInfoMap = {};
 
+    $(document).on('dataChange.diseasematcher', function(e) {
+    	if (e.namespace !== 'data'){
+    		//TODO: implement refresh table functionality
+        	$('#data-table-container').table('setQuery', getQuery());
+    	}
+	});
+    
     /**
 	 * @memberOf molgenis.dataexplorer.data
 	 */
@@ -53,7 +60,10 @@
 			'attributes' : attributes,
 			'query' : getQuery(),
 			'editable' : editable,
-			'rowClickable': rowClickable
+			'rowClickable': rowClickable,
+			'onDataChange' : function(){
+				$(document).trigger('dataChange.data');
+			}
 		});
 	}
 	

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-diseasematcher.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-diseasematcher.js
@@ -53,11 +53,18 @@
 	
 	var phenotipsFilteredQuery;
 	
+	var currentQuery;
+	
 	/**
 	 * Listens for data explorer query changes and updates the selected gene/disease lists.
 	 */
 	$(document).on('changeQuery', function(e, query) {	
 		updateSelectionList(currentSelectionMode);
+	});
+	
+	$(document).on('dataChange.data', function(e) {
+		//TODO: implement table refresh
+		$('#diseasematcher-variant-panel').table('setQuery', currentQuery);
 	});
 	
 	//disease matcher parts
@@ -87,7 +94,6 @@
 			variantPanel.table('setAttributes', data.attributes);
 		}
 	});
-
 	
 	/**
 	 * Checks if the current state of Molgenis meets the requirements of this tool. 
@@ -95,6 +101,7 @@
 	 * a gene symbol column. All calls are async to avoid hanging of the application.
 	 *
 	 * @param entityUri the URI of the entity to check for a gene symbol column
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function checkToolAvailable(entityUri) {
 		checkDatasetAvailable('Disease');
@@ -118,6 +125,7 @@
 	 * Checks if a dataset is loaded. Shows a warning when it is not. 
 	 * 
 	 * @param dataset the dataset to check for
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function checkDatasetAvailable(dataset) {
 		restApi.getAsync('/api/v1/' + dataset, {'num' : 1},	function(data){
@@ -134,6 +142,7 @@
 	 * 
 	 * @param element the selected link
 	 * @selectionMode the appropriate selection mode to use
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function onClickNavBtn(element, selectionMode){
 		if (!toolAvailable) return;
@@ -159,6 +168,9 @@
 		}
 	}
 	
+	/**
+	 * @memberOf molgenis.dataexplorer.diseasematcher
+	 */
 	function rankHPOTerms(terms, callback){
 		var queryString = '';
 		$.each(terms, function(index, t){
@@ -182,6 +194,9 @@
 		
 	}
 	
+	/**
+	 * @memberOf molgenis.dataexplorer.diseasematcher
+	 */
 	function filterPhenotipsOutputComplete(terms){
 		var entityName = getEntity().name;
 		var request = {
@@ -367,7 +382,7 @@
 	}
 	
 	/**
-	 * 
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function downloadFilteredVariants() {
 		$.download(molgenis.getContextUrl() + '/download', {
@@ -379,10 +394,9 @@
 	}
 	
 	/**
-	 * 
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function createDiseaseMatcherDownloadDataRequest() {
-		//TODO: combine phenotips filter with search/item filters on download	
 		var entityQuery = getQuery();
 		
 		var dataRequest = {
@@ -391,7 +405,7 @@
 			query : {
 				rules : phenotipsFilteredQuery
 			},
-			colNames : $('input[name=ColNames]:checked').val()
+			colNames : 'ATTRIBUTE_LABELS'
 		};
 
 		//dataRequest.query.sort = $('#data-table-container').table('getSort');	
@@ -488,6 +502,7 @@
 	 * refreshing of the selection list.
 	 * 
 	 * @param selectionMode 
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function updateSelectionList(selectionMode) {
 		var entityName = getEntity().name;
@@ -511,8 +526,7 @@
 					populateSelectionList(data.genes, selectionMode);		
 				}
 				
-				window.setTimeout(initPager(data.total, selectionMode), 3000);
-				
+				initPager(data.total, selectionMode);
 			}
 		});
 	}
@@ -523,6 +537,7 @@
 	 * 
 	 * @param list the list of diseases or genes
 	 * @param selectionMode the current selection mode
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function populateSelectionList(list, selectionMode) {
 		//TODO handle nulls
@@ -558,6 +573,7 @@
 	 * 
 	 * @param total the total amount of items 
 	 * @param selectionMode the selection mode for this list
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function initPager(total, selectionMode) {
 		var container = $('#diseasematcher-selection-pager');
@@ -582,6 +598,7 @@
 	 * @param pageStart index of the first item of this page
 	 * @param pageEnd index of the last item of this page
 	 * @param selectionMode the selection mode for this list
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function onPageChange(pageStart, pageEnd, selectionMode) {
 		var entityName = getEntity().name;
@@ -613,6 +630,7 @@
 	 * Takes an OMIM object and transforms the data to content which is shown in a disease tab.
 	 * 
 	 * @param omimObject the OMIM object to show
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function showOmimObject(omimObject){
 		
@@ -724,6 +742,7 @@
 	 * 
 	 * @param diseaseId
 	 * @returns
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function onSelectDiseaseTab(diseaseId) {
 		if (localStorageSupported && diseaseId in localStorage){
@@ -757,6 +776,7 @@
 	 * 
 	 * @param link the item that was selected
 	 * @param selectionMode the current selection mode
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function onSelectListItem(link, selectionMode) {
 		// visually select the right item in the list
@@ -802,6 +822,7 @@
 	 * Sets readable names for disease tabs (replace the default OMIM identifier).
 	 * 
 	 * @param diseaseIds the OMIM identifiers to get names for
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function setDiseaseTabNames(diseaseIds){
 		var requestParams = '?';
@@ -830,6 +851,7 @@
 	 * 
 	 * @param id OMIM id or gene symbol
 	 * @param selectionMode selection mode for the id
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function showDiseases(id, selectionMode) {
 		// empty disease tabs
@@ -904,6 +926,7 @@
 	 * 
 	 * @param genes the genes to get variants for
 	 * @param panel the panel to add/update
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function showVariants(genes, panel) {
 		var queryRules = [];
@@ -920,31 +943,33 @@
 			});
 		});
 		
-		var query = {'q' : queryRules};
-
+		currentQuery = {'q' : queryRules};
+		
 		// show associated variants in info panel	
 		if (tableEditable) {
 			tableEditable = molgenis.hasWritePermission(molgenis.dataexplorer.getSelectedEntityMeta().name);
 		}
 	
 		if (panel.has('table').length){
-			panel.table('setQuery', query);
+			panel.table('setQuery', currentQuery);
 		}else{
-			panel.table({
+			var table = panel.table({
 				'entityMetaData' : getEntity(),
 				'attributes' : getAttributes(),
-				'query' : query,
-				'editable': tableEditable
+				'query' : currentQuery,
+				'editable': tableEditable,
+				'onDataChange' : function(){
+					$(document).trigger('dataChange.diseasematcher');
+				}
 			});
 		}
 	}
-	
-	
 
 	/**
 	 * Escapes regular expression characters within a string.
 	 * 
 	 * @param string the string in which to escape regular expression characters
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function escapeRegExp(string) {
 	    return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, "\\$1");
@@ -957,6 +982,7 @@
 	 * @param string the string in which to replace
 	 * @param find the substring(s) to be replaced
 	 * @param replace the value to replace the targets with
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function replaceAll(string, find, replace) {
 		  return string.replace(new RegExp(escapeRegExp(find), 'g'), replace);
@@ -967,6 +993,7 @@
 	 * Returns the selected entity from the data explorer.
 	 * 
 	 * @returns the selected entity
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function getEntity() {
 		return molgenis.dataexplorer.getSelectedEntityMeta();
@@ -977,6 +1004,7 @@
 	 * Returns the currently active data explorer query.
 	 * 
 	 * @returns a data explorer query
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function getQuery() {
 		return molgenis.dataexplorer.getEntityQuery();
@@ -987,6 +1015,7 @@
 	 * Returns the currently selected attributes.
 	 * 
 	 * @returns attributes
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function getAttributes() {
 		return molgenis.dataexplorer.getSelectedAttributes();
@@ -997,6 +1026,7 @@
 	 * Checks if a browser supports local storage.
 	 * 
 	 * @returns boolean telling if a browser supports local storage
+	 * @memberOf molgenis.dataexplorer.diseasematcher
 	 */
 	function browserSupportsLocalStorage() {
 		try {

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-diseasematcher.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-diseasematcher.js
@@ -76,10 +76,6 @@
 	var selectionTitle = $('#diseasematcher-selection-title');
 	
 	//handlebars templates
-	var hbColumnWarning = $('#hb-column-warning');
-	var hbColumnWarningComp = Handlebars.compile(hbColumnWarning.html());
-	var hbDatasetWarning = $('#hb-dataset-warning');
-	var hbDatasetWarningComp = Handlebars.compile(hbDatasetWarning.html());
 	var hbSelectionList = $('#hb-selection-list');
 	var hbClinicalSynopsis = $('#hb-clinical-synopsis');
 	var hbClinicalSynopsisComp = Handlebars.compile(hbClinicalSynopsis.html());
@@ -109,13 +105,13 @@
 
 		// if an entity is selected, check if it has a gene symbol column and show a warning if it does not
 		restApi.getAsync(entityUri + '/meta', {}, function(data) {
-			if (data === null || !data.attributes.hasOwnProperty(geneSymbolColumn)) {
+			if (data === null || !data.attributes.hasOwnProperty(geneSymbolColumn)) {			
+				molgenis.createAlert([{
+					message: 'No geneSymbol column found!</strong> For this tool to work, make sure your dataset has a <em>geneSymbol</em> column.'}], 
+					'warning',
+					infoPanel);
 				
-				var warning = hbColumnWarningComp({column: geneSymbolColumn});
-				infoPanel.append(warning);
 				toolAvailable = false;
-		
-				// TODO determine which annotators to propose
 			}
 		});
 	}
@@ -130,8 +126,11 @@
 	function checkDatasetAvailable(dataset) {
 		restApi.getAsync('/api/v1/' + dataset, {'num' : 1},	function(data){
 			if (data.total === 0) {
-				var warning = hbDatasetWarningComp({dataset: dataset});
-				infoPanel.append(warning);
+				molgenis.createAlert([{
+					message: '<strong>' + dataset + ' not loaded!</strong> For this tool to work, please upload a valid <em>' + dataset + '</em> dataset.'}], 
+					'warning',
+					infoPanel);
+				
 				toolAvailable = false;
 			}
 		});
@@ -248,7 +247,10 @@
 					});
 					
 					if (suggestionObjects.length === 0){
-						molgenis.createAlert([{message: 'PhenoTips is offline or (one of) the HPO terms you entered is not valid!'}], 'warning');
+						molgenis.createAlert([{
+							message: 'PhenoTips is offline or (one of) the HPO terms you entered is not valid!'}], 
+							'warning',
+							$('.diseasematcher-warnings'));
 						return;
 					}
 					
@@ -467,7 +469,10 @@
 			var terms = $('#hpoTermsInput').val();
 						
 			if (/^(HP:\d{7})(,HP:\d{7})*$/.test(terms) === false){
-				molgenis.createAlert([{message: 'Incorrect input. Make sure to use HPO terms and separate them with a comma (without spaces).'}], 'warning');	
+				molgenis.createAlert([{
+					message: 'Incorrect input. Make sure to use HPO terms and separate them with a comma (without spaces).'}], 
+					'warning',
+					$('.diseasematcher-warnings'));	
 			}else{
 				terms = terms.split(',');		
 				filterPhenotipsOutputComplete(terms);

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
@@ -436,11 +436,6 @@ function($, molgenis, settingsXhr) {
 			$(document).trigger('changeQuery', createEntityQuery());
 		});
 		
-		$("#observationset-search").change(function(e) {
-			searchQuery = $(this).val().trim();
-			$(document).trigger('changeQuery', createEntityQuery());
-		});
-		
 		$('#search-clear-button').click(function(){
 			$("#observationset-search").val('');
 			$("#observationset-search").change();

--- a/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-diseasematcher.ftl
+++ b/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-diseasematcher.ftl
@@ -181,7 +181,7 @@
 				{{this}}
 			</a></li>
 		{{else}}
-			<p>No genes found...</p>
+			<p>No genes or diseases found...</p>
 		{{/each}}
 	{{/if}}
 </script>

--- a/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-diseasematcher.ftl
+++ b/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-diseasematcher.ftl
@@ -22,6 +22,8 @@
 						<div class="col-md-12"><h3 class="text-center">PhenoTips disease filter</h3></div>
 					</div>
 					
+					<div class="diseasematcher-warnings"></div>
+					
 					<div class="top-buffer"/>
 					
 					<div class="col-md-6">
@@ -149,18 +151,6 @@
 		</div>
 	</div>		
 </div>
-
-<script id="hb-dataset-warning" class="diseasematcher" type="text/x-handlebars-template">
-	<div class="alert alert-warning" id="{{dataset}}-warning">
-		<strong>{{dataset}} not loaded!</strong> For this tool to work, please upload a valid <em>{{dataset}}</em> dataset.
-	</div>	
-</script>
-
-<script id="hb-column-warning" class="diseasematcher" type="text/x-handlebars-template">
-	<div class="alert alert-warning" id="{{column}}-warning">
-		<strong>No {{column}} column found!</strong> For this tool to work, make sure your dataset has a <em>{{column}}</em> column.
-	</div>	
-</script>
 
 <script id="hb-selection-list" class="diseasematcher" type="text/x-handlebars-template">
 	{{#if this.0.diseaseId}}

--- a/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-diseasematcher.ftl
+++ b/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-diseasematcher.ftl
@@ -203,7 +203,13 @@
 
 <script>
 	var tableEditable = ${tableEditable?string('true', 'false')};
-	$.when($.ajax("<@resource_href "/js/dataexplorer-diseasematcher.js"/>", {'cache': true}))
-			.then(function() {
+	<#-- load css dependencies -->
+	if (!$('link[href="<@resource_href '/css/jquery.molgenis.table.css'/>"]').length)
+		$('head').append('<link rel="stylesheet" href="<@resource_href "/css/jquery.molgenis.table.css"/>" type="text/css" />');
+	<#-- load js dependencies -->
+	$.when(
+		$.ajax("<@resource_href "/js/dataexplorer-diseasematcher.js"/>", {'cache': true}),
+		$.ajax("<@resource_href "/js/jquery.bootstrap.pager.js"/>", {'cache': true})
+		).then(function() {
 	});
 </script>


### PR DESCRIPTION
Added onDataChange setting to molgenis.table 
Changed custom warning system to molgenis.createAlert

Bug fixes:
- When applying a filter with 0 results, the info of the last selected gene/disease stays visible
- Using the search box in data explorer fires the queryChanged event twice
- Clinical synopsis not rendered correctly
- 'PhenoTips offline’ message when actually input was wrong (added input check)
- Data Explorer table doesn’t update when values are edited in DM, and vice versa
- Download button not working in Filter menu (page not available)
- Some Text links point to OMIM pages that don’t exist
- PhenoTips filtered dataset has results even when nothing in query
- “No genes found” when in Disease list menu
- When refreshing the page with DM open: pager not showing + error (undefined is not a function)