### PR TITLE
Revert "Print compound attribute values in entity toString". The toString is causing null pointers in the abstract entity tests. Quick revert to fix the build.

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/support/AbstractEntity.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/AbstractEntity.java
@@ -159,8 +159,10 @@ public abstract class AbstractEntity implements Entity
 	{
 		StringBuilder sb = new StringBuilder();
 		sb.append(this.getClass().getSimpleName() + "{");
-		Iterable<AttributeMetaData> allAttributes = this.getEntityMetaData().getAtomicAttributes();
-		allAttributes.forEach(attribute -> sb.append(attribute.getName() + "='" + this.get(attribute.getName()) + "', "));
+		for (String attrName : this.getAttributeNames())
+		{
+			sb.append(attrName + "='" + this.get(attrName) + "', ");
+		}
 		sb.delete(sb.length() - 2, sb.length());
 		sb.append("}");
 		return sb.toString();


### PR DESCRIPTION
Reverts molgenis/molgenis#3383
