### PR TITLE
[1.9] Fix #3551 Annotating with two annotators shows only one annotator's data unless you create a copy

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
@@ -1,6 +1,11 @@
 package org.molgenis.data.elasticsearch;
 
 import static java.util.stream.StreamSupport.stream;
+import static org.elasticsearch.index.query.FilterBuilders.andFilter;
+import static org.elasticsearch.index.query.FilterBuilders.queryFilter;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.indicesQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.molgenis.data.elasticsearch.util.ElasticsearchEntityUtils.toElasticsearchId;
 import static org.molgenis.data.elasticsearch.util.ElasticsearchEntityUtils.toElasticsearchIds;
 import static org.molgenis.data.elasticsearch.util.MapperTypeSanitizer.sanitizeMapperType;
@@ -40,6 +45,8 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchHit;
@@ -1048,6 +1055,29 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 					SearchRequestBuilder searchRequestBuilder = client.prepareSearch(indexNames);
 					searchRequestGenerator.buildSearchRequest(searchRequestBuilder, type, SearchType.QUERY_AND_FETCH,
 							q, fieldsToReturn, null, null, null, entityMetaData);
+
+					// We are in a transaction, the first index is the status before the transaction started, the second
+					// index the status within the transaction. We don't want to return the deleted records and of the
+					// updated records we want the latest version (that of the transaction)
+					if (indexNames.length > 1)
+					{
+						QueryBuilder findUpdatesQuery = indicesQuery(
+								termQuery(CRUD_TYPE_FIELD_NAME, CrudType.UPDATE.name()), indexNames[1]);
+
+						// Exclude the updated records from the first index
+						QueryBuilder excludeUpdatesQuery = indicesQuery(boolQuery().mustNot(findUpdatesQuery),
+								indexNames[0]);
+
+						QueryBuilder findDeletesQuery = indicesQuery(
+								termQuery(CRUD_TYPE_FIELD_NAME, CrudType.DELETE.name()), indexNames[1]);
+
+						// Exclude deleted records fom both indices
+						BoolQueryBuilder excludeDeletesQuery = boolQuery().mustNot(findDeletesQuery);
+
+						searchRequestBuilder.setPostFilter(andFilter(queryFilter(excludeUpdatesQuery),
+								queryFilter(excludeDeletesQuery)));
+					}
+
 					if (LOG.isTraceEnabled())
 					{
 						LOG.trace("SearchRequest: " + searchRequestBuilder);


### PR DESCRIPTION
Annotating with two annotators shows only one annotator's data unless you create a copy