### PR TITLE
Fix #3572 Form validation errors displayed wrong location

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/component/Form.js
+++ b/molgenis-core-ui/src/main/resources/js/component/Form.js
@@ -37,7 +37,7 @@
 				modal: false,
 				enableOptionalFilter: true,
 				enableFormIndex: true,
-				enableAlertMessageInFormIndex: true,
+				enableAlertMessageInFormIndex: false,
 				colOffset: 3,
 				saveOnBlur: false,
 				showHidden: false,

--- a/molgenis-core-ui/src/main/resources/js/component/Questionnaire.js
+++ b/molgenis-core-ui/src/main/resources/js/component/Questionnaire.js
@@ -52,6 +52,7 @@
     	        enableOptionalFilter: false,
     	        saveOnBlur: true,
     	        enableFormIndex: true,
+    	        enableAlertMessageInFormIndex: true,
     	        categoricalMrefShowSelectAll: false,
     	        showAsteriskIfNotNillable: false,
     	        beforeSubmit: this._handleBeforeSubmit,


### PR DESCRIPTION
Change the enableAlertMessageInFormIndex value to false, restore old
user interaction. Set the enableAlertMessageInFormIndex to true only
for the questionnaire.
