### PR TITLE
Unicode escape the Searching… [1.4.4 -> master]

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/select2-patched.js
+++ b/molgenis-core-ui/src/main/resources/js/select2-patched.js
@@ -3508,8 +3508,8 @@ the specific language governing permissions and limitations under the Apache Lic
          formatInputTooShort: function (input, min) { var n = min - input.length; return "Please enter " + n + " or more character" + (n == 1 ? "" : "s"); },
          formatInputTooLong: function (input, max) { var n = input.length - max; return "Please delete " + n + " character" + (n == 1 ? "" : "s"); },
          formatSelectionTooBig: function (limit) { return "You can only select " + limit + " item" + (limit == 1 ? "" : "s"); },
-         formatLoadMore: function (pageNumber) { return "Loading more results…"; },
-         formatSearching: function () { return "Searching…"; }
+         formatLoadMore: function (pageNumber) { return "Loading more results\u2026"; },
+         formatSearching: function () { return "Searching\u2026"; }
     };
 
     $.extend($.fn.select2.defaults, $.fn.select2.locales['en']);


### PR DESCRIPTION
Unicode escape the Searching… in the mref2 select javascript file,
so that it can be served as ASCII and does not suffer from #3252.

Port from 1.4.4 to master.