### PR TITLE
fix #2752

### DIFF
--- a/molgenis-data-semanticsearch/src/main/java/org/molgenis/data/semantic/UntypedTagService.java
+++ b/molgenis-data-semanticsearch/src/main/java/org/molgenis/data/semantic/UntypedTagService.java
@@ -90,17 +90,20 @@ public class UntypedTagService implements TagService<LabeledResource, LabeledRes
 	public Iterable<Tag<EntityMetaData, LabeledResource, LabeledResource>> getTagsForEntity(
 			EntityMetaData entityMetaData)
 	{
+		List<Tag<EntityMetaData, LabeledResource, LabeledResource>> result = new ArrayList<Tag<EntityMetaData, LabeledResource, LabeledResource>>();
 		Entity entity = findEntity(entityMetaData);
 		if (entity == null)
 		{
-			throw new UnknownEntityException("No known entity with name " + entityMetaData.getName() + ".");
+			LOG.warn("No known entity with name " + entityMetaData.getName() + ".");
 		}
-		List<Tag<EntityMetaData, LabeledResource, LabeledResource>> tags = new ArrayList<Tag<EntityMetaData, LabeledResource, LabeledResource>>();
-		for (Entity tagEntity : entity.getEntities(EntityMetaDataMetaData.TAGS))
+		else
 		{
-			tags.add(TagImpl.asTag(entityMetaData, tagEntity));
+			for (Entity tagEntity : entity.getEntities(EntityMetaDataMetaData.TAGS))
+			{
+				result.add(TagImpl.asTag(entityMetaData, tagEntity));
+			}
 		}
-		return tags;
+		return result;
 	}
 
 	@Override

--- a/molgenis-model-registry/src/main/java/org/molgenis/standardsregistry/StandardsRegistryController.java
+++ b/molgenis-model-registry/src/main/java/org/molgenis/standardsregistry/StandardsRegistryController.java
@@ -153,7 +153,8 @@ public class StandardsRegistryController extends MolgenisPluginController
 							if (!molgenisPermissionService.hasPermissionOnEntity(entityName, Permission.READ)) return false;
 
 							// Check has data
-							if (dataService.count(entityName, new QueryImpl()) == 0) return false;
+							if (!dataService.hasRepository(entityName)
+									|| dataService.count(entityName, new QueryImpl()) == 0) return false;
 
 							return true;
 						}


### PR DESCRIPTION
* Modifications to the map and set that list the repositories should be synchronized on the DataService so that they keep a consistent state.
* The iterator that gets handed out in getEntityNames() should iterate over a copy of the repository names. This is the one that fixes #2752 for me.
* The get() methods on the repository map may well collide across threads. It's probably a bad idea for performance reasons to make getRepository synchronized so I've made the map synchronized instead.