### PR TITLE
Fix/2873

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/EmxImportService.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/EmxImportService.java
@@ -86,6 +86,7 @@ public class EmxImportService implements ImportService
 			}
 			catch (Exception ignore)
 			{
+				LOG.error("Error rolling back schema changes", ignore);
 			}
 			throw e;
 		}

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportWriter.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportWriter.java
@@ -331,7 +331,16 @@ public class ImportWriter
 	private void dropAddedEntities(List<String> addedEntities)
 	{
 		// Rollback metadata, create table statements cannot be rolled back, we have to do it ourselves
-		Lists.reverse(addedEntities).forEach(dataService.getMeta()::deleteEntityMeta);
+		Lists.reverse(addedEntities).forEach(entity -> {
+			try
+			{
+				dataService.getMeta().deleteEntityMeta(entity);
+			}
+			catch (Exception ex)
+			{
+				LOG.error("Failed to rollback creation of entity {}", entity);
+			}
+		});
 	}
 
 	/**
@@ -558,7 +567,7 @@ public class ImportWriter
 		@Override
 		public Iterable<Entity> getEntities(String attributeName)
 		{
-			return from((Iterable<Entity>) super.getEntities(attributeName)).filter(notNull());
+			return from(super.getEntities(attributeName)).filter(notNull());
 		}
 	}
 }

--- a/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepositoryCollection.java
+++ b/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepositoryCollection.java
@@ -65,9 +65,11 @@ public abstract class MysqlRepositoryCollection implements ManageableRepositoryC
 	public void deleteEntityMeta(String entityName)
 	{
 		MysqlRepository repo = repositories.get(entityName);
-		if (repo == null) throw new UnknownEntityException(String.format("Unknown entity '%s'", entityName));
-		repo.drop();
-		repositories.remove(entityName);
+		if (repo != null)
+		{
+			repo.drop();
+			repositories.remove(entityName);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
What happened was
1. TypeTestRef gets created
2. Creation of TypeTest fails
3. Importer begins to roll back table creations
4. Rollback of creation of TypeTest fails because it didn't get created
5. Importer gives up rolling back table creations

Changed 2 things:
* MysqlRepositoryCollection no longer considers it a good idea to throw an exception if it is asked to delete a repository that doesn't exist.
* Importer tries to rollback all table creations even if a couple of the rollbacks fail