### PR TITLE
[1.11] Fix #3897. REST API entity create NPE

### DIFF
--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityCollectionBatchRequestV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityCollectionBatchRequestV2.java
@@ -17,4 +17,15 @@ public abstract class EntityCollectionBatchRequestV2
 	@NotEmpty(message = "Please provide at least one entity in the entities property.")
 	@Size(max = RestControllerV2.MAX_ENTITIES, message = "Number of entities cannot be more than {max}.")
 	public abstract List<Map<String, Object>> getEntities();
+
+	@Override
+	public int hashCode()
+	{
+		// See #3897. If hashCode fails, the validation throws an exception
+		if (getEntities() == null)
+		{
+			return 0;
+		}
+		return super.hashCode();
+	}
 }


### PR DESCRIPTION
Override generated hashCode so that it won't fail if entities is missing.