### PR TITLE
Added annotator constructor for seamless chaining

### DIFF
--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/AbstractRepositoryAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/AbstractRepositoryAnnotator.java
@@ -120,6 +120,20 @@ public abstract class AbstractRepositoryAnnotator implements RepositoryAnnotator
 			}
 		};
 	}
+	
+	@Override
+	@Transactional
+	public Iterator<Entity> annotate(final Iterator<Entity> sourceIterable)
+	{
+		return this.annotate(new Iterable<Entity>()
+		{
+			@Override
+			public Iterator<Entity> iterator()
+			{
+				return sourceIterable;
+			}
+		});
+	}
 
 	public abstract List<Entity> annotateEntity(Entity entity) throws IOException, InterruptedException;
 

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/RepositoryAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/RepositoryAnnotator.java
@@ -21,6 +21,9 @@ public interface RepositoryAnnotator
 	// add entityAnnotator
 	Iterator<Entity> annotate(Iterable<Entity> source);
 
+	// alternative constructor that allows seamless chaining
+	Iterator<Entity> annotate(Iterator<Entity> source);
+
 	/**
 	 * returns an entityMetaData containing the attributes the annotator will add
 	 * 

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/impl/SnpEffServiceAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/impl/SnpEffServiceAnnotator.java
@@ -490,4 +490,17 @@ public class SnpEffServiceAnnotator implements RepositoryAnnotator
 		return AnnotatorInfo.create(Status.INDEV, Type.UNUSED, "unknown", "no description", getOutputMetaData());
 	}
 
+	@Override
+	public Iterator<Entity> annotate(Iterator<Entity> source)
+	{
+		return this.annotate(new Iterable<Entity>()
+		{
+			@Override
+			public Iterator<Entity> iterator()
+			{
+				return source;
+			}
+		});
+	}
+
 }


### PR DESCRIPTION
Very convenient, allows you to chain annotators, for example:

```java
Iterator<Entity> vcfIterWithExac = exacAnnotator.annotate(vcfRepo);
Iterator<Entity> vcfIterWithExacAndCadd = caddAnnotator.annotate(vcfIterWithExac);
```