### PR TITLE
Code cleanup in the RestController.

### DIFF
--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/AttributeMetaDataResponse.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/AttributeMetaDataResponse.java
@@ -12,6 +12,7 @@ import org.molgenis.data.Range;
 import org.molgenis.security.core.MolgenisPermissionService;
 
 import com.google.common.base.Function;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
@@ -105,8 +106,8 @@ public class AttributeMetaDataResponse
 			}
 			else
 			{
-				this.refEntity = refEntity != null ? new Href(Href.concatMetaEntityHref(RestController.BASE_URI,
-						refEntity.getName())) : null;
+				this.refEntity = refEntity != null ? ImmutableMap.<String, String> of("href",
+						Href.concatMetaEntityHref(RestController.BASE_URI, refEntity.getName())) : null;
 			}
 		}
 		else this.refEntity = null;

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/Href.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/Href.java
@@ -9,19 +9,6 @@ import org.springframework.web.util.UriUtils;
 
 public class Href
 {
-	private final String href;
-
-	public Href(String href)
-	{
-		super();
-		this.href = href;
-	}
-
-	public String getHref()
-	{
-		return href;
-	}
-
 	/**
 	 * Create an encoded href for an attribute
 	 * 

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
@@ -36,7 +36,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
@@ -101,7 +100,6 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
@@ -508,14 +506,7 @@ public class RestController
 
 		// Check attribute names
 		Iterable<String> attributesIterable = Iterables.transform(meta.getAtomicAttributes(),
-				new Function<AttributeMetaData, String>()
-				{
-					@Override
-					public String apply(AttributeMetaData attributeMetaData)
-					{
-						return attributeMetaData.getName().toLowerCase();
-					}
-				});
+				attributeMetaData -> attributeMetaData.getName().toLowerCase());
 
 		if (attributesSet != null)
 		{
@@ -527,25 +518,12 @@ public class RestController
 			}
 		}
 
-		attributesIterable = Iterables.transform(meta.getAtomicAttributes(), new Function<AttributeMetaData, String>()
-		{
-			@Override
-			public String apply(AttributeMetaData attributeMetaData)
-			{
-				return attributeMetaData.getName();
-			}
-		});
+		attributesIterable = Iterables.transform(meta.getAtomicAttributes(), AttributeMetaData::getName);
 
 		if (attributesSet != null)
 		{
-			attributesIterable = Iterables.filter(attributesIterable, new Predicate<String>()
-			{
-				@Override
-				public boolean apply(@Nullable String attribute)
-				{
-					return attributesSet.contains(attribute.toLowerCase());
-				}
-			});
+			attributesIterable = Iterables.filter(attributesIterable,
+					attribute -> attributesSet.contains(attribute.toLowerCase()));
 		}
 
 		return new DefaultEntityCollection(entities, attributesIterable);

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/HrefTest.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/HrefTest.java
@@ -1,0 +1,31 @@
+package org.molgenis.data.rest;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class HrefTest
+{
+	@Test
+	public static void testAttribute()
+	{
+		Assert.assertEquals(Href.concatAttributeHref("http://molgenis.org/api/v1", "org_test_TypeTest", "1", "xint"),
+				"http://molgenis.org/api/v1/org_test_TypeTest/1/xint");
+	}
+
+	@Test
+	public static void testAttributeUrlEncodeIdWithSpace()
+	{
+		Assert.assertEquals(
+				Href.concatAttributeHref("http://molgenis.org/api/v1", "org_test_TypeTest", "weird id", "xint"),
+				"http://molgenis.org/api/v1/org_test_TypeTest/weird%20id/xint");
+	}
+
+	@Test
+	public static void testAttributeUrlEncodeIdWithSlash()
+	{
+		Assert.assertEquals(
+				Href.concatAttributeHref("http://molgenis.org/api/v1", "org_test_TypeTest", "weird/id", "xint"),
+				"http://molgenis.org/api/v1/org_test_TypeTest/weird%2Fid/xint");
+	}
+
+}


### PR DESCRIPTION
Remove double use of Href class.
Make RestController code more readable through a lambda expression