### PR TITLE
add profile to pom to prevent runnable Annotator jar from always building (war gets huge that way)

### DIFF
--- a/molgenis-data-annotators/pom.xml
+++ b/molgenis-data-annotators/pom.xml
@@ -7,7 +7,7 @@
 	</parent>
 	<artifactId>molgenis-data-annotators</artifactId>
 	<packaging>jar</packaging>
-	
+
 	<dependencies>
 		<dependency>
             <groupId>org.molgenis</groupId>
@@ -74,6 +74,7 @@
 					</descriptorRefs>
 					<finalName>CmdLineAnnotator</finalName>
 					<appendAssemblyId>false</appendAssemblyId>
+                    <skipAssembly>${skip.delivery}</skipAssembly>
 				</configuration>
 				<executions>
 					<execution>

--- a/molgenis-data/src/main/java/org/molgenis/data/validation/RepositoryValidationDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/validation/RepositoryValidationDecorator.java
@@ -240,7 +240,7 @@ public class RepositoryValidationDecorator extends CrudRepositoryDecorator
 				}
 				else if (attr.getDataType() instanceof MrefField)
 				{
-					Iterable<Entity> refEntities = entity.getEntities(attr.getRefEntity().getName());
+					Iterable<Entity> refEntities = entity.getEntities(attr.getName());
 					if (refEntities != null)
 					{
 						for (Entity refEntity : refEntities)

--- a/molgenis-data/src/main/java/org/molgenis/data/validation/RepositoryValidationDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/validation/RepositoryValidationDecorator.java
@@ -240,7 +240,7 @@ public class RepositoryValidationDecorator extends CrudRepositoryDecorator
 				}
 				else if (attr.getDataType() instanceof MrefField)
 				{
-					Iterable<Entity> refEntities = entity.getEntities(attr.getName());
+					Iterable<Entity> refEntities = entity.getEntities(attr.getRefEntity().getName());
 					if (refEntities != null)
 					{
 						for (Entity refEntity : refEntities)

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
                 <logger.level.root>INFO</logger.level.root>
                 <logger.level.org.molgenis>DEBUG</logger.level.org.molgenis>
                 <minify.skipMinify>true</minify.skipMinify>
+                <skip.delivery>true</skip.delivery>
             </properties>
         </profile>
         <!-- release profile (default) -->
@@ -49,10 +50,22 @@
                 <logger.level.root>WARN</logger.level.root>
                 <logger.level.org.molgenis>INFO</logger.level.org.molgenis>
                 <minify.skipMinify>false</minify.skipMinify>
+                <skip.delivery>true</skip.delivery>
             </properties>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
+        </profile>
+
+        <profile>
+            <id>create-delivery</id>
+            <properties>
+                <molgenis.build.profile>dev</molgenis.build.profile>
+                <logger.level.root>INFO</logger.level.root>
+                <logger.level.org.molgenis>DEBUG</logger.level.org.molgenis>
+                <minify.skipMinify>true</minify.skipMinify>
+                <skip.delivery>false</skip.delivery>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
add "create-delivery" profile if you want to build the runnable jar for the annotators