### PR TITLE
Fix #2456

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
@@ -69,6 +69,7 @@ import org.molgenis.data.meta.EntityMetaDataMetaData;
 import org.molgenis.data.support.DefaultEntity;
 import org.molgenis.data.support.QueryImpl;
 import org.molgenis.util.DependencyResolver;
+import org.molgenis.util.EntityUtils;
 import org.molgenis.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1080,7 +1081,8 @@ public class ElasticSearchService implements SearchService
 
 	private void updateReferences(Entity refEntity, EntityMetaData refEntityMetaData)
 	{
-		for (Pair<EntityMetaData, List<AttributeMetaData>> pair : getReferencingEntityMetaData(refEntityMetaData))
+		for (Pair<EntityMetaData, List<AttributeMetaData>> pair : EntityUtils.getReferencingEntityMetaData(
+				refEntityMetaData, dataService))
 		{
 			EntityMetaData entityMetaData = pair.getA();
 
@@ -1116,43 +1118,6 @@ public class ElasticSearchService implements SearchService
 		{
 			updateReferences(entity, entityMetaData);
 		}
-	}
-
-	private List<Pair<EntityMetaData, List<AttributeMetaData>>> getReferencingEntityMetaData(
-			EntityMetaData entityMetaData)
-	{
-		List<Pair<EntityMetaData, List<AttributeMetaData>>> referencingEntityMetaData = null;
-
-		// get entity types that referencing the given entity (including self)
-		String entityName = entityMetaData.getName();
-		for (String otherEntityName : dataService.getEntityNames())
-		{
-			EntityMetaData otherEntityMetaData = dataService.getEntityMetaData(otherEntityName);
-
-			// get referencing attributes for other entity
-			List<AttributeMetaData> referencingAttributes = null;
-			for (AttributeMetaData attributeMetaData : otherEntityMetaData.getAtomicAttributes())
-			{
-				EntityMetaData refEntityMetaData = attributeMetaData.getRefEntity();
-				if (refEntityMetaData != null && refEntityMetaData.getName().equals(entityName))
-				{
-					if (referencingAttributes == null) referencingAttributes = new ArrayList<AttributeMetaData>();
-					referencingAttributes.add(attributeMetaData);
-				}
-			}
-
-			// store references
-			if (referencingAttributes != null)
-			{
-				if (referencingEntityMetaData == null) referencingEntityMetaData = new ArrayList<Pair<EntityMetaData, List<AttributeMetaData>>>();
-				referencingEntityMetaData.add(new Pair<EntityMetaData, List<AttributeMetaData>>(otherEntityMetaData,
-						referencingAttributes));
-			}
-		}
-
-		return referencingEntityMetaData != null ? referencingEntityMetaData : Collections
-				.<Pair<EntityMetaData, List<AttributeMetaData>>> emptyList();
-
 	}
 
 	/**
@@ -1206,7 +1171,8 @@ public class ElasticSearchService implements SearchService
 	// Checks if entities can be deleted, have no ref entities pointing to it
 	private boolean canBeDeleted(Iterable<?> ids, EntityMetaData meta)
 	{
-		List<Pair<EntityMetaData, List<AttributeMetaData>>> referencingMetas = getReferencingEntityMetaData(meta);
+		List<Pair<EntityMetaData, List<AttributeMetaData>>> referencingMetas = EntityUtils
+				.getReferencingEntityMetaData(meta, dataService);
 		if (referencingMetas.isEmpty()) return true;
 
 		for (Pair<EntityMetaData, List<AttributeMetaData>> pair : referencingMetas)

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticSearchServiceTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticSearchServiceTest.java
@@ -43,6 +43,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Lists;
+
 public class ElasticSearchServiceTest
 {
 	private Client client;
@@ -92,6 +94,8 @@ public class ElasticSearchServiceTest
 		DefaultEntityMetaData entityMetaData = createEntityMeta("entity");
 
 		MapEntity entity = createEntityAndRegisterSource(entityMetaData, "id0");
+
+		when(dataService.getEntityNames()).thenReturn(Lists.newArrayList());
 
 		searchService.index(entity, entityMetaData, IndexingMode.UPDATE);
 		verify(client, times(1)).prepareIndex(eq(indexName), eq("entity"), any(String.class));

--- a/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
+++ b/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
@@ -30,6 +30,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.Manageable;
 import org.molgenis.data.MolgenisDataException;
+import org.molgenis.data.MolgenisReferencedEntityException;
 import org.molgenis.data.Query;
 import org.molgenis.data.QueryRule;
 import org.molgenis.data.Repository;
@@ -47,6 +48,8 @@ import org.molgenis.fieldtypes.StringField;
 import org.molgenis.fieldtypes.TextField;
 import org.molgenis.fieldtypes.XrefField;
 import org.molgenis.model.MolgenisModelException;
+import org.molgenis.util.EntityUtils;
+import org.molgenis.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataAccessException;
@@ -105,8 +108,27 @@ public class MysqlRepository extends AbstractRepository implements Manageable
 				remembered = remembered != null ? remembered : e;
 			}
 		}
-		DataAccessException e = tryExecute(getDropSql());
-		remembered = remembered != null ? remembered : e;
+
+		// Deleting entites that are referenced won't work due to failing key constraints
+		// Find out if the entity is referenced and if it is, report those entities
+		List<Pair<EntityMetaData, List<AttributeMetaData>>> referencingEntities = EntityUtils
+				.getReferencingEntityMetaData(getEntityMetaData(), dataService);
+		if (!referencingEntities.isEmpty())
+		{
+			List<String> entityNames = Lists.newArrayList();
+			referencingEntities.forEach(pair -> entityNames.add(pair.getA().getName()));
+
+			StringBuilder msg = new StringBuilder("Cannot delete entity '").append(getEntityMetaData().getName())
+					.append("' because it is referenced by the following entities: ").append(entityNames.toString());
+
+			throw new MolgenisReferencedEntityException(msg.toString());
+		}
+		else
+		{
+			DataAccessException e = tryExecute(getDropSql());
+			remembered = remembered != null ? remembered : e;
+		}
+
 		if (remembered != null)
 		{
 			throw remembered;

--- a/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryXrefTest.java
+++ b/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryXrefTest.java
@@ -72,14 +72,17 @@ public class MysqlRepositoryXrefTest extends MysqlRepositoryAbstractDatatypeTest
 		Assert.assertEquals(xrefRepo.getCreateFKeySql(getMetaData().getAttribute("stringRef")),
 				"ALTER TABLE `XrefTest` ADD FOREIGN KEY (`stringRef`) REFERENCES `StringTarget`(`identifier`)");
 
-		xrefRepo.drop();
-		stringRepo.drop();
-		intRepo.drop();
+		// simply dropping the repos won't work because the references keep existing after the tables are deleted, so we
+		// use the data service
+		dataService.getMeta().deleteEntityMeta(xrefRepo.getName());
+		dataService.getMeta().deleteEntityMeta(stringRepo.getName());
+		dataService.getMeta().deleteEntityMeta(intRepo.getName());
 
 		Assert.assertEquals(xrefRepo.getCreateSql(), createSql());
-		stringRepo.create();
-		intRepo.create();
-		xrefRepo.create();
+
+		dataService.getMeta().addEntityMeta(getMetaData().getAttribute("intRef").getRefEntity());
+		dataService.getMeta().addEntityMeta(getMetaData().getAttribute("stringRef").getRefEntity());
+		dataService.getMeta().addEntityMeta(getMetaData());
 
 		// add records
 		Entity entity = new MapEntity();

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
@@ -50,6 +50,7 @@ import org.molgenis.data.EntityCollection;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisDataAccessException;
 import org.molgenis.data.MolgenisDataException;
+import org.molgenis.data.MolgenisReferencedEntityException;
 import org.molgenis.data.Query;
 import org.molgenis.data.QueryRule;
 import org.molgenis.data.Repository;
@@ -889,7 +890,7 @@ public class RestController
 	@ResponseBody
 	public ErrorMessageResponse handleMolgenisDataException(MolgenisDataException e)
 	{
-		LOG.error("", e);
+		LOG.error("SUPERTEST", e);
 		return new ErrorMessageResponse(new ErrorMessage(e.getMessage()));
 	}
 
@@ -915,6 +916,15 @@ public class RestController
 	@ResponseStatus(INTERNAL_SERVER_ERROR)
 	@ResponseBody
 	public ErrorMessageResponse handleRuntimeException(RuntimeException e)
+	{
+		LOG.error("", e);
+		return new ErrorMessageResponse(new ErrorMessage(e.getMessage()));
+	}
+
+	@ExceptionHandler(MolgenisReferencedEntityException.class)
+	@ResponseStatus(INTERNAL_SERVER_ERROR)
+	@ResponseBody
+	public ErrorMessageResponse handleMolgenisReferencingEntityException(MolgenisReferencedEntityException e)
 	{
 		LOG.error("", e);
 		return new ErrorMessageResponse(new ErrorMessage(e.getMessage()));

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
@@ -890,7 +890,7 @@ public class RestController
 	@ResponseBody
 	public ErrorMessageResponse handleMolgenisDataException(MolgenisDataException e)
 	{
-		LOG.error("SUPERTEST", e);
+		LOG.error("", e);
 		return new ErrorMessageResponse(new ErrorMessage(e.getMessage()));
 	}
 

--- a/molgenis-data/src/main/java/org/molgenis/data/MolgenisReferencedEntityException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/MolgenisReferencedEntityException.java
@@ -1,0 +1,26 @@
+package org.molgenis.data;
+
+
+public class MolgenisReferencedEntityException extends MolgenisDataException
+{
+	private static final long serialVersionUID = 1L;
+
+	public MolgenisReferencedEntityException()
+	{
+	}
+
+	public MolgenisReferencedEntityException(String message)
+	{
+		super(message);
+	}
+
+	public MolgenisReferencedEntityException(Throwable cause)
+	{
+		super(cause);
+	}
+
+	public MolgenisReferencedEntityException(String message, Throwable cause)
+	{
+		super(message, cause);
+	}
+}

--- a/molgenis-data/src/main/java/org/molgenis/util/EntityUtils.java
+++ b/molgenis-data/src/main/java/org/molgenis/util/EntityUtils.java
@@ -1,6 +1,9 @@
 package org.molgenis.util;
 
 import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.molgenis.MolgenisFieldTypes.FieldTypeEnum;
@@ -16,6 +19,7 @@ import com.google.common.collect.Iterables;
 
 public class EntityUtils
 {
+
 	/**
 	 * Checks if an entity contains data or not
 	 * 
@@ -32,6 +36,43 @@ public class EntityUtils
 		}
 
 		return true;
+	}
+
+	public static List<Pair<EntityMetaData, List<AttributeMetaData>>> getReferencingEntityMetaData(
+			EntityMetaData entityMetaData, DataService dataService)
+	{
+		List<Pair<EntityMetaData, List<AttributeMetaData>>> referencingEntityMetaData = null;
+
+		// get entity types that referencing the given entity (including self)
+		String entityName = entityMetaData.getName();
+		for (String otherEntityName : dataService.getEntityNames())
+		{
+			EntityMetaData otherEntityMetaData = dataService.getEntityMetaData(otherEntityName);
+
+			// get referencing attributes for other entity
+			List<AttributeMetaData> referencingAttributes = null;
+			for (AttributeMetaData attributeMetaData : otherEntityMetaData.getAtomicAttributes())
+			{
+				EntityMetaData refEntityMetaData = attributeMetaData.getRefEntity();
+				if (refEntityMetaData != null && refEntityMetaData.getName().equals(entityName))
+				{
+					if (referencingAttributes == null) referencingAttributes = new ArrayList<AttributeMetaData>();
+					referencingAttributes.add(attributeMetaData);
+				}
+			}
+
+			// store references
+			if (referencingAttributes != null)
+			{
+				if (referencingEntityMetaData == null) referencingEntityMetaData = new ArrayList<Pair<EntityMetaData, List<AttributeMetaData>>>();
+				referencingEntityMetaData.add(new Pair<EntityMetaData, List<AttributeMetaData>>(otherEntityMetaData,
+						referencingAttributes));
+			}
+		}
+
+		return referencingEntityMetaData != null ? referencingEntityMetaData : Collections
+				.<Pair<EntityMetaData, List<AttributeMetaData>>> emptyList();
+
 	}
 
 	/**


### PR DESCRIPTION
- Moved code that decides if an entity is referenced by another entity from ElasticSearchService to EntityUtils. 
- MysqlRepository: now throws MolgenisReferencedEntityException when trying to drop referenced entity. 
- Updated tests. 
- Clear error message is passed to the user detailing the entities that block deletion