### PR TITLE
[1.8] Fix #3869 To 1.5 does not add constraints with delete cascade

### DIFF
--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/version/v1_8/Step11cAttributeMappingAddSourceAttributeMetaDatas.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/version/v1_8/Step11cAttributeMappingAddSourceAttributeMetaDatas.java
@@ -36,5 +36,9 @@ public class Step11cAttributeMappingAddSourceAttributeMetaDatas
 				"AttributeMapping", attrId);
 
 		LOG.info("Added AttributeMapping.sourceAttributeMetaDatas");
+
+		// Injecting migration steps is not possible, after a release was performed future versions will use the next
+		// available step number. As a workaround a required step in a previous release is called from an existing step.
+		new Step11dEntitiesAttributesConstraints(dataSource).upgrade();
 	}
 }

--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/version/v1_8/Step11dEntitiesAttributesConstraints.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/version/v1_8/Step11dEntitiesAttributesConstraints.java
@@ -1,0 +1,35 @@
+package org.molgenis.data.version.v1_8;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.sql.DataSource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class Step11dEntitiesAttributesConstraints
+{
+	private static final Logger LOG = LoggerFactory.getLogger(Step11cAttributeMappingAddSourceAttributeMetaDatas.class);
+
+	private final DataSource dataSource;
+
+	public Step11dEntitiesAttributesConstraints(DataSource dataSource)
+	{
+		this.dataSource = requireNonNull(dataSource);
+	}
+
+	public void upgrade()
+	{
+		LOG.info("Updating metadata from version 11.2 to 11.3 ...");
+		JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+
+		// see https://github.com/molgenis/molgenis/issues/3869
+		jdbcTemplate.execute(
+				"ALTER TABLE entities_attributes ADD FOREIGN KEY (`fullName`) REFERENCES `entities` (`fullName`) ON DELETE CASCADE;");
+		jdbcTemplate.execute(
+				"ALTER TABLE entities_attributes ADD FOREIGN KEY (`attributes`) REFERENCES `attributes` (`identifier`) ON DELETE CASCADE;");
+
+		LOG.info("Added DELETE CASCADE foreign key constraints to entities_attributes");
+	}
+}


### PR DESCRIPTION
Step is added to 1.8 instead of 1.5 since delete cascade foreign keys cannot be used with MyISAM tables. All tables in 1.8 are guaranteed to be InnoDb tables.