### PR TITLE
Fix #3747 In the "Single Mapping project overview" add source does not work

### DIFF
--- a/molgenis-data-mapper/src/main/java/org/molgenis/data/mapper/repository/impl/AttributeMappingRepositoryImpl.java
+++ b/molgenis-data-mapper/src/main/java/org/molgenis/data/mapper/repository/impl/AttributeMappingRepositoryImpl.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.molgenis.data.AttributeMetaData;
 import org.molgenis.data.DataService;
@@ -117,8 +118,8 @@ public class AttributeMappingRepositoryImpl implements AttributeMappingRepositor
 		attributeMappingEntity.set(AttributeMappingMetaData.TARGETATTRIBUTEMETADATA, attributeMapping
 				.getTargetAttributeMetaData() != null ? attributeMapping.getTargetAttributeMetaData().getName() : null);
 		attributeMappingEntity.set(AttributeMappingMetaData.ALGORITHM, attributeMapping.getAlgorithm());
-		attributeMappingEntity.set(AttributeMappingMetaData.SOURCEATTRIBUTEMETADATAS,
-				attributeMapping.getSourceAttributeMetaDatas());
+		attributeMappingEntity.set(AttributeMappingMetaData.SOURCEATTRIBUTEMETADATAS, attributeMapping
+				.getSourceAttributeMetaDatas().stream().map(AttributeMetaData::getName).collect(Collectors.toList()));
 		attributeMappingEntity.set(AttributeMappingMetaData.ALGORITHMSTATE, attributeMapping.getAlgorithmState());
 		return attributeMappingEntity;
 	}


### PR DESCRIPTION
In the attribute sourceAttributeMetaDatas of the entity AttributeMapping
was not filled correctlly whole attributes instead of the only the
names. Fix #3747