### PR TITLE
[master] fix #2768 When CHROM / POS columns are hidden and you click a genetic…

### DIFF
--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
@@ -95,7 +95,11 @@
 	}
 
 	function onRowClick(entity) {
-		genomeBrowser.setLocation(entity[genomebrowserChromosomeAttribute.name],entity[genomebrowserStartAttribute.name]-50,entity[genomebrowserStartAttribute.name]+50);
+		var chrom = entity[genomebrowserChromosomeAttribute.name];
+		var pos = entity[genomebrowserStartAttribute.name];
+		if(chrom !== undefined && chrom !== "" && pos !== undefined && pos !== ""){
+			genomeBrowser.setLocation(chrom,pos-50,pos+50);
+		}
 	}
 
 	/**


### PR DESCRIPTION
… data row, you get "viewFeatures called with silly scale"