### PR TITLE
Fix 3637 Clicking the 'map'-tab gives an error when no xref...

### DIFF
--- a/molgenis-data-mapper/src/main/resources/js/attribute-mapping.js
+++ b/molgenis-data-mapper/src/main/resources/js/attribute-mapping.js
@@ -232,10 +232,7 @@
 			$(this).prop('checked', inArray >= 0);
 		});
 		
-		// Hide the map tab when no attributes are selected
-		if (sourceAttrs.length < 1) {
-			$('#map-tab').hide();
-		}
+		$('#attribute-mapping-table :checkbox').change();
 	}
 
 	/**
@@ -410,11 +407,12 @@
 				highlightActiveLine : true
 			});
 			
-			$textarea.data('ace').editor.getSession().on('change', function(object) {		
-				
+			$textarea.data('ace').editor.getSession().on('change', function(object) {
 				var algorithm = $textarea.data('ace').editor.getSession().getValue();
-					// check attributes if manually added
+				
+				// check attributes if manually added
 				checkSelectedAttributes(algorithm);
+				
 				// update save buttons visibility
 				disableEnableSaveButtons(algorithm);
 				


### PR DESCRIPTION
Fix after reopened: Clicking the 'map'-tab gives an error when no xref attribute has been selected yet #3637