### PR TITLE
[master] Fix #3786 Filtering in the DataExplorer on date / timestamp fails

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/request/QueryGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/request/QueryGenerator.java
@@ -14,6 +14,7 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.molgenis.MolgenisFieldTypes.FieldTypeEnum;
 import org.molgenis.data.AttributeMetaData;
+import org.molgenis.data.DataConverter;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisQueryException;
@@ -247,7 +248,7 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? queryValue.toString() : queryValue;
+				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).gt(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -262,7 +263,7 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? queryValue.toString() : queryValue;
+				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).gte(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -354,7 +355,7 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? queryValue.toString() : queryValue;
+				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).lt(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -368,7 +369,7 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? queryValue.toString() : queryValue;
+				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).lte(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorReferencesTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorReferencesTest.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.mockito.ArgumentCaptor;
 import org.molgenis.MolgenisFieldTypes;
 import org.molgenis.data.AttributeMetaData;
+import org.molgenis.data.DataConverter;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisQueryException;
 import org.molgenis.data.Query;
@@ -123,7 +124,7 @@ public class QueryGeneratorReferencesTest
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
 				.nestedFilter(REF_ENTITY_ATT,
-						FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gt(value.toString())));
+						FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gt(DataConverter.toString(value))));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -135,10 +136,12 @@ public class QueryGeneratorReferencesTest
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
-		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(
-				QueryBuilders.matchAllQuery(),
-				FilterBuilders.nestedFilter(REF_ENTITY_ATT,
-						FilterBuilders.rangeFilter(PREFIX + refDateTimeAttributeName).gt(value.toString())));
+		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(),
+				FilterBuilders
+						.nestedFilter(
+								REF_ENTITY_ATT,
+								FilterBuilders.rangeFilter(PREFIX + refDateTimeAttributeName).gt(
+										DataConverter.toString(value))));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -191,7 +194,7 @@ public class QueryGeneratorReferencesTest
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
 				.nestedFilter(REF_ENTITY_ATT,
-						FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gte(value.toString())));
+						FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gte(DataConverter.toString(value))));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorTest.java
@@ -18,6 +18,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.mockito.ArgumentCaptor;
 import org.molgenis.MolgenisFieldTypes;
 import org.molgenis.data.AttributeMetaData;
+import org.molgenis.data.DataConverter;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisQueryException;
@@ -130,7 +131,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).gt(value.toString()));
+				.rangeFilter(dateAttributeName).gt(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -143,7 +144,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateTimeAttributeName).gt(value.toString()));
+				.rangeFilter(dateTimeAttributeName).gt(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -208,7 +209,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).gte(value.toString()));
+				.rangeFilter(dateAttributeName).gte(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -221,7 +222,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateTimeAttributeName).gte(value.toString()));
+				.rangeFilter(dateTimeAttributeName).gte(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -286,7 +287,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).lte(value.toString()));
+				.rangeFilter(dateAttributeName).lte(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -299,7 +300,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateTimeAttributeName).lte(value.toString()));
+				.rangeFilter(dateTimeAttributeName).lte(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -699,7 +700,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).lt(value.toString()));
+				.rangeFilter(dateAttributeName).lt(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -712,7 +713,7 @@ public class QueryGeneratorTest
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateTimeAttributeName).lt(value.toString()));
+				.rangeFilter(dateTimeAttributeName).lt(DataConverter.toString(value)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/importer/VcfImporterService.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/importer/VcfImporterService.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.google.common.collect.Lists;
 
@@ -62,9 +61,7 @@ public class VcfImporterService implements ImportService
 	}
 
 	@Override
-	@Transactional
-	public EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction,
-			String defaultPackage)
+	public EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String defaultPackage)
 	{
 		if (databaseAction != DatabaseAction.ADD) throw new IllegalArgumentException("Only ADD is supported");
 
@@ -190,7 +187,8 @@ public class VcfImporterService implements ImportService
 		}
 	}
 
-	private EntityImportReport importVcf(Repository inRepository, List<EntityMetaData> addedEntities) throws IOException
+	private EntityImportReport importVcf(Repository inRepository, List<EntityMetaData> addedEntities)
+			throws IOException
 	{
 		EntityImportReport report = new EntityImportReport();
 		Repository sampleRepository = null;


### PR DESCRIPTION
Also fixed rollback error in case of error during vcf import 