### PR TITLE
Fix questionnaires importing a non-existing css file [Master]

### DIFF
--- a/molgenis-questionnaires/src/main/resources/templates/view-questionnaire.ftl
+++ b/molgenis-questionnaires/src/main/resources/templates/view-questionnaire.ftl
@@ -1,7 +1,7 @@
 <#include "molgenis-header.ftl">
 <#include "molgenis-footer.ftl">
 
-<#assign css=['molgenis-form.css','questionnaire.css']>
+<#assign css=['questionnaire.css']>
 <#assign js=['questionnaire.js']>
 
 <@header css js/>


### PR DESCRIPTION
The questionnaire plugin will break when the app is deployed on the server