### PR TITLE
MySQL Repository stores VARCHAR as TEXT

### DIFF
--- a/molgenis-core/src/main/java/org/molgenis/fieldtypes/StringField.java
+++ b/molgenis-core/src/main/java/org/molgenis/fieldtypes/StringField.java
@@ -31,9 +31,7 @@ public class StringField extends FieldType
 	@Override
 	public String getMysqlType() throws MolgenisModelException
 	{
-		// if(f == null) return "VARCHAR(255)";
-		// return "VARCHAR(" + f.getVarCharLength() + ")";
-		// Changed to text to allow for 1000 columns
+		// Changed from varchar to text to allow for more columns
 		return "TEXT";
 	}
 

--- a/molgenis-core/src/main/java/org/molgenis/fieldtypes/StringField.java
+++ b/molgenis-core/src/main/java/org/molgenis/fieldtypes/StringField.java
@@ -31,8 +31,10 @@ public class StringField extends FieldType
 	@Override
 	public String getMysqlType() throws MolgenisModelException
 	{
-        if(f == null) return "VARCHAR(255)";
-		return "VARCHAR(" + f.getVarCharLength() + ")";
+		// if(f == null) return "VARCHAR(255)";
+		// return "VARCHAR(" + f.getVarCharLength() + ")";
+		// Changed to text to allow for 1000 columns
+		return "TEXT";
 	}
 
 	@Override

--- a/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
+++ b/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
@@ -453,7 +453,9 @@ public class MysqlRepository extends AbstractRepository implements Manageable
 			else
 			{
 				// id attributes can not be of type TEXT so we'll change it to VARCHAR
-				if (att == getEntityMetaData().getIdAttribute())
+				if (att == getEntityMetaData().getIdAttribute()
+						&& getEntityMetaData().getIdAttribute().getDataType().getEnumType()
+								.equals(FieldTypeEnum.STRING))
 				{
 					sql.append(VARCHAR);
 				}

--- a/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryStringTest.java
+++ b/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryStringTest.java
@@ -25,7 +25,7 @@ public class MysqlRepositoryStringTest extends MysqlRepositoryAbstractDatatypeTe
 	@Override
 	public String createSql()
 	{
-		return "CREATE TABLE IF NOT EXISTS `VarcharTest`(`col1` VARCHAR(255) NOT NULL, `col2` VARCHAR(255), `col3` VARCHAR(255), PRIMARY KEY (`col1`)) ENGINE=InnoDB;";
+		return "CREATE TABLE IF NOT EXISTS `VarcharTest`(`col1` VARCHAR(255) NOT NULL, `col2` TEXT, `col3` TEXT, PRIMARY KEY (`col1`)) ENGINE=InnoDB;";
 	}
 
 	@Override

--- a/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryTest.java
+++ b/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryTest.java
@@ -93,7 +93,7 @@ public class MysqlRepositoryTest extends AbstractTestNGSpringContextTests
 		Assert.assertEquals(repo.getInsertSql(), "INSERT INTO `MysqlPerson` (`firstName`, `lastName`) VALUES (?, ?)");
 		Assert.assertEquals(
 				repo.getCreateSql(),
-				"CREATE TABLE IF NOT EXISTS `MysqlPerson`(`firstName` VARCHAR(255) NOT NULL, `lastName` VARCHAR(255) NOT NULL, PRIMARY KEY (`lastName`)) ENGINE=InnoDB;");
+				"CREATE TABLE IF NOT EXISTS `MysqlPerson`(`firstName` TEXT NOT NULL, `lastName` VARCHAR(255) NOT NULL, PRIMARY KEY (`lastName`)) ENGINE=InnoDB;");
 
 		metaData.addAttribute("age").setDataType(MolgenisFieldTypes.INT);
 		metaDataRepositories.updateEntityMeta(metaData);
@@ -102,7 +102,7 @@ public class MysqlRepositoryTest extends AbstractTestNGSpringContextTests
 				"INSERT INTO `MysqlPerson` (`firstName`, `lastName`, `age`) VALUES (?, ?, ?)");
 		Assert.assertEquals(
 				repo.getCreateSql(),
-				"CREATE TABLE IF NOT EXISTS `MysqlPerson`(`firstName` VARCHAR(255) NOT NULL, `lastName` VARCHAR(255) NOT NULL, `age` INTEGER, PRIMARY KEY (`lastName`)) ENGINE=InnoDB;");
+				"CREATE TABLE IF NOT EXISTS `MysqlPerson`(`firstName` TEXT NOT NULL, `lastName` VARCHAR(255) NOT NULL, `age` INTEGER, PRIMARY KEY (`lastName`)) ENGINE=InnoDB;");
 		Assert.assertEquals(repo.getCountSql(new QueryImpl(), Lists.newArrayList()),
 				"SELECT COUNT(DISTINCT this.`lastName`) FROM `MysqlPerson` AS this");
 


### PR DESCRIPTION
The standard FieldType String is now stored as TEXT in the mysql backend, except for identifiers or foreign keys (xref/mref), which are still stored as VARCHAR.