### PR TITLE
[master] fix #3647: If you have an mref with missing values in one of the refe…

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/component/Table.js
+++ b/molgenis-core-ui/src/main/resources/js/component/Table.js
@@ -518,7 +518,7 @@
 						var CellContentForValue = this._createTableCellContent(value, 'c' + i);
 						return i < this.props.value.length - 1 ? [CellContentForValue, br({key: 'b' + i})] : CellContentForValue;
 					} else {
-						return null;
+						return br();
 					}
 				}.bind(this)));
 			} else {


### PR DESCRIPTION
…renced entities, the table shifts the values

This fix is already aplied to 1.9.0