### PR TITLE
[1.9] fix #3600 Using an int as an identifier for entities used as ref…

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/molgenis.js
+++ b/molgenis-core-ui/src/main/resources/js/molgenis.js
@@ -690,9 +690,9 @@ function createInput(attr, attrs, val, lbl) {
 	
 	var toRsqlValue = function(value) {
 		var rsqlValue;
-		if (value.indexOf('"') !== -1 || value.indexOf('\'') !== -1 || value.indexOf('(') !== -1 || value.indexOf(')') !== -1 || value.indexOf(';') !== -1
+		if (_.isString(value)===false || (value.indexOf('"') !== -1 || value.indexOf('\'') !== -1 || value.indexOf('(') !== -1 || value.indexOf(')') !== -1 || value.indexOf(';') !== -1
 				|| value.indexOf(',') !== -1 || value.indexOf('=') !== -1 || value.indexOf('!') !== -1 || value.indexOf('~') !== -1 || value.indexOf('<') !== -1
-				|| value.indexOf('>') !== -1 || value.indexOf(' ') !== -1) {
+				|| value.indexOf('>') !== -1 || value.indexOf(' ') !== -1)) {
 			rsqlValue = '"' + encodeURIComponent(value) + '"';
 		} else {
 			rsqlValue = encodeURIComponent(value);


### PR DESCRIPTION
… entities, i.e. target entities for mrefs, xrefs etc.. will cause the DOM to crash if you click the mref link in the dataexplorer