### PR TITLE
[1.10] Fix #3786 Filtering in the DataExplorer on date / timestamp fails (date)

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/request/QueryGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/request/QueryGenerator.java
@@ -2,6 +2,7 @@ package org.molgenis.data.elasticsearch.request;
 
 import static org.molgenis.data.elasticsearch.index.ElasticsearchIndexCreator.DEFAULT_ANALYZER;
 
+import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
@@ -14,7 +15,6 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.molgenis.MolgenisFieldTypes.FieldTypeEnum;
 import org.molgenis.data.AttributeMetaData;
-import org.molgenis.data.DataConverter;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisQueryException;
@@ -23,6 +23,7 @@ import org.molgenis.data.QueryRule;
 import org.molgenis.data.QueryRule.Operator;
 import org.molgenis.data.UnknownAttributeException;
 import org.molgenis.data.elasticsearch.index.MappingsBuilder;
+import org.molgenis.util.MolgenisDateFormat;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
@@ -248,7 +249,12 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
+				if (queryValue instanceof Date)
+				{
+					AttributeMetaData attr = getAttribute(entityMetaData, attributePath);
+					queryValue = getESDateQueryValue((Date) queryValue, attr);
+				}
+
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).gt(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -263,7 +269,11 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
+				if (queryValue instanceof Date)
+				{
+					AttributeMetaData attr = getAttribute(entityMetaData, attributePath);
+					queryValue = getESDateQueryValue((Date) queryValue, attr);
+				}
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).gte(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -355,7 +365,11 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
+				if (queryValue instanceof Date)
+				{
+					AttributeMetaData attr = getAttribute(entityMetaData, attributePath);
+					queryValue = getESDateQueryValue((Date) queryValue, attr);
+				}
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).lt(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -369,7 +383,11 @@ public class QueryGenerator implements QueryPartGenerator
 				String[] attributePath = parseAttributePath(queryField);
 
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValue = queryValue instanceof java.util.Date ? DataConverter.toString(queryValue) : queryValue;
+				if (queryValue instanceof Date)
+				{
+					AttributeMetaData attr = getAttribute(entityMetaData, attributePath);
+					queryValue = getESDateQueryValue((Date) queryValue, attr);
+				}
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).lte(queryValue);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
 				queryBuilder = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), filterBuilder);
@@ -389,15 +407,25 @@ public class QueryGenerator implements QueryPartGenerator
 
 				Iterator<?> iterator = iterable.iterator();
 
+				String[] attributePath = parseAttributePath(queryField);
+				AttributeMetaData attr = getAttribute(entityMetaData, attributePath);
+
 				Object queryValueFrom = iterator.next();
+
 				// Workaround for Elasticsearch Date to String conversion issue
-				queryValueFrom = queryValueFrom instanceof java.util.Date ? queryValueFrom.toString() : queryValueFrom;
+				if (queryValueFrom instanceof Date)
+				{
+					queryValueFrom = getESDateQueryValue((Date) queryValueFrom, attr);
+				}
 
 				Object queryValueTo = iterator.next();
-				// Workaround for Elasticsearch Date to String conversion issue
-				queryValueTo = queryValueTo instanceof java.util.Date ? queryValueTo.toString() : queryValueTo;
 
-				String[] attributePath = parseAttributePath(queryField);
+				// Workaround for Elasticsearch Date to String conversion issue
+				if (queryValueTo instanceof Date)
+				{
+					queryValueTo = getESDateQueryValue((Date) queryValueTo, attr);
+				}
+
 				FilterBuilder filterBuilder = FilterBuilders.rangeFilter(queryField).gte(queryValueFrom)
 						.lte(queryValueTo);
 				filterBuilder = nestedFilterBuilder(attributePath, filterBuilder);
@@ -731,5 +759,15 @@ public class QueryGenerator implements QueryPartGenerator
 
 			return attr;
 		}
+	}
+
+	private String getESDateQueryValue(Date queryValue, AttributeMetaData attr)
+	{
+		if (attr.getDataType().getEnumType() == FieldTypeEnum.DATE_TIME)
+		{
+			return MolgenisDateFormat.getDateTimeFormat().format(queryValue);
+		}
+
+		return MolgenisDateFormat.getDateFormat().format(queryValue);
 	}
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorReferencesTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorReferencesTest.java
@@ -117,14 +117,14 @@ public class QueryGeneratorReferencesTest
 	@Test
 	public void generateOneQueryRuleGreaterDate() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22");
+		String date = "2015-05-22";
+		Date value = MolgenisDateFormat.getDateFormat().parse(date);
 		Query q = new QueryImpl().gt(PREFIX + refDateAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.nestedFilter(REF_ENTITY_ATT,
-						FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gt(DataConverter.toString(value))));
+				.nestedFilter(REF_ENTITY_ATT, FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gt(date)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
@@ -187,14 +187,14 @@ public class QueryGeneratorReferencesTest
 	@Test
 	public void generateOneQueryRuleGreaterEqualDate() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22");
+		String date = "2015-05-22";
+		Date value = MolgenisDateFormat.getDateFormat().parse(date);
 		Query q = new QueryImpl().ge(PREFIX + refDateAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.nestedFilter(REF_ENTITY_ATT,
-						FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gte(DataConverter.toString(value))));
+				.nestedFilter(REF_ENTITY_ATT, FilterBuilders.rangeFilter(PREFIX + refDateAttributeName).gte(date)));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/request/QueryGeneratorTest.java
@@ -125,20 +125,21 @@ public class QueryGeneratorTest
 	@Test
 	public void generateOneQueryRuleGreaterDate() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-01-22");
+		String date = "2015-01-22";
+		Date value = MolgenisDateFormat.getDateFormat().parse(date);
 		Query q = new QueryImpl().gt(dateAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).gt(DataConverter.toString(value)));
+				.rangeFilter(dateAttributeName).gt(date));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
 	@Test
 	public void generateOneQueryRuleGreaterDateTime() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22T11:12:13+0500");
+		Date value = MolgenisDateFormat.getDateTimeFormat().parse("2015-05-22T11:12:13+0500");
 		Query q = new QueryImpl().gt(dateTimeAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
@@ -203,20 +204,21 @@ public class QueryGeneratorTest
 	@Test
 	public void generateOneQueryRuleGreaterEqualDate() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22");
+		String date = "2015-05-22";
+		Date value = MolgenisDateFormat.getDateFormat().parse(date);
 		Query q = new QueryImpl().ge(dateAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).gte(DataConverter.toString(value)));
+				.rangeFilter(dateAttributeName).gte(date));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
 	@Test
 	public void generateOneQueryRuleGreaterEqualDateTime() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22T11:12:13+0500");
+		Date value = MolgenisDateFormat.getDateTimeFormat().parse("2015-05-22T11:12:13+0500");
 		Query q = new QueryImpl().ge(dateTimeAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
@@ -281,20 +283,21 @@ public class QueryGeneratorTest
 	@Test
 	public void generateOneQueryRuleLesserEqualDate() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22");
+		String date = "2015-05-22";
+		Date value = MolgenisDateFormat.getDateFormat().parse(date);
 		Query q = new QueryImpl().le(dateAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).lte(DataConverter.toString(value)));
+				.rangeFilter(dateAttributeName).lte(date));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
 	@Test
 	public void generateOneQueryRuleLesserEqualDateTime() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22T11:12:13+0500");
+		Date value = MolgenisDateFormat.getDateTimeFormat().parse("2015-05-22T11:12:13+0500");
 		Query q = new QueryImpl().le(dateTimeAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
@@ -694,20 +697,21 @@ public class QueryGeneratorTest
 	@Test
 	public void generateOneQueryRuleLesserDate() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22");
+		String date = "2015-05-22";
+		Date value = MolgenisDateFormat.getDateFormat().parse(date);
 		Query q = new QueryImpl().lt(dateAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);
 		verify(searchRequestBuilder).setQuery(captor.capture());
 		QueryBuilder expectedQuery = QueryBuilders.filteredQuery(QueryBuilders.matchAllQuery(), FilterBuilders
-				.rangeFilter(dateAttributeName).lt(DataConverter.toString(value)));
+				.rangeFilter(dateAttributeName).lt(date));
 		assertQueryBuilderEquals(captor.getValue(), expectedQuery);
 	}
 
 	@Test
 	public void generateOneQueryRuleLesserDateTime() throws ParseException
 	{
-		Date value = MolgenisDateFormat.getDateFormat().parse("2015-05-22T11:12:13+0500");
+		Date value = MolgenisDateFormat.getDateTimeFormat().parse("2015-05-22T11:12:13+0500");
 		Query q = new QueryImpl().lt(dateTimeAttributeName, value);
 		new QueryGenerator().generate(searchRequestBuilder, q, entityMetaData);
 		ArgumentCaptor<QueryBuilder> captor = ArgumentCaptor.forClass(QueryBuilder.class);


### PR DESCRIPTION
After fixing datetime it turned out date was also failing