### PR TITLE
Use getAtomicAttributes instead "attributes" (to show contents of (r1.7.0)

### DIFF
--- a/molgenis-data-mapper/src/main/resources/templates/view-attribute-mapping.ftl
+++ b/molgenis-data-mapper/src/main/resources/templates/view-attribute-mapping.ftl
@@ -64,7 +64,7 @@
 						</tr>
 					</thead>
 					<tbody>
-						<#list attributes as source>
+						<#list entityMapping.sourceEntityMetaData.getAtomicAttributes().iterator() as source>
 							<tr>
 								<td>
 									<b>${source.label?html}</b> (${source.dataType})


### PR DESCRIPTION
compound attrs)

Conflicts:
	molgenis-data-mapper/src/main/resources/templates/view-attribute-mapping.ftl