### PR TITLE
[master] Fix #3897 REST API entity create NPE

### DIFF
--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityCollectionBatchRequestV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityCollectionBatchRequestV2.java
@@ -15,6 +15,6 @@ import com.google.auto.value.AutoValue;
 public abstract class EntityCollectionBatchRequestV2
 {
 	@NotEmpty(message = "Please provide at least one entity in the entities property.")
-	@Size(min = 1, max = RestControllerV2.MAX_ENTITIES, message = "Number of entities must be between {min} and {max}.")
+	@Size(max = RestControllerV2.MAX_ENTITIES, message = "Number of entities cannot be more than {max}.")
 	public abstract List<Map<String, Object>> getEntities();
 }

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/RestControllerV2Test.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/RestControllerV2Test.java
@@ -423,7 +423,7 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 	public void testCreateEntitiesExceptions2() throws Exception
 	{
 		this.testCreateEntitiesExceptions("entity", this.createMaxPlusOneEntitiesAsTestContent(),
-				"Number of entities must be between 1 and 1000.");
+				"Number of entities cannot be more than 1000.");
 	}
 
 	/**
@@ -519,7 +519,7 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 	public void testUpdateEntitiesExceptions2() throws Exception
 	{
 		this.testUpdateEntitiesExceptions("entity", this.createMaxPlusOneEntitiesAsTestContent(),
-				"Number of entities must be between 1 and 1000.");
+				"Number of entities cannot be more than 1000.");
 	}
 
 	/**
@@ -570,7 +570,7 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 	public void testUpdateEntitiesSpecificAttributeExceptions2() throws Exception
 	{
 		this.testUpdateEntitiesSpecificAttributeExceptions("entity", "email",
-				this.createMaxPlusOneEntitiesAsTestContent(), "Number of entities must be between 1 and 1000.");
+				this.createMaxPlusOneEntitiesAsTestContent(), "Number of entities cannot be more than 1000.");
 	}
 
 	/**


### PR DESCRIPTION
 Don't have two checks for the same case where entities is empty.