### PR TITLE
[google friday] Create link from genomebrowser popup to entityreport.

### DIFF
--- a/molgenis-das/src/main/java/org/molgenis/das/impl/RepositoryRangeHandlingDataSource.java
+++ b/molgenis-das/src/main/java/org/molgenis/das/impl/RepositoryRangeHandlingDataSource.java
@@ -66,12 +66,10 @@ public class RepositoryRangeHandlingDataSource extends RangeHandlingDataSource
 
 		String posAttribute = null;
 		String chromosomeAttribute = null;
-		String idAttribute = null;
 		String stopAttribute = null;
 		String refAttribute = null;
 		String altAttribute = null;
 		String descriptionAttribute = null;
-		String nameAttribute = null;
 		String linkAttribute = null;
 		String patientAttribute = null;
 
@@ -100,8 +98,6 @@ public class RepositoryRangeHandlingDataSource extends RangeHandlingDataSource
 			Integer valueStart = null;
 			Integer valueStop = null;
 			String valueDescription = null;
-			String valueIdentifier = null;
-			String valueName = null;
 			String valueLink = null;
 			String valuePatient = null;
 			String valueRef = null;
@@ -109,21 +105,17 @@ public class RepositoryRangeHandlingDataSource extends RangeHandlingDataSource
 
 			posAttribute = getAttributeName(posAttribute, GenomicDataSettings.Meta.ATTRS_POS, entity);
 			chromosomeAttribute = getAttributeName(chromosomeAttribute, GenomicDataSettings.Meta.ATTRS_CHROM, entity);
-			idAttribute = getAttributeName(idAttribute, GenomicDataSettings.Meta.ATTRS_IDENTIFIER, entity);
 			stopAttribute = getAttributeName(stopAttribute, GenomicDataSettings.Meta.ATTRS_STOP, entity);
 			descriptionAttribute = getAttributeName(descriptionAttribute, GenomicDataSettings.Meta.ATTRS_DESCRIPTION,
 					entity);
 			refAttribute = getAttributeName(refAttribute, GenomicDataSettings.Meta.ATTRS_REF, entity);
 			altAttribute = getAttributeName(altAttribute, GenomicDataSettings.Meta.ATTRS_ALT, entity);
-			nameAttribute = getAttributeName(nameAttribute, GenomicDataSettings.Meta.ATTRS_NAME, entity);
 			linkAttribute = getAttributeName(linkAttribute, GenomicDataSettings.Meta.ATTRS_LINKOUT, entity);
 			patientAttribute = getAttributeName(patientAttribute, GenomicDataSettings.Meta.ATTRS_PATIENT_ID, entity);
 
 			try
 			{
 				valueStart = entity.getInt(posAttribute);
-				valueIdentifier = StringUtils.isNotEmpty(idAttribute)
-						&& StringUtils.isNotEmpty(entity.getString(idAttribute)) ? entity.getString(idAttribute) : "-";
 			}
 			catch (ClassCastException e)
 			{
@@ -136,7 +128,6 @@ public class RepositoryRangeHandlingDataSource extends RangeHandlingDataSource
 			valueStop = Iterables.contains(attributes, stopAttribute) ? entity.getInt(stopAttribute) : valueStart;
 			valueDescription = Iterables.contains(attributes, descriptionAttribute)
 					? entity.getString(descriptionAttribute) : "";
-			valueName = Iterables.contains(attributes, nameAttribute) ? entity.getString(nameAttribute) : "";
 			valueLink = Iterables.contains(attributes, linkAttribute) ? entity.getString(linkAttribute) : "";
 			valuePatient = Iterables.contains(attributes, patientAttribute) ? entity.getString(patientAttribute) : "";
 
@@ -181,7 +172,7 @@ public class RepositoryRangeHandlingDataSource extends RangeHandlingDataSource
 					++score;
 				}
 
-				feature = createDasFeature(valueStart, valueStop, valueIdentifier, valueName, valueDescription,
+				feature = createDasFeature(valueStart, valueStop, entity.getIdValue().toString(), entity.getLabelValue(), valueDescription,
 						valueLink, type, method, dataSet, valuePatient, notes);
 				features.add(feature);
 			}

--- a/molgenis-das/src/test/java/org/molgenis/das/impl/RepositoryRangeHandlingDataSourceTest.java
+++ b/molgenis-das/src/test/java/org/molgenis/das/impl/RepositoryRangeHandlingDataSourceTest.java
@@ -27,6 +27,7 @@ import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.Query;
 import org.molgenis.data.elasticsearch.util.Hit;
 import org.molgenis.data.elasticsearch.util.SearchResult;
+import org.molgenis.data.support.DefaultAttributeMetaData;
 import org.molgenis.data.support.DefaultEntityMetaData;
 import org.molgenis.data.support.GenomicDataSettings;
 import org.molgenis.data.support.MapEntity;
@@ -87,18 +88,29 @@ public class RepositoryRangeHandlingDataSourceTest
 		linkout.put(new URL("http://www.molgenis.org/"), "Link");
 
 		List<DasTarget> dasTarget = new ArrayList<DasTarget>();
-		dasTarget.add(new MolgenisDasTarget("mutation id", 10, 1000, "mutation name,description"));
+		dasTarget.add(new MolgenisDasTarget("mutation id", 10, 1000, "description"));
 		List<String> notes = new ArrayList<String>();
 		notes.add("track:dataset");
 		notes.add("source:MOLGENIS");
 
-		dasFeature = new DasFeature("mutation id", "mutation name,description", type, method, 10, 1000, new Double(0),
+		dasFeature = new DasFeature("mutation id", "description", type, method, 10, 1000, new Double(0),
 				DasFeatureOrientation.ORIENTATION_NOT_APPLICABLE, DasPhase.PHASE_NOT_APPLICABLE, notes, linkout,
 				dasTarget, new ArrayList<String>(), null);
 
 		Query q = new QueryImpl().eq("CHROM", "1");
 		q.pageSize(100);
 		SearchResult result = mock(SearchResult.class);
+		DefaultEntityMetaData emd = new DefaultEntityMetaData("DAS");
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("STOP"));
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("linkout"));
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("NAME").setLabelAttribute(true));
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("INFO"));
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("POS"));
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("ID").setIdAttribute(true));
+		emd.addAttributeMetaData(new DefaultAttributeMetaData("CHROM"));
+
+		MapEntity entity = new MapEntity(emd);
+
 		Map<String, Object> map = new HashMap<String, Object>();
 		map.put("STOP", 1000);
 		map.put("linkout", "http://www.molgenis.org/");
@@ -108,10 +120,11 @@ public class RepositoryRangeHandlingDataSourceTest
 		map.put("ID", "mutation id");
 		map.put("CHROM", "1");
 
-		MapEntity entity = new MapEntity(map);
-		resultList = new ArrayList<Hit>();
+		entity.set(new MapEntity(map));
+
+		resultList = new ArrayList<>();
 		resultList.add(new Hit("", "", map));
-		featureList = new ArrayList<DasFeature>();
+		featureList = new ArrayList<>();
 		featureList.add(dasFeature);
 		when(dataService.findAll("dataset", q)).thenReturn(Arrays.<Entity> asList(entity));
 		when(result.iterator()).thenReturn(resultList.iterator());

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
@@ -284,6 +284,12 @@
                         info.setTitle("Chromosome:"+f.segment+" Position:"+ f.min);
                     }
                 }
+
+                var entityReportLink = $('<a href="javascript:void(0)">' + f.id + '</a>');
+                entityReportLink.click(function () {
+                	onRowInspect({id:f.id, name:getEntity().name});
+                });
+                info.add("Show details:", entityReportLink[0]);
             }
             featureInfoMap[info.tier.dasSource.name + f.id + f.label] = info;
         }


### PR DESCRIPTION
two parts in this PR:
- change DAS code to use id and label from the entity instead of custom black magic now used to figure out which fields to use for this.
- add a link to the genome browser popup to show the entityreport directly from the GB. Requested bij one of our Mutation Database customers