### PR TITLE
Fix #2351 Elasticsearch all shards failed error

### DIFF
--- a/molgenis-data-elasticsearch/pom.xml
+++ b/molgenis-data-elasticsearch/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.4.2</version>
+            <version>1.4.4</version>
         </dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
Release notes:
- [Elasticsearch 1.4.3](http://www.elasticsearch.org/downloads/1-4-3)
- [Elasticsearch 1.4.4](http://www.elasticsearch.org/downloads/1-4-4)