### PR TITLE
Annotators: Fixed HPO annotator not working in UI

### DIFF
--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/HPOAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/HPOAnnotator.java
@@ -6,8 +6,8 @@ import static org.molgenis.data.annotation.entity.impl.HPORepository.HPO_TERM_CO
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
@@ -105,7 +105,7 @@ public class HPOAnnotator
 		@Override
 		public Collection<AttributeMetaData> getRequiredAttributes()
 		{
-			return Arrays.asList();
+			return Collections.emptyList();
 		}
 
 		@Override

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/HPOAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/HPOAnnotator.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
+import org.molgenis.MolgenisFieldTypes;
 import org.molgenis.data.AttributeMetaData;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;
@@ -40,7 +41,10 @@ import com.google.common.base.Optional;
 /**
  * Typical HPO terms for a gene identifier (already present via SnpEff) Source:
  * http://compbio.charite.de/hudson/job/hpo. annotations.monthly/lastStableBuild/artifact/annotation/
- * ALL_SOURCES_TYPICAL_FEATURES_diseases_to_genes_to_phenotypes .txts
+ * ALL_SOURCES_TYPICAL_FEATURES_diseases_to_genes_to_phenotypes .txt
+ * 
+ * Add resource file path to RuntimeProperty 'hpo_location'
+ * 
  */
 @Configuration
 public class HPOAnnotator
@@ -64,8 +68,8 @@ public class HPOAnnotator
 	public RepositoryAnnotator hpo()
 	{
 		List<AttributeMetaData> attributes = new ArrayList<>();
-		attributes.add(new DefaultAttributeMetaData(HPO_IDS));
-		attributes.add(new DefaultAttributeMetaData(HPO_TERMS));
+		attributes.add(new DefaultAttributeMetaData(HPO_IDS).setDataType(MolgenisFieldTypes.TEXT));
+		attributes.add(new DefaultAttributeMetaData(HPO_TERMS).setDataType(MolgenisFieldTypes.TEXT));
 
 		AnnotatorInfo info = AnnotatorInfo
 				.create(Status.READY,
@@ -101,8 +105,7 @@ public class HPOAnnotator
 		@Override
 		public Collection<AttributeMetaData> getRequiredAttributes()
 		{
-			return Arrays.asList(new DefaultAttributeMetaData(HPO_ID_COL_NAME), new DefaultAttributeMetaData(
-					HPO_TERM_COL_NAME));
+			return Arrays.asList();
 		}
 
 		@Override

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/query/GeneNameQueryCreator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/query/GeneNameQueryCreator.java
@@ -11,21 +11,19 @@ import org.molgenis.data.Query;
 import org.molgenis.data.annotation.entity.QueryCreator;
 import org.molgenis.data.annotation.entity.impl.SnpEffAnnotator;
 import org.molgenis.data.support.DefaultAttributeMetaData;
-import org.molgenis.data.vcf.VcfRepository;
 
 public class GeneNameQueryCreator implements QueryCreator
 {
 	@Override
 	public Collection<AttributeMetaData> getRequiredAttributes()
 	{
-		return Collections.singleton(new DefaultAttributeMetaData(VcfRepository.getInfoPrefix()
-				+ SnpEffAnnotator.GENE_NAME));
+		return Collections.singleton(new DefaultAttributeMetaData(SnpEffAnnotator.GENE_NAME));
 	}
 
 	@Override
 	public Query createQuery(Entity entity)
 	{
-		Object value = entity.get(VcfRepository.getInfoPrefix() + SnpEffAnnotator.GENE_NAME);
+		Object value = entity.get(SnpEffAnnotator.GENE_NAME);
 		return EQ(SnpEffAnnotator.GENE_NAME, value);
 	}
 }


### PR DESCRIPTION
- Exposed right attributes
- Set attributes to type TEXT, because the phenotype strings can get very long
 - **Please add this edge case to the integration test by annotating a gene with loads of HPO terms**
