### PR TITLE
M3796 Retrieve entities by id from backend instead of index + improvements

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppConfig.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppConfig.java
@@ -22,6 +22,7 @@ import org.molgenis.dataexplorer.freemarker.DataExplorerHyperlinkDirective;
 import org.molgenis.migrate.version.v1_10.Step17RuntimePropertiesToGafListSettings;
 import org.molgenis.migrate.version.v1_10.Step18RuntimePropertiesToAnnotatorSettings;
 import org.molgenis.migrate.version.v1_10.Step19RemoveMolgenisLock;
+import org.molgenis.migrate.version.v1_11.Step20RebuildElasticsearchIndex;
 import org.molgenis.migrate.version.v1_5.Step1UpgradeMetaData;
 import org.molgenis.migrate.version.v1_5.Step2;
 import org.molgenis.migrate.version.v1_5.Step3AddOrderColumnToMrefTables;
@@ -70,7 +71,7 @@ import freemarker.template.TemplateException;
 @EnableTransactionManagement
 @EnableWebMvc
 @EnableAsync
-@ComponentScan(basePackages = "org.molgenis", excludeFilters = @Filter(type = FilterType.ANNOTATION, value = CommandLineOnlyConfiguration.class))
+@ComponentScan(basePackages = "org.molgenis", excludeFilters = @Filter(type = FilterType.ANNOTATION, value = CommandLineOnlyConfiguration.class) )
 @Import(
 { WebAppSecurityConfig.class, DatabaseConfig.class, EmbeddedElasticSearchConfig.class })
 public class WebAppConfig extends MolgenisWebAppConfig
@@ -117,6 +118,9 @@ public class WebAppConfig extends MolgenisWebAppConfig
 	@Autowired
 	private Step19RemoveMolgenisLock step19RemoveMolgenisLock;
 
+	@Autowired
+	private Step20RebuildElasticsearchIndex step20RebuildElasticsearchIndex;
+
 	@Override
 	public ManageableRepositoryCollection getBackend()
 	{
@@ -130,8 +134,8 @@ public class WebAppConfig extends MolgenisWebAppConfig
 		upgradeService.addUpgrade(new Step2(dataService, jpaRepositoryCollection, dataSource, searchService));
 		upgradeService.addUpgrade(new Step3AddOrderColumnToMrefTables(dataSource));
 		upgradeService.addUpgrade(new Step4VarcharToText(dataSource, mysqlRepositoryCollection));
-		upgradeService.addUpgrade(new Step5AlterDataexplorerMenuURLs(jpaRepositoryCollection
-				.getRepository("RuntimeProperty")));
+		upgradeService.addUpgrade(
+				new Step5AlterDataexplorerMenuURLs(jpaRepositoryCollection.getRepository("RuntimeProperty")));
 		upgradeService.addUpgrade(new Step6ChangeRScriptType(dataSource, searchService));
 		upgradeService.addUpgrade(new Step7UpgradeMetaDataTo1_6(dataSource, searchService));
 		upgradeService.addUpgrade(new Step8VarcharToTextRepeated(dataSource));
@@ -159,6 +163,7 @@ public class WebAppConfig extends MolgenisWebAppConfig
 		upgradeService.addUpgrade(step17RuntimePropertiesToGafListSettings);
 		upgradeService.addUpgrade(step18RuntimePropertiesToAnnotatorSettings);
 		upgradeService.addUpgrade(step19RemoveMolgenisLock);
+		upgradeService.addUpgrade(step20RebuildElasticsearchIndex);
 	}
 
 	@Override
@@ -170,8 +175,8 @@ public class WebAppConfig extends MolgenisWebAppConfig
 			@Override
 			protected MysqlRepository createMysqlRepository()
 			{
-				return new MysqlRepository(localDataService, dataSource, new AsyncJdbcTemplate(new JdbcTemplate(
-						dataSource)));
+				return new MysqlRepository(localDataService, dataSource,
+						new AsyncJdbcTemplate(new JdbcTemplate(dataSource)));
 			}
 
 			@Override
@@ -183,8 +188,8 @@ public class WebAppConfig extends MolgenisWebAppConfig
 
 		// metadata repositories get created here.
 		localDataService.getMeta().setDefaultBackend(backend);
-		List<EntityMetaData> metas = DependencyResolver.resolve(Sets.newHashSet(localDataService.getMeta()
-				.getEntityMetaDatas()));
+		List<EntityMetaData> metas = DependencyResolver
+				.resolve(Sets.newHashSet(localDataService.getMeta().getEntityMetaDatas()));
 
 		for (EntityMetaData emd : metas)
 		{
@@ -209,8 +214,8 @@ public class WebAppConfig extends MolgenisWebAppConfig
 	@Override
 	protected void addFreemarkerVariables(Map<String, Object> freemarkerVariables)
 	{
-		freemarkerVariables.put("dataExplorerLink", new DataExplorerHyperlinkDirective(molgenisPluginRegistry(),
-				dataService));
+		freemarkerVariables.put("dataExplorerLink",
+				new DataExplorerHyperlinkDirective(molgenisPluginRegistry(), dataService));
 	}
 
 	@Override

--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/MolgenisWebAppConfig.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/MolgenisWebAppConfig.java
@@ -411,6 +411,8 @@ public abstract class MolgenisWebAppConfig extends WebMvcConfigurerAdapter
 		repos.forEach(repo -> {
 			localSearchService.rebuildIndex(repo, repo.getEntityMetaData());
 		});
+
+		localSearchService.optimizeIndex();
 	}
 
 	@PostConstruct

--- a/molgenis-data-elasticsearch/pom.xml
+++ b/molgenis-data-elasticsearch/pom.xml
@@ -26,7 +26,7 @@
         <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.4.4</version>
+            <version>1.7.2</version>
         </dependency>
 	</dependencies>
 </project>

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/AbstractElasticsearchRepository.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/AbstractElasticsearchRepository.java
@@ -10,7 +10,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.IndexedRepository;
 import org.molgenis.data.Query;
-import org.molgenis.data.elasticsearch.ElasticSearchService.IndexingMode;
+import org.molgenis.data.elasticsearch.ElasticsearchService.IndexingMode;
 import org.molgenis.data.elasticsearch.util.ElasticsearchEntityUtils;
 import org.molgenis.data.support.QueryImpl;
 import org.springframework.transaction.annotation.Transactional;

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
@@ -64,6 +64,7 @@ import org.molgenis.data.elasticsearch.util.SearchResult;
 import org.molgenis.data.meta.AttributeMetaDataMetaData;
 import org.molgenis.data.meta.EntityMetaDataMetaData;
 import org.molgenis.data.support.DefaultEntity;
+import org.molgenis.data.support.MapEntity;
 import org.molgenis.data.support.QueryImpl;
 import org.molgenis.data.transaction.MolgenisTransactionListener;
 import org.molgenis.data.transaction.MolgenisTransactionLogEntryMetaData;
@@ -438,7 +439,11 @@ public class ElasticsearchService implements SearchService, MolgenisTransactionL
 		{
 			if (transactionId != null)
 			{
-				createMappings(transactionId, entityMetaData);
+				// store entities in the index related to this transaction even if the entity should not be stored in
+				// the index, after transaction commit the transaction index is merged with the main index. Based on the
+				// main index mapping the data is (not) stored. The transaction index is removed after transaction
+				// commit or rollback.
+				createMappings(transactionId, entityMetaData, true, true, true);
 			}
 
 			for (Entity entity : entities)
@@ -512,7 +517,8 @@ public class ElasticsearchService implements SearchService, MolgenisTransactionL
 			if (response.isExists())
 			{
 				// Copy to temp transaction index and mark as deleted
-				Entity entity = get(id, entityMetaData);
+				Entity entity = new MapEntity(entityMetaData);
+				entity.set(entityMetaData.getIdAttribute().getName(), id);
 				index(transactionId, Arrays.asList(entity), entityMetaData, CrudType.DELETE, false);
 			}
 			else
@@ -622,6 +628,9 @@ public class ElasticsearchService implements SearchService, MolgenisTransactionL
 		refresh();
 	}
 
+	/**
+	 * Retrieve a stored entity from the index. Can only be used if the mapping was created with storeSource=true.
+	 */
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -667,6 +676,9 @@ public class ElasticsearchService implements SearchService, MolgenisTransactionL
 		}
 	}
 
+	/**
+	 * Retrieve stored entities from the index. Can only be used if the mapping was created with storeSource=true.
+	 */
 	/*
 	 * (non-Javadoc)
 	 * 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticSearchService.java
@@ -1,10 +1,7 @@
 package org.molgenis.data.elasticsearch;
 
+import static java.util.Objects.requireNonNull;
 import static java.util.stream.StreamSupport.stream;
-import static org.elasticsearch.index.query.FilterBuilders.queryFilter;
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.indicesQuery;
-import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.molgenis.data.elasticsearch.util.ElasticsearchEntityUtils.toElasticsearchId;
 import static org.molgenis.data.elasticsearch.util.ElasticsearchEntityUtils.toElasticsearchIds;
 import static org.molgenis.data.elasticsearch.util.MapperTypeSanitizer.sanitizeMapperType;
@@ -25,6 +22,7 @@ import org.elasticsearch.action.admin.indices.exists.types.TypesExistsResponse;
 import org.elasticsearch.action.admin.indices.mapping.delete.DeleteMappingResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsResponse;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.action.admin.indices.optimize.OptimizeResponse;
 import org.elasticsearch.action.bulk.BulkProcessor;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
@@ -38,17 +36,14 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchType;
-import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchHit;
-import org.elasticsearch.search.SearchHits;
 import org.molgenis.data.AggregateQuery;
 import org.molgenis.data.AggregateResult;
 import org.molgenis.data.AttributeMetaData;
@@ -89,9 +84,10 @@ import com.google.common.collect.Iterables;
  * 
  * @author erwin
  */
-public class ElasticSearchService implements SearchService, MolgenisTransactionListener
+public class ElasticsearchService implements SearchService, MolgenisTransactionListener
 {
-	private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchService.class);
+	private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchService.class);
+
 	public static final String CRUD_TYPE_FIELD_NAME = "MolgenisCrudType";
 	private static BulkProcessorFactory BULK_PROCESSOR_FACTORY = new BulkProcessorFactory();
 	private static List<String> NON_TRANSACTIONAL_ENTITIES = Arrays.asList(MolgenisTransactionLogMetaData.ENTITY_NAME,
@@ -115,7 +111,7 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 	private final EntityToSourceConverter entityToSourceConverter;
 	private final ElasticsearchUtils elasticsearchUtils;
 
-	public ElasticSearchService(Client client, String indexName, DataService dataService,
+	public ElasticsearchService(Client client, String indexName, DataService dataService,
 			EntityToSourceConverter entityToSourceConverter)
 	{
 		this(client, indexName, dataService, entityToSourceConverter, true);
@@ -130,17 +126,13 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 	 * @param entityToSourceConverter
 	 * @param createIndexIfNotExists
 	 */
-	ElasticSearchService(Client client, String indexName, DataService dataService,
+	ElasticsearchService(Client client, String indexName, DataService dataService,
 			EntityToSourceConverter entityToSourceConverter, boolean createIndexIfNotExists)
 	{
-		if (client == null) throw new IllegalArgumentException("Client is null");
-		if (indexName == null) throw new IllegalArgumentException("IndexName is null");
-		if (dataService == null) throw new IllegalArgumentException("DataService is null");
-		if (entityToSourceConverter == null) throw new IllegalArgumentException("EntityToSourceConverter is null");
-		this.indexName = indexName;
-		this.client = client;
-		this.dataService = dataService;
-		this.entityToSourceConverter = entityToSourceConverter;
+		this.client = requireNonNull(client);
+		this.indexName = requireNonNull(indexName);
+		this.dataService = requireNonNull(dataService);
+		this.entityToSourceConverter = requireNonNull(entityToSourceConverter);
 		this.elasticsearchUtils = new ElasticsearchUtils(client);
 
 		if (createIndexIfNotExists)
@@ -194,16 +186,17 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 		// ElasticSearchService, because ElasticSearchService should not be
 		// aware of DataService. E.g. Put EntityMetaData in the SearchRequest
 		// object
-		EntityMetaData entityMetaData = (request.getDocumentType() != null && dataService != null && dataService
-				.hasRepository(request.getDocumentType())) ? dataService.getEntityMetaData(request.getDocumentType()) : null;
+		EntityMetaData entityMetaData = (request.getDocumentType() != null && dataService != null
+				&& dataService.hasRepository(request.getDocumentType()))
+						? dataService.getEntityMetaData(request.getDocumentType()) : null;
 		String documentType = request.getDocumentType() == null ? null : sanitizeMapperType(request.getDocumentType());
 		if (LOG.isTraceEnabled())
 		{
 			LOG.trace("*** REQUEST\n" + builder);
 		}
-		generator.buildSearchRequest(builder, documentType, searchType, request.getQuery(),
-				request.getFieldsToReturn(), request.getAggregateField1(), request.getAggregateField2(),
-				request.getAggregateFieldDistinct(), entityMetaData);
+		generator.buildSearchRequest(builder, documentType, searchType, request.getQuery(), request.getFieldsToReturn(),
+				request.getAggregateField1(), request.getAggregateField2(), request.getAggregateFieldDistinct(),
+				entityMetaData);
 		SearchResponse response = builder.execute().actionGet();
 		if (LOG.isTraceEnabled())
 		{
@@ -250,12 +243,14 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 	@Override
 	public void createMappings(EntityMetaData entityMetaData)
 	{
-		createMappings(entityMetaData, true, true, true);
+		boolean storeSource = storeSource(entityMetaData);
+		createMappings(entityMetaData, storeSource, true, true);
 	}
 
 	public void createMappings(String index, EntityMetaData entityMetaData)
 	{
-		createMappings(index, entityMetaData, true, true, true);
+		boolean storeSource = storeSource(entityMetaData);
+		createMappings(index, entityMetaData, storeSource, true, true);
 	}
 
 	private void createMappings(String index, EntityMetaData entityMetaData, boolean storeSource, boolean enableNorms,
@@ -273,8 +268,8 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 
 			if (!response.isAcknowledged())
 			{
-				throw new ElasticsearchException("Creation of mapping for documentType [" + entityName
-						+ "] failed. Response=" + response);
+				throw new ElasticsearchException(
+						"Creation of mapping for documentType [" + entityName + "] failed. Response=" + response);
 			}
 
 			if (LOG.isDebugEnabled()) LOG.debug("Created Elasticsearch mapping [" + jsonBuilder.string() + "]");
@@ -714,13 +709,12 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 					throw new ElasticsearchException("Search failed. Returned headers:" + itemResponse.getFailure());
 				}
 				GetResponse getResponse = itemResponse.getResponse();
-				return getResponse.isExists() ? new DefaultEntity(entityMetaData, dataService, getResponse.getSource()) : null;
+				return getResponse.isExists() ? new DefaultEntity(entityMetaData, dataService, getResponse.getSource())
+						: null;
 			}
 		});
 	}
 
-	// TODO replace Iterable<Entity> with EntityCollection and add
-	// EntityCollection.getTotal()
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -823,10 +817,23 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 		}
 	}
 
+	@Override
+	public void optimizeIndex()
+	{
+		LOG.trace("Optimizing Elasticsearch index [{}] ...", indexName);
+		// setMaxNumSegments(1) fully optimizes the index
+		OptimizeResponse response = client.admin().indices().prepareOptimize(indexName).setMaxNumSegments(1).get();
+		if (response.getFailedShards() > 0)
+		{
+			throw new ElasticsearchException("Optimize failed. Returned headers:" + response.getHeaders());
+		}
+		LOG.debug("Optimized Elasticsearch index [{}]", indexName);
+	}
+
 	private void updateReferences(Entity refEntity, EntityMetaData refEntityMetaData)
 	{
-		for (Pair<EntityMetaData, List<AttributeMetaData>> pair : EntityUtils.getReferencingEntityMetaData(
-				refEntityMetaData, dataService))
+		for (Pair<EntityMetaData, List<AttributeMetaData>> pair : EntityUtils
+				.getReferencingEntityMetaData(refEntityMetaData, dataService))
 		{
 			EntityMetaData entityMetaData = pair.getA();
 
@@ -840,7 +847,7 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 
 			Iterable<Entity> entities = new ElasticsearchEntityIterable(q, entityMetaData, client, dataService,
 					generator, new String[]
-					{ indexName });
+			{ indexName });
 
 			// Don't use cached ref entities but make new ones
 			entities = Iterables.transform(entities, new Function<Entity, Entity>()
@@ -941,169 +948,6 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 		return true;
 	}
 
-	/**
-	 * Retrieve search results in batches. Note: We do not use Elasticsearch scan & scroll, because scrolling is not
-	 * intended for real time user request: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current
-	 * /search-request-scroll.html
-	 */
-	private static class ElasticsearchEntityIterable implements Iterable<Entity>
-	{
-		private static final int BATCH_SIZE = 1000;
-
-		private final Query q;
-		private final EntityMetaData entityMetaData;
-		private final Client client;
-		private final DataService dataService;;
-		private final SearchRequestGenerator searchRequestGenerator;
-		private final String[] indexNames;
-
-		private final String type;
-		private final List<String> fieldsToReturn;
-		private final int offset;
-		private final int pageSize;
-
-		public ElasticsearchEntityIterable(Query q, EntityMetaData entityMetaData, Client client,
-				DataService dataService, SearchRequestGenerator searchRequestGenerator, String[] indexNames)
-		{
-			this.client = client;
-			this.q = q;
-			this.entityMetaData = entityMetaData;
-			this.dataService = dataService;
-			this.searchRequestGenerator = searchRequestGenerator;
-			this.indexNames = indexNames;
-
-			this.type = sanitizeMapperType(entityMetaData.getName());
-			this.fieldsToReturn = Collections.<String> emptyList();
-			this.offset = q.getOffset();
-			this.pageSize = q.getPageSize();
-		}
-
-		@Override
-		public Iterator<Entity> iterator()
-		{
-			return new Iterator<Entity>()
-			{
-				private long totalHits;
-				private SearchHit[] batchHits;
-				private int batchPos;
-
-				private int currentOffset;
-
-				@Override
-				public boolean hasNext()
-				{
-					if (batchHits == null)
-					{
-						int batchOffset = offset;
-						int batchSize = pageSize != 0 ? Math.min(pageSize - currentOffset, BATCH_SIZE) : BATCH_SIZE;
-						doBatchSearch(batchOffset, batchSize);
-					}
-
-					if (batchHits.length == 0)
-					{
-						return false;
-					}
-
-					if (batchPos < batchHits.length)
-					{
-						return true;
-					}
-					else if (batchPos == batchHits.length)
-					{
-						long requestedHits = pageSize != 0 ? Math.min(pageSize, totalHits) : totalHits;
-						if (currentOffset + batchHits.length < requestedHits)
-						{
-							int batchOffset = currentOffset + BATCH_SIZE;
-							int batchSize = pageSize != 0 ? Math.min(pageSize - batchOffset, BATCH_SIZE) : BATCH_SIZE;
-							doBatchSearch(batchOffset, batchSize);
-
-							return batchHits.length > 0;
-						}
-						else
-						{
-							return false;
-						}
-					}
-					else throw new RuntimeException();
-				}
-
-				@Override
-				public Entity next()
-				{
-					boolean next = hasNext();
-					if (next)
-					{
-						SearchHit hit = batchHits[batchPos];
-						++batchPos;
-						return new DefaultEntity(entityMetaData, dataService, hit.getSource());
-					}
-					else throw new ArrayIndexOutOfBoundsException();
-				}
-
-				private void doBatchSearch(int from, int size)
-				{
-					q.offset(from);
-					q.pageSize(size);
-
-					if (LOG.isTraceEnabled())
-					{
-						LOG.trace("Searching Elasticsearch '" + type + "' docs using query [" + q + "] ...");
-					}
-
-					SearchRequestBuilder searchRequestBuilder = client.prepareSearch(indexNames);
-					searchRequestGenerator.buildSearchRequest(searchRequestBuilder, type, SearchType.QUERY_AND_FETCH,
-							q, fieldsToReturn, null, null, null, entityMetaData);
-
-					// We are in a transaction, the first index is the status before the transaction started, the second
-					// index the status within the transaction. We don't want to return the deleted records and of the
-					// updated records we want the latest version (that of the transaction)
-					if (indexNames.length > 1)
-					{
-						QueryBuilder findUpdatesQuery = indicesQuery(
-								termQuery(CRUD_TYPE_FIELD_NAME, CrudType.UPDATE.name()), indexNames[1]);
-
-						// Exclude the updated records from the first index
-						QueryBuilder excludeUpdatesQuery = indicesQuery(boolQuery().mustNot(findUpdatesQuery),
-								indexNames[0]);
-
-						// NOTE: deletes cannot be handled by ES in this way, so if you do a delete then the entity will
-						// still be returned. Only after the commit of the transaction the queries won't return the
-						// entity anymore
-
-						searchRequestBuilder.setPostFilter(queryFilter(excludeUpdatesQuery));
-					}
-
-					if (LOG.isTraceEnabled())
-					{
-						LOG.trace("SearchRequest: " + searchRequestBuilder);
-					}
-					SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();
-
-					if (searchResponse.getFailedShards() > 0)
-					{
-						StringBuilder sb = new StringBuilder("Search failed.");
-						for (ShardSearchFailure failure : searchResponse.getShardFailures())
-						{
-							sb.append("\n").append(failure.reason());
-						}
-						throw new ElasticsearchException(sb.toString());
-					}
-					if (LOG.isDebugEnabled())
-					{
-						LOG.debug("Searched Elasticsearch '" + type + "' docs using query [" + q + "] in "
-								+ searchResponse.getTookInMillis() + "ms");
-					}
-					SearchHits searchHits = searchResponse.getHits();
-					this.totalHits = searchHits.getTotalHits();
-					this.batchHits = searchHits.getHits();
-					this.batchPos = 0;
-
-					this.currentOffset = from;
-				}
-			};
-		}
-	}
-
 	@Override
 	public void transactionStarted(String transactionId)
 	{
@@ -1179,4 +1023,14 @@ public class ElasticSearchService implements SearchService, MolgenisTransactionL
 		flush();
 	}
 
+	/**
+	 * Entities are stored (in addition to indexed) in Elasticsearch only if the entity backend is Elasticsearch
+	 * 
+	 * @param entityMeta
+	 * @return whether or not this entity class is stored in Elasticsearch
+	 */
+	private boolean storeSource(EntityMetaData entityMeta)
+	{
+		return ElasticsearchRepositoryCollection.NAME.equals(entityMeta.getBackend());
+	}
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchEntityIterable.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchEntityIterable.java
@@ -195,7 +195,6 @@ class ElasticsearchEntityIterable implements Iterable<Entity>
 				{
 					List<Object> entityIds = Arrays.stream(batchHits).map(SearchHit::getId)
 							.collect(Collectors.toList());
-					System.out.println(entityIds);
 					this.batchEntities = Lists.newArrayList(dataService.findAll(entityMeta.getName(), entityIds));
 				}
 				else

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchEntityIterable.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchEntityIterable.java
@@ -1,0 +1,211 @@
+package org.molgenis.data.elasticsearch;
+
+import static java.util.Objects.requireNonNull;
+import static org.elasticsearch.index.query.FilterBuilders.queryFilter;
+import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
+import static org.elasticsearch.index.query.QueryBuilders.indicesQuery;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.molgenis.data.elasticsearch.util.MapperTypeSanitizer.sanitizeMapperType;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.search.SearchRequestBuilder;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.SearchType;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.SearchHits;
+import org.molgenis.data.DataService;
+import org.molgenis.data.Entity;
+import org.molgenis.data.EntityMetaData;
+import org.molgenis.data.Query;
+import org.molgenis.data.elasticsearch.ElasticsearchService.CrudType;
+import org.molgenis.data.elasticsearch.request.SearchRequestGenerator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Retrieve search results in batches. Note: We do not use Elasticsearch scan & scroll, because scrolling is not
+ * intended for real time user request: http://www.elasticsearch.org/guide/en/elasticsearch/reference/current
+ * /search-request-scroll.html
+ */
+class ElasticsearchEntityIterable implements Iterable<Entity>
+{
+	private static final Logger LOG = LoggerFactory.getLogger(ElasticsearchEntityIterable.class);
+
+	private static final int BATCH_SIZE = 1000;
+
+	private final Query q;
+	private final EntityMetaData entityMeta;
+	private final Client client;
+	private final DataService dataService;;
+	private final SearchRequestGenerator searchRequestGenerator;
+	private final String[] indexNames;
+
+	private final String type;
+	private final List<String> fieldsToReturn;
+	private final int offset;
+	private final int pageSize;
+
+	public ElasticsearchEntityIterable(Query q, EntityMetaData entityMetaData, Client client, DataService dataService,
+			SearchRequestGenerator searchRequestGenerator, String[] indexNames)
+	{
+		this.q = requireNonNull(q);
+		this.entityMeta = requireNonNull(entityMetaData);
+		this.client = requireNonNull(client);
+		this.dataService = requireNonNull(dataService);
+		this.searchRequestGenerator = requireNonNull(searchRequestGenerator);
+		this.indexNames = requireNonNull(indexNames);
+
+		this.type = sanitizeMapperType(entityMetaData.getName());
+		this.fieldsToReturn = Collections.<String> emptyList();
+		this.offset = q.getOffset();
+		this.pageSize = q.getPageSize();
+	}
+
+	@Override
+	public Iterator<Entity> iterator()
+	{
+		return new Iterator<Entity>()
+		{
+			private long totalHits;
+			private List<Entity> batchEntities;
+			private int batchPos;
+
+			private int currentOffset;
+
+			@Override
+			public boolean hasNext()
+			{
+				if (batchEntities == null)
+				{
+					int batchOffset = offset;
+					int batchSize = pageSize != 0 ? Math.min(pageSize - currentOffset, BATCH_SIZE) : BATCH_SIZE;
+					doBatchSearch(batchOffset, batchSize);
+				}
+
+				if (batchEntities.isEmpty())
+				{
+					return false;
+				}
+
+				if (batchPos < batchEntities.size())
+				{
+					return true;
+				}
+				else if (batchPos == batchEntities.size())
+				{
+					long requestedHits = pageSize != 0 ? Math.min(pageSize, totalHits) : totalHits;
+					if (currentOffset + batchEntities.size() < requestedHits)
+					{
+						int batchOffset = currentOffset + BATCH_SIZE;
+						int batchSize = pageSize != 0 ? Math.min(pageSize - batchOffset, BATCH_SIZE) : BATCH_SIZE;
+						doBatchSearch(batchOffset, batchSize);
+
+						return !batchEntities.isEmpty();
+					}
+					else
+					{
+						return false;
+					}
+				}
+				else throw new RuntimeException();
+			}
+
+			@Override
+			public Entity next()
+			{
+				boolean next = hasNext();
+				if (next)
+				{
+					Entity entity = batchEntities.get(batchPos);
+					++batchPos;
+					return entity;
+				}
+				else throw new ArrayIndexOutOfBoundsException();
+			}
+
+			private void doBatchSearch(int from, int size)
+			{
+				q.offset(from);
+				q.pageSize(size);
+
+				if (LOG.isTraceEnabled())
+				{
+					LOG.trace("Searching Elasticsearch '" + type + "' docs using query [" + q + "] ...");
+				}
+
+				SearchRequestBuilder searchRequestBuilder = client.prepareSearch(indexNames);
+				searchRequestGenerator.buildSearchRequest(searchRequestBuilder, type, SearchType.QUERY_AND_FETCH, q,
+						fieldsToReturn, null, null, null, entityMeta);
+
+				// We are in a transaction, the first index is the status before the transaction started, the second
+				// index the status within the transaction. We don't want to return the deleted records and of the
+				// updated records we want the latest version (that of the transaction)
+				if (indexNames.length > 1)
+				{
+					QueryBuilder findUpdatesQuery = indicesQuery(
+							termQuery(ElasticsearchService.CRUD_TYPE_FIELD_NAME, CrudType.UPDATE.name()),
+							indexNames[1]);
+
+					// Exclude the updated records from the first index
+					QueryBuilder excludeUpdatesQuery = indicesQuery(boolQuery().mustNot(findUpdatesQuery),
+							indexNames[0]);
+
+					// NOTE: deletes cannot be handled by ES in this way, so if you do a delete then the entity will
+					// still be returned. Only after the commit of the transaction the queries won't return the
+					// entity anymore
+
+					searchRequestBuilder.setPostFilter(queryFilter(excludeUpdatesQuery));
+				}
+
+				if (LOG.isTraceEnabled())
+				{
+					LOG.trace("SearchRequest: " + searchRequestBuilder);
+				}
+				SearchResponse searchResponse = searchRequestBuilder.execute().actionGet();
+
+				if (searchResponse.getFailedShards() > 0)
+				{
+					StringBuilder sb = new StringBuilder("Search failed.");
+					for (ShardSearchFailure failure : searchResponse.getShardFailures())
+					{
+						sb.append("\n").append(failure.reason());
+					}
+					throw new ElasticsearchException(sb.toString());
+				}
+				if (LOG.isDebugEnabled())
+				{
+					LOG.debug("Searched Elasticsearch '" + type + "' docs using query [" + q + "] in "
+							+ searchResponse.getTookInMillis() + "ms");
+				}
+				SearchHits searchHits = searchResponse.getHits();
+				this.totalHits = searchHits.getTotalHits();
+				SearchHit[] batchHits = searchHits.getHits();
+				if (batchHits.length > 0)
+				{
+					List<Object> entityIds = Arrays.stream(batchHits).map(SearchHit::getId)
+							.collect(Collectors.toList());
+					System.out.println(entityIds);
+					this.batchEntities = Lists.newArrayList(dataService.findAll(entityMeta.getName(), entityIds));
+				}
+				else
+				{
+					this.batchEntities = Collections.emptyList();
+				}
+				this.batchPos = 0;
+
+				this.currentOffset = from;
+			}
+		};
+	}
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecorator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecorator.java
@@ -1,5 +1,6 @@
 package org.molgenis.data.elasticsearch;
 
+import java.util.Iterator;
 import java.util.Set;
 
 import org.molgenis.data.Entity;
@@ -9,6 +10,7 @@ import org.molgenis.data.Manageable;
 import org.molgenis.data.MolgenisDataAccessException;
 import org.molgenis.data.Repository;
 import org.molgenis.data.RepositoryCapability;
+import org.molgenis.data.support.QueryImpl;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
@@ -131,6 +133,13 @@ public class ElasticsearchRepositoryDecorator extends AbstractElasticsearchRepos
 	public Iterable<Entity> findAll(Iterable<Object> ids)
 	{
 		return repository.findAll(ids);
+	}
+
+	// retrieve all entities via decorated repository
+	@Override
+	public Iterator<Entity> iterator()
+	{
+		return repository.iterator();
 	}
 
 	@Override

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecorator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecorator.java
@@ -119,6 +119,20 @@ public class ElasticsearchRepositoryDecorator extends AbstractElasticsearchRepos
 		super.deleteAll();
 	}
 
+	// retrieve entity by id via decorated repository
+	@Override
+	public Entity findOne(Object id)
+	{
+		return repository.findOne(id);
+	}
+
+	// retrieve entities by id via decorated repository
+	@Override
+	public Iterable<Entity> findAll(Iterable<Object> ids)
+	{
+		return repository.findAll(ids);
+	}
+
 	@Override
 	public void rebuildIndex()
 	{

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/SearchService.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/SearchService.java
@@ -5,7 +5,7 @@ import org.molgenis.data.AggregateResult;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.Query;
-import org.molgenis.data.elasticsearch.ElasticSearchService.IndexingMode;
+import org.molgenis.data.elasticsearch.ElasticsearchService.IndexingMode;
 import org.molgenis.data.elasticsearch.util.SearchRequest;
 import org.molgenis.data.elasticsearch.util.SearchResult;
 
@@ -29,7 +29,8 @@ public interface SearchService
 
 	void createMappings(EntityMetaData entityMetaData);
 
-	void createMappings(EntityMetaData entityMetaData, boolean storeSource, boolean enableNorms, boolean createAllIndex);
+	void createMappings(EntityMetaData entityMetaData, boolean storeSource, boolean enableNorms,
+			boolean createAllIndex);
 
 	/**
 	 * Refresh index, making all operations performed since the last refresh available for search
@@ -84,4 +85,9 @@ public interface SearchService
 	void flush();
 
 	void rebuildIndex(Iterable<? extends Entity> entities, EntityMetaData entityMetaData);
+
+	/**
+	 * Optimize the index for faster search operations, remove documents that are marked as deleted.
+	 */
+	void optimizeIndex();
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfig.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfig.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import org.elasticsearch.common.logging.ESLoggerFactory;
 import org.elasticsearch.common.logging.slf4j.Slf4jESLoggerFactory;
 import org.molgenis.data.DataService;
-import org.molgenis.data.elasticsearch.ElasticSearchService;
+import org.molgenis.data.elasticsearch.ElasticsearchService;
 import org.molgenis.data.elasticsearch.SearchService;
 import org.molgenis.data.elasticsearch.factory.EmbeddedElasticSearchServiceFactory;
 import org.molgenis.data.elasticsearch.index.EntityToSourceConverter;
@@ -68,7 +68,7 @@ public class EmbeddedElasticSearchConfig
 	@Bean
 	public SearchService searchService()
 	{
-		ElasticSearchService elasticSearchService = embeddedElasticSearchServiceFactory().create(dataService,
+		ElasticsearchService elasticSearchService = embeddedElasticSearchServiceFactory().create(dataService,
 				entityToSourceConverter);
 		molgenisTransactionManager.addTransactionListener(elasticSearchService);
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/factory/EmbeddedElasticSearchServiceFactory.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/factory/EmbeddedElasticSearchServiceFactory.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.settings.ImmutableSettings.Builder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.node.Node;
 import org.molgenis.data.DataService;
-import org.molgenis.data.elasticsearch.ElasticSearchService;
+import org.molgenis.data.elasticsearch.ElasticsearchService;
 import org.molgenis.data.elasticsearch.index.EntityToSourceConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -76,9 +76,9 @@ public class EmbeddedElasticSearchServiceFactory implements Closeable
 		LOG.info("Embedded elasticsearch server started, data path=[" + settings.get("path.data") + "]");
 	}
 
-	public ElasticSearchService create(DataService dataService, EntityToSourceConverter entityToSourceConverter)
+	public ElasticsearchService create(DataService dataService, EntityToSourceConverter entityToSourceConverter)
 	{
-		return new ElasticSearchService(client, indexName, dataService, entityToSourceConverter);
+		return new ElasticsearchService(client, indexName, dataService, entityToSourceConverter);
 	}
 
 	public Client getClient()

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/index/MappingsBuilder.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/index/MappingsBuilder.java
@@ -9,7 +9,7 @@ import org.molgenis.data.AttributeMetaData;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisDataException;
 import org.molgenis.data.Repository;
-import org.molgenis.data.elasticsearch.ElasticSearchService;
+import org.molgenis.data.elasticsearch.ElasticsearchService;
 import org.molgenis.data.elasticsearch.util.MapperTypeSanitizer;
 
 /**
@@ -85,7 +85,7 @@ public class MappingsBuilder
 
 		jsonBuilder.startObject("properties");
 
-		jsonBuilder.startObject(ElasticSearchService.CRUD_TYPE_FIELD_NAME);
+		jsonBuilder.startObject(ElasticsearchService.CRUD_TYPE_FIELD_NAME);
 		jsonBuilder.field("type", "string").field("index", "not_analyzed");
 		jsonBuilder.endObject();
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecoratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecoratorTest.java
@@ -21,7 +21,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.Query;
 import org.molgenis.data.Repository;
-import org.molgenis.data.elasticsearch.ElasticSearchService.IndexingMode;
+import org.molgenis.data.elasticsearch.ElasticsearchService.IndexingMode;
 import org.molgenis.data.support.AggregateQueryImpl;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -31,7 +31,7 @@ import com.google.common.collect.Iterables;
 public class ElasticsearchRepositoryDecoratorTest
 {
 	private ElasticsearchRepositoryDecorator elasticSearchRepository;
-	private ElasticSearchService elasticSearchService;
+	private ElasticsearchService elasticSearchService;
 	private Repository repository;
 	private EntityMetaData repositoryEntityMetaData;
 	private String entityName;
@@ -40,7 +40,7 @@ public class ElasticsearchRepositoryDecoratorTest
 	@BeforeMethod
 	public void setUp() throws IOException
 	{
-		elasticSearchService = mock(ElasticSearchService.class);
+		elasticSearchService = mock(ElasticsearchService.class);
 		repository = mock(Repository.class);
 		entityName = "";
 		repositoryEntityMetaData = mock(EntityMetaData.class);
@@ -199,7 +199,7 @@ public class ElasticsearchRepositoryDecoratorTest
 	{
 		List<Object> ids = Arrays.asList(mock(Object.class), mock(Object.class));
 		elasticSearchRepository.findAll(ids);
-		verify(elasticSearchService).get(ids, repositoryEntityMetaData);
+		verify(repository).findAll(ids);
 	}
 
 	@Test
@@ -208,8 +208,8 @@ public class ElasticsearchRepositoryDecoratorTest
 		Query q = mock(Query.class);
 		Entity entity0 = mock(Entity.class);
 		Entity entity1 = mock(Entity.class);
-		when(elasticSearchService.search(q, repositoryEntityMetaData)).thenReturn(
-				Arrays.<Entity> asList(entity0, entity1));
+		when(elasticSearchService.search(q, repositoryEntityMetaData))
+				.thenReturn(Arrays.<Entity> asList(entity0, entity1));
 		elasticSearchRepository.findOne(q);
 		verify(elasticSearchService).search(q, repositoryEntityMetaData);
 	}
@@ -228,7 +228,7 @@ public class ElasticsearchRepositoryDecoratorTest
 	{
 		Object id = mock(Object.class);
 		elasticSearchRepository.findOne(id);
-		verify(elasticSearchService).get(id, repositoryEntityMetaData);
+		verify(repository).findOne(id);
 	}
 
 	@Test

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfigTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfigTest.java
@@ -4,7 +4,7 @@ import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
-import org.molgenis.data.elasticsearch.ElasticSearchService;
+import org.molgenis.data.elasticsearch.ElasticsearchService;
 import org.molgenis.data.elasticsearch.SearchService;
 import org.molgenis.data.elasticsearch.factory.EmbeddedElasticSearchServiceFactory;
 import org.molgenis.data.elasticsearch.index.EntityToSourceConverter;
@@ -49,6 +49,6 @@ public class EmbeddedElasticSearchConfigTest
 	{
 		SearchService searchService = context.getBean(SearchService.class);
 		assertNotNull(searchService);
-		assertTrue(searchService instanceof ElasticSearchService);
+		assertTrue(searchService instanceof ElasticsearchService);
 	}
 }

--- a/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/MolgenisVersionService.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/MolgenisVersionService.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class MolgenisVersionService
 {
-	public static final int CURRENT_VERSION = 19;
+	public static final int CURRENT_VERSION = 20;
 
 	private static final Logger LOG = LoggerFactory.getLogger(MolgenisVersionService.class);
 

--- a/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/v1_11/Step20RebuildElasticsearchIndex.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/v1_11/Step20RebuildElasticsearchIndex.java
@@ -1,0 +1,22 @@
+package org.molgenis.migrate.version.v1_11;
+
+import org.molgenis.framework.MolgenisUpgrade;
+import org.springframework.stereotype.Component;
+
+/**
+ * Rebuilds Elasticsearch index due to changes in which entities are (not) stored in the Elasticsearch index
+ */
+@Component
+public class Step20RebuildElasticsearchIndex extends MolgenisUpgrade
+{
+	public Step20RebuildElasticsearchIndex()
+	{
+		super(19, 20);
+	}
+
+	@Override
+	public void upgrade()
+	{
+		// no operation, index is rebuild after migration steps have been executed
+	}
+}

--- a/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/v1_5/Step2.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/v1_5/Step2.java
@@ -24,7 +24,7 @@ import org.molgenis.data.MolgenisDataException;
 import org.molgenis.data.Range;
 import org.molgenis.data.Repository;
 import org.molgenis.data.RepositoryCollection;
-import org.molgenis.data.elasticsearch.ElasticSearchService;
+import org.molgenis.data.elasticsearch.ElasticsearchService;
 import org.molgenis.data.elasticsearch.ElasticsearchRepositoryCollection;
 import org.molgenis.data.elasticsearch.SearchService;
 import org.molgenis.data.meta.MetaDataServiceImpl;
@@ -71,7 +71,7 @@ public class Step2 extends MolgenisUpgrade
 	private final DataService dataService;
 	private final RepositoryCollection jpaBackend;
 	private final JdbcTemplate jdbcTemplate;
-	private final ElasticSearchService searchService;
+	private final ElasticsearchService searchService;
 
 	public Step2(DataService dataService, RepositoryCollection jpaBackend, DataSource dataSource,
 			SearchService searchService)
@@ -80,7 +80,7 @@ public class Step2 extends MolgenisUpgrade
 		this.dataService = dataService;
 		this.jpaBackend = jpaBackend;
 		this.jdbcTemplate = new JdbcTemplate(dataSource);
-		this.searchService = (ElasticSearchService) searchService;
+		this.searchService = (ElasticsearchService) searchService;
 	}
 
 	@Override


### PR DESCRIPTION
- Update Elasticsearch 1.4.4 to 1.7.2
- Do not store entities in Elasticsearch unless the backend is Elasticsearch
- Elasticsearch decorator retrieves entities by id from decorated repository instead of index
- Add optimizeIndex to SearchService, execute after each migration