### PR TITLE
M3389 As Parelsnoer I want to have the correct tissue types mapped in the Promise link

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/promise/mapper/ParelMapper.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/promise/mapper/ParelMapper.java
@@ -293,9 +293,9 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 		List<String> unknown = Lists.newArrayList();
 		for (Entity sample : promiseSampleEntities)
 		{
-			// when MATERIAL_TYPES_SUB = -1, there is no tissue stored
+			String type = sample.getString("MATERIAL_TYPES");
 			String tissue = sample.getString("MATERIAL_TYPES_SUB");
-			if (tissue != null && !tissue.equals("-1"))
+			if (type.equals("weefsel") && tissue != null)
 			{
 				if (tissueTypesMap.containsKey(tissue))
 				{
@@ -308,7 +308,6 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 			}
 			else
 			{
-				String type = sample.getString("MATERIAL_TYPES");
 				if (materialTypesMap.containsKey(type))
 				{
 					materialTypesMap.get(type).forEach(t -> ids.add(t));
@@ -318,9 +317,11 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 					unknown.add(type);
 				}
 			}
+
 		}
 
 		if (!unknown.isEmpty())
+
 		{
 			throw new RuntimeException("Unknown ProMISe material types: [" + String.join(",", unknown) + "]");
 		}
@@ -328,6 +329,7 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 		Iterable<Entity> materialTypes = dataService.findAll(REF_MATERIAL_TYPES, transform(ids, id -> (Object) id));
 
 		if (!materialTypes.iterator().hasNext())
+
 		{
 			String message = String.format("Couldn't find mappings for some of the material types in %s.", ids);
 			throw new RuntimeException(message);

--- a/molgenis-app/src/main/java/org/molgenis/app/promise/mapper/ParelMapper.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/promise/mapper/ParelMapper.java
@@ -98,6 +98,16 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 		materialTypesMap.put("weefsel", asList("TISSUE_FROZEN", "TISSUE_PARAFFIN_EMBEDDED"));
 	}
 
+	private static final HashMap<String, List<String>> tissueTypesMap;
+
+	static
+	{
+		tissueTypesMap = new HashMap<>();
+		tissueTypesMap.put("1", asList("TISSUE_PARAFFIN_EMBEDDED"));
+		tissueTypesMap.put("2", asList("TISSUE_FROZEN"));
+		tissueTypesMap.put("9", asList("OTHER"));
+	}
+
 	@Autowired
 	public ParelMapper(PromiseMapperFactory promiseMapperFactory, PromiseDataParser promiseDataParser,
 			DataService dataService)
@@ -280,14 +290,29 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 		List<String> unknown = Lists.newArrayList();
 		for (Entity sample : promiseSampleEntities)
 		{
-			String type = sample.getString("MATERIAL_TYPES");
-			if (materialTypesMap.containsKey(type))
+			String tissue = sample.getString("MATERIAL_TYPES_SUB");
+			if (tissue != null && !tissue.equals("-1"))
 			{
-				materialTypesMap.get(type).forEach(t -> ids.add(t));
+				if (tissueTypesMap.containsKey(tissue))
+				{
+					tissueTypesMap.get(tissue).forEach(t -> ids.add(t));
+				}
+				else
+				{
+					unknown.add(tissue);
+				}
 			}
 			else
 			{
-				unknown.add(type);
+				String type = sample.getString("MATERIAL_TYPES");
+				if (materialTypesMap.containsKey(type))
+				{
+					materialTypesMap.get(type).forEach(t -> ids.add(t));
+				}
+				else
+				{
+					unknown.add(type);
+				}
 			}
 		}
 

--- a/molgenis-app/src/main/java/org/molgenis/app/promise/mapper/ParelMapper.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/promise/mapper/ParelMapper.java
@@ -95,7 +95,10 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 		materialTypesMap.put("RNA uit bloedcellen", asList("RNA"));
 		materialTypesMap.put("serum", asList("SERUM"));
 		materialTypesMap.put("urine", asList("URINE"));
-		materialTypesMap.put("weefsel", asList("TISSUE_FROZEN", "TISSUE_PARAFFIN_EMBEDDED"));
+		materialTypesMap.put("weefsel", asList("TISSUE_FROZEN", "TISSUE_PARAFFIN_EMBEDDED")); // when a Parel doesn't
+																								// distinguish between
+																								// tissue types, add
+																								// them both
 	}
 
 	private static final HashMap<String, List<String>> tissueTypesMap;
@@ -290,6 +293,7 @@ public class ParelMapper implements PromiseMapper, ApplicationListener<ContextRe
 		List<String> unknown = Lists.newArrayList();
 		for (Entity sample : promiseSampleEntities)
 		{
+			// when MATERIAL_TYPES_SUB = -1, there is no tissue stored
 			String tissue = sample.getString("MATERIAL_TYPES_SUB");
 			if (tissue != null && !tissue.equals("-1"))
 			{


### PR DESCRIPTION
- Parels having a ```MATERIAL_TYPES_SUB``` field can distinguish between tissue types (```TISSUE_PARAFFIN_EMBEDDED``` and ```TISSUE_FROZEN```)
- Parels without ```MATERIAL_TYPES_SUB``` that have tissue stored still map to both the paraffin embedded and frozen tissue types