### PR TITLE
Fix #4212 If one attribute is selected in a compound the table shows all columns

### DIFF
--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeFilterToFetchConverter.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeFilterToFetchConverter.java
@@ -89,7 +89,7 @@ public class AttributeFilterToFetchConverter
 					subAttrFilter.forEach(entry -> {
 						String attrPartName = entry.getKey();
 						AttributeMetaData attrPart = attr.getAttributePart(attrPartName);
-						createFetchContentRec(attrFilter, entityMeta, attrPart, fetch);
+						createFetchContentRec(subAttrFilter, entityMeta, attrPart, fetch);
 					});
 				}
 				else

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeMetaDataResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeMetaDataResponseV2.java
@@ -1,5 +1,7 @@
 package org.molgenis.data.rest.v2;
 
+import static org.molgenis.MolgenisFieldTypes.FieldTypeEnum.COMPOUND;
+
 import java.util.List;
 
 import org.molgenis.MolgenisFieldTypes.FieldTypeEnum;
@@ -80,17 +82,7 @@ class AttributeMetaDataResponseV2
 		if (attrParts != null)
 		{
 			// filter attribute parts
-			if (fetch != null)
-			{
-				attrParts = Iterables.filter(attrParts, new Predicate<AttributeMetaData>()
-				{
-					@Override
-					public boolean apply(AttributeMetaData attr)
-					{
-						return fetch != null ? fetch.hasField(attr) : true;
-					}
-				});
-			}
+			attrParts = filterAttributes(fetch, attrParts);
 
 			// create attribute response
 			this.attributes = Lists.newArrayList(
@@ -102,7 +94,14 @@ class AttributeMetaDataResponseV2
 							Fetch subAttrFetch;
 							if (fetch != null)
 							{
-								subAttrFetch = fetch;
+								if (attr.getDataType().getEnumType() == FieldTypeEnum.COMPOUND)
+								{
+									subAttrFetch = fetch;
+								}
+								else
+								{
+									subAttrFetch = fetch.getFetch(attr);
+								}
 							}
 							else if (attr.getDataType() instanceof XrefField || attr.getDataType() instanceof MrefField)
 							{
@@ -134,6 +133,44 @@ class AttributeMetaDataResponseV2
 		this.visible = attr.isVisible();
 		this.visibleExpression = attr.getVisibleExpression();
 		this.validationExpression = attr.getValidationExpression();
+	}
+
+	public static Iterable<AttributeMetaData> filterAttributes(Fetch fetch, Iterable<AttributeMetaData> attrs)
+	{
+		if (fetch != null)
+		{
+			return Iterables.filter(attrs, new Predicate<AttributeMetaData>()
+			{
+				@Override
+				public boolean apply(AttributeMetaData attr)
+				{
+					return filterAttributeRec(fetch, attr);
+				}
+			});
+		}
+		else
+		{
+			return attrs;
+		}
+	}
+
+	public static boolean filterAttributeRec(Fetch fetch, AttributeMetaData attr)
+	{
+		if (attr.getDataType().getEnumType() == COMPOUND)
+		{
+			for (AttributeMetaData attrPart : attr.getAttributeParts())
+			{
+				if (filterAttributeRec(fetch, attrPart))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+		else
+		{
+			return fetch.hasField(attr);
+		}
 	}
 
 	public String getHref()

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeMetaDataResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeMetaDataResponseV2.java
@@ -102,7 +102,7 @@ class AttributeMetaDataResponseV2
 							Fetch subAttrFetch;
 							if (fetch != null)
 							{
-								subAttrFetch = fetch.getFetch(attr);
+								subAttrFetch = fetch;
 							}
 							else if (attr.getDataType() instanceof XrefField || attr.getDataType() instanceof MrefField)
 							{

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityMetaDataResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityMetaDataResponseV2.java
@@ -1,10 +1,9 @@
 package org.molgenis.data.rest.v2;
 
+import static org.molgenis.data.rest.v2.AttributeMetaDataResponseV2.filterAttributes;
 import static org.molgenis.data.rest.v2.RestControllerV2.BASE_URI;
 
-import java.util.Iterator;
 import java.util.List;
-import java.util.Queue;
 
 import org.molgenis.MolgenisFieldTypes.FieldTypeEnum;
 import org.molgenis.data.AttributeMetaData;
@@ -19,10 +18,8 @@ import org.molgenis.security.core.MolgenisPermissionService;
 import org.molgenis.security.core.Permission;
 
 import com.google.common.base.Function;
-import com.google.common.base.Predicate;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Queues;
 
 class EntityMetaDataResponseV2
 {
@@ -68,40 +65,7 @@ class EntityMetaDataResponseV2
 		this.label = meta.getLabel();
 
 		// filter attribute parts
-		Iterable<AttributeMetaData> filteredAttrs = fetch != null
-				? Iterables.filter(meta.getAttributes(), new Predicate<AttributeMetaData>()
-				{
-					@Override
-					public boolean apply(AttributeMetaData attr)
-					{
-						// fetch only contains atomic attributes, the REST API meta response contains a tree of
-						// attributes. the algorithm below determines whether or not to include this compound attribute.
-						boolean keep;
-						if (attr.getDataType().getEnumType() == FieldTypeEnum.COMPOUND)
-						{
-							keep = false;
-							Queue<AttributeMetaData> queue = Queues.newConcurrentLinkedQueue(attr.getAttributeParts());
-							for (Iterator<AttributeMetaData> it = queue.iterator(); it.hasNext();)
-							{
-								AttributeMetaData attrPart = it.next();
-								if (attrPart.getDataType().getEnumType() == FieldTypeEnum.COMPOUND)
-								{
-									queue.addAll(Lists.newArrayList(attrPart.getAttributeParts()));
-								}
-								if (fetch.hasField(attrPart))
-								{
-									keep = true;
-									break;
-								}
-							}
-						}
-						else
-						{
-							keep = fetch.hasField(attr.getName());
-						}
-						return keep;
-					}
-				}) : meta.getAttributes();
+		Iterable<AttributeMetaData> filteredAttrs = filterAttributes(fetch, meta.getAttributes());
 
 		this.attributes = Lists.newArrayList(
 				Iterables.transform(filteredAttrs, new Function<AttributeMetaData, AttributeMetaDataResponseV2>()
@@ -112,7 +76,14 @@ class EntityMetaDataResponseV2
 						Fetch subAttrFetch;
 						if (fetch != null)
 						{
-							subAttrFetch = fetch;
+							if (attr.getDataType().getEnumType() == FieldTypeEnum.COMPOUND)
+							{
+								subAttrFetch = fetch;
+							}
+							else
+							{
+								subAttrFetch = fetch.getFetch(attr);
+							}
 						}
 						else if (attr.getDataType() instanceof XrefField || attr.getDataType() instanceof MrefField)
 						{

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityMetaDataResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityMetaDataResponseV2.java
@@ -74,7 +74,7 @@ class EntityMetaDataResponseV2
 					@Override
 					public boolean apply(AttributeMetaData attr)
 					{
-						// fetch only contains compound attributes, the REST API meta response contains a tree of
+						// fetch only contains atomic attributes, the REST API meta response contains a tree of
 						// attributes. the algorithm below determines whether or not to include this compound attribute.
 						boolean keep;
 						if (attr.getDataType().getEnumType() == FieldTypeEnum.COMPOUND)
@@ -112,7 +112,7 @@ class EntityMetaDataResponseV2
 						Fetch subAttrFetch;
 						if (fetch != null)
 						{
-							subAttrFetch = fetch.getFetch(attr);
+							subAttrFetch = fetch;
 						}
 						else if (attr.getDataType() instanceof XrefField || attr.getDataType() instanceof MrefField)
 						{
@@ -122,6 +122,7 @@ class EntityMetaDataResponseV2
 						{
 							subAttrFetch = null;
 						}
+
 						return new AttributeMetaDataResponseV2(name, attr, subAttrFetch, permissionService,
 								dataService);
 					}

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
@@ -551,7 +551,7 @@ class RestControllerV2
 		for (AttributeMetaData attr : attrs) // TODO performance use fetch instead of attrs
 		{
 			String attrName = attr.getName();
-			if (fetch == null || fetch.hasField(attr))
+			if (fetch == null || fetch.hasField(attrName))
 			{
 				FieldTypeEnum dataType = attr.getDataType().getEnumType();
 				switch (dataType)

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/AttributeFilterToFetchConverterTest.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/AttributeFilterToFetchConverterTest.java
@@ -26,6 +26,9 @@ public class AttributeFilterToFetchConverterTest
 	private static final String COMPOUND_ATTR_NAME = "attrCompound";
 	private static final String COMPOUND_PART_ATTR_NAME = "attrCompoundPart";
 	private static final String COMPOUND_PART_FILE_ATTR_NAME = "attrCompoundPartFile";
+	private static final String COMPOUND_PART_COMPOUND_ATTR_NAME = "attrCompoundPartCompound";
+	private static final String COMPOUND_PART_COMPOUND_PART_ATTR_NAME = "attrCompoundPartCompoundPart";
+	private static final String COMPOUND_PART_COMPOUND_PART_ATTR2_NAME = "attr2CompoundPartCompoundPart";
 	private static final String XREF_ATTR_NAME = "xrefAttr";
 
 	private static final String REF_ID_ATTR_NAME = "refAttrId";
@@ -78,13 +81,42 @@ public class AttributeFilterToFetchConverterTest
 		when(compoundPartFileAttr.getRefEntity()).thenReturn(FileMeta.META_DATA);
 		AttributeMetaData compoundAttr = when(mock(AttributeMetaData.class).getName()).thenReturn(COMPOUND_ATTR_NAME)
 				.getMock();
+		AttributeMetaData compoundPartCompoundAttr = when(mock(AttributeMetaData.class).getName())
+				.thenReturn(COMPOUND_PART_COMPOUND_ATTR_NAME).getMock();
+		when(compoundPartCompoundAttr.getDataType()).thenReturn(COMPOUND);
+
+		AttributeMetaData compoundPartCompoundPartAttr = when(mock(AttributeMetaData.class).getName())
+				.thenReturn(COMPOUND_PART_COMPOUND_PART_ATTR_NAME).getMock();
+		when(compoundPartCompoundPartAttr.getDataType()).thenReturn(STRING);
+
+		AttributeMetaData compoundPartCompoundPartAttr2 = when(mock(AttributeMetaData.class).getName())
+				.thenReturn(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME).getMock();
+		when(compoundPartCompoundPartAttr2.getDataType()).thenReturn(STRING);
+
+		when(compoundPartCompoundAttr.getAttributeParts())
+				.thenReturn(Arrays.asList(compoundPartCompoundPartAttr, compoundPartCompoundPartAttr2));
+		when(compoundPartCompoundAttr.getAttributePart(COMPOUND_PART_COMPOUND_PART_ATTR_NAME))
+				.thenReturn(compoundPartCompoundPartAttr);
+		when(compoundPartCompoundAttr.getAttributePart(COMPOUND_PART_COMPOUND_PART_ATTR_NAME.toLowerCase()))
+				.thenReturn(compoundPartCompoundPartAttr);
+
+		when(compoundPartCompoundAttr.getAttributePart(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME))
+				.thenReturn(compoundPartCompoundPartAttr2);
+		when(compoundPartCompoundAttr.getAttributePart(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME.toLowerCase()))
+				.thenReturn(compoundPartCompoundPartAttr2);
+
 		when(compoundAttr.getDataType()).thenReturn(COMPOUND);
-		when(compoundAttr.getAttributeParts()).thenReturn(Arrays.asList(compoundPartAttr, compoundPartFileAttr));
+		when(compoundAttr.getAttributeParts())
+				.thenReturn(Arrays.asList(compoundPartAttr, compoundPartFileAttr, compoundPartCompoundAttr));
 		when(compoundAttr.getAttributePart(COMPOUND_PART_ATTR_NAME.toLowerCase())).thenReturn(compoundPartAttr);
 		when(compoundAttr.getAttributePart(COMPOUND_PART_ATTR_NAME)).thenReturn(compoundPartAttr);
 		when(compoundAttr.getAttributePart(COMPOUND_PART_FILE_ATTR_NAME.toLowerCase()))
 				.thenReturn(compoundPartFileAttr);
 		when(compoundAttr.getAttributePart(COMPOUND_PART_FILE_ATTR_NAME)).thenReturn(compoundPartFileAttr);
+		when(compoundAttr.getAttributePart(COMPOUND_PART_COMPOUND_ATTR_NAME.toLowerCase()))
+				.thenReturn(compoundPartCompoundAttr);
+		when(compoundAttr.getAttributePart(COMPOUND_PART_COMPOUND_ATTR_NAME)).thenReturn(compoundPartCompoundAttr);
+
 		xrefAttr = when(mock(AttributeMetaData.class).getName()).thenReturn(XREF_ATTR_NAME).getMock();
 		when(xrefAttr.getDataType()).thenReturn(XREF);
 		when(xrefAttr.getRefEntity()).thenReturn(xrefEntityMeta);
@@ -97,13 +129,24 @@ public class AttributeFilterToFetchConverterTest
 		when(entityMeta.getAttribute(LABEL_ATTR_NAME)).thenReturn(labelAttr);
 		when(entityMeta.getAttribute(COMPOUND_ATTR_NAME.toLowerCase())).thenReturn(compoundAttr);
 		when(entityMeta.getAttribute(COMPOUND_ATTR_NAME)).thenReturn(compoundAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_ATTR_NAME.toLowerCase())).thenReturn(compoundPartAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_ATTR_NAME)).thenReturn(compoundPartAttr);
 		when(entityMeta.getAttribute(XREF_ATTR_NAME.toLowerCase())).thenReturn(xrefAttr);
 		when(entityMeta.getAttribute(XREF_ATTR_NAME)).thenReturn(xrefAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_COMPOUND_ATTR_NAME)).thenReturn(compoundPartCompoundAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_COMPOUND_ATTR_NAME.toLowerCase()))
+				.thenReturn(compoundPartCompoundAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_COMPOUND_PART_ATTR_NAME)).thenReturn(compoundPartCompoundPartAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_COMPOUND_PART_ATTR_NAME.toLowerCase()))
+				.thenReturn(compoundPartCompoundPartAttr);
+		when(entityMeta.getAttribute(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME)).thenReturn(compoundPartCompoundPartAttr2);
+		when(entityMeta.getAttribute(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME.toLowerCase()))
+				.thenReturn(compoundPartCompoundPartAttr2);
 		when(entityMeta.getIdAttribute()).thenReturn(idAttr);
 		when(entityMeta.getLabelAttribute()).thenReturn(labelAttr);
 		when(entityMeta.getAttributes()).thenReturn(Arrays.asList(idAttr, labelAttr, compoundAttr, xrefAttr));
-		when(entityMeta.getAtomicAttributes())
-				.thenReturn(Arrays.asList(idAttr, labelAttr, compoundPartAttr, compoundPartFileAttr, xrefAttr));
+		when(entityMeta.getAtomicAttributes()).thenReturn(Arrays.asList(idAttr, labelAttr, compoundPartAttr,
+				compoundPartFileAttr, compoundPartCompoundPartAttr, compoundPartCompoundPartAttr2, xrefAttr));
 	}
 
 	@Test
@@ -112,7 +155,8 @@ public class AttributeFilterToFetchConverterTest
 		Fetch fetch = new Fetch().field(ID_ATTR_NAME).field(LABEL_ATTR_NAME).field(COMPOUND_PART_ATTR_NAME)
 				.field(COMPOUND_PART_FILE_ATTR_NAME,
 						new Fetch().field(FileMeta.ID).field(FileMeta.FILENAME).field(FileMeta.URL))
-				.field(XREF_ATTR_NAME, new Fetch().field(REF_ID_ATTR_NAME).field(REF_LABEL_ATTR_NAME));
+				.field(XREF_ATTR_NAME, new Fetch().field(REF_ID_ATTR_NAME).field(REF_LABEL_ATTR_NAME))
+				.field(COMPOUND_PART_COMPOUND_PART_ATTR_NAME).field(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME);
 		assertEquals(AttributeFilterToFetchConverter.convert(null, entityMeta), fetch);
 	}
 
@@ -144,9 +188,11 @@ public class AttributeFilterToFetchConverterTest
 	{
 		AttributeFilter attrFilter = new AttributeFilter().add(COMPOUND_ATTR_NAME);
 		assertEquals(AttributeFilterToFetchConverter.convert(attrFilter, entityMeta),
-				new Fetch().field(COMPOUND_PART_ATTR_NAME).field(COMPOUND_PART_FILE_ATTR_NAME,
-						new Fetch().field(FileMeta.META_DATA.getIdAttribute().getName())
-								.field(FileMeta.META_DATA.getLabelAttribute().getName()).field(FileMeta.URL)));
+				new Fetch().field(COMPOUND_PART_ATTR_NAME)
+						.field(COMPOUND_PART_FILE_ATTR_NAME,
+								new Fetch().field(FileMeta.META_DATA.getIdAttribute().getName())
+										.field(FileMeta.META_DATA.getLabelAttribute().getName()).field(FileMeta.URL))
+						.field(COMPOUND_PART_COMPOUND_PART_ATTR_NAME).field(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME));
 	}
 
 	@Test
@@ -156,6 +202,15 @@ public class AttributeFilterToFetchConverterTest
 				new AttributeFilter().add(COMPOUND_PART_ATTR_NAME));
 		assertEquals(AttributeFilterToFetchConverter.convert(attrFilter, entityMeta),
 				new Fetch().field(COMPOUND_PART_ATTR_NAME));
+	}
+
+	@Test
+	public void convertAttrFilterCompoundPartCompoundAttr()
+	{
+		AttributeFilter attrFilter = new AttributeFilter().add(COMPOUND_ATTR_NAME, new AttributeFilter().add(
+				COMPOUND_PART_COMPOUND_ATTR_NAME, new AttributeFilter().add(COMPOUND_PART_COMPOUND_PART_ATTR_NAME)));
+		assertEquals(AttributeFilterToFetchConverter.convert(attrFilter, entityMeta),
+				new Fetch().field(COMPOUND_PART_COMPOUND_PART_ATTR_NAME));
 	}
 
 	@Test
@@ -180,7 +235,8 @@ public class AttributeFilterToFetchConverterTest
 		Fetch fetch = new Fetch().field(ID_ATTR_NAME).field(LABEL_ATTR_NAME).field(COMPOUND_PART_ATTR_NAME)
 				.field(COMPOUND_PART_FILE_ATTR_NAME,
 						new Fetch().field(FileMeta.ID).field(FileMeta.FILENAME).field(FileMeta.URL))
-				.field(XREF_ATTR_NAME, new Fetch().field(REF_ID_ATTR_NAME).field(REF_LABEL_ATTR_NAME));
+				.field(XREF_ATTR_NAME, new Fetch().field(REF_ID_ATTR_NAME).field(REF_LABEL_ATTR_NAME))
+				.field(COMPOUND_PART_COMPOUND_PART_ATTR_NAME).field(COMPOUND_PART_COMPOUND_PART_ATTR2_NAME);
 		assertEquals(AttributeFilterToFetchConverter.createDefaultEntityFetch(entityMeta), fetch);
 	}
 

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/RestControllerV2Test.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/RestControllerV2Test.java
@@ -115,6 +115,10 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 	private String attrBool;
 	private String attrString;
 	private String attrXref;
+	private String attrCompound;
+	private String attrCompoundAttr0;
+	private String attrCompoundAttrCompound;
+	private String attrCompoundAttrCompoundAttr0;
 	private String refAttrValue;
 	private String refAttrId;
 	private String refAttrRef;
@@ -143,10 +147,10 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 		attrBool = "bool";
 		String attrCategorical = "categorical";
 		String attrCategoricalMref = "categorical_mref";
-		String attrCompound = "compound";
-		String attrCompoundAttr0 = "compound_attr0";
-		String attrCompoundAttrCompound = "compound_attrcompound";
-		String attrCompoundAttrCompoundAttr0 = "compound_attrcompound_attr0";
+		attrCompound = "compound";
+		attrCompoundAttr0 = "compound_attr0";
+		attrCompoundAttrCompound = "compound_attrcompound";
+		attrCompoundAttrCompoundAttr0 = "compound_attrcompound_attr0";
 		String attrDate = "date";
 		String attrDateTime = "date_time";
 		String attrDecimal = "decimal";
@@ -355,6 +359,23 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 		mockMvc.perform(get(HREF_ENTITY_ID).param("attrs", attrBool)).andExpect(status().isOk())
 				.andExpect(content().contentType(APPLICATION_JSON))
 				.andExpect(content().string(resourcePartialAttributeResponse));
+	}
+
+	@Test
+	public void retrieveResourcePartialResponseAttributeInCompound() throws Exception
+	{
+		mockMvc.perform(get(HREF_ENTITY_ID).param("attrs", attrCompound + '(' + attrCompoundAttr0 + ')'))
+				.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JSON))
+				.andExpect(content().string(resourcePartialAttributeInCompoundResponse));
+	}
+
+	@Test
+	public void retrieveResourcePartialResponseAttributeInCompoundInCompound() throws Exception
+	{
+		mockMvc.perform(get(HREF_ENTITY_ID).param("attrs",
+				attrCompound + '(' + attrCompoundAttrCompound + '(' + attrCompoundAttrCompoundAttr0 + "))"))
+				.andExpect(status().isOk()).andExpect(content().contentType(APPLICATION_JSON))
+				.andExpect(content().string(resourcePartialAttributeInCompoundInCompoundResponse));
 	}
 
 	@Test
@@ -1156,6 +1177,55 @@ public class RestControllerV2Test extends AbstractTestNGSpringContextTests
 			+ "    \"labelAttribute\": \"id\",\n" + "    \"idAttribute\": \"id\",\n" + "    \"lookupAttributes\": [],\n"
 			+ "    \"isAbstract\": false,\n" + "    \"writable\": false\n" + "  },\n"
 			+ "  \"_href\": \"/api/v2/entity/0\",\n" + "  \"bool\": true\n" + "}";
+
+	private String resourcePartialAttributeInCompoundResponse = "{\n" + "  \"_meta\": {\n"
+			+ "    \"href\": \"/api/v2/entity\",\n" + "    \"hrefCollection\": \"/api/v2/entity\",\n"
+			+ "    \"name\": \"entity\",\n" + "    \"label\": \"entity\",\n" + "    \"attributes\": [\n" + "      {\n"
+			+ "        \"href\": \"/api/v2/entity/meta/compound\",\n" + "        \"fieldType\": \"COMPOUND\",\n"
+			+ "        \"name\": \"compound\",\n" + "        \"label\": \"compound\",\n" + "        \"attributes\": [\n"
+			+ "          {\n" + "            \"href\": \"/api/v2/entity/meta/compound_attr0\",\n"
+			+ "            \"fieldType\": \"STRING\",\n" + "            \"name\": \"compound_attr0\",\n"
+			+ "            \"label\": \"compound_attr0\",\n" + "            \"attributes\": [],\n"
+			+ "            \"maxLength\": 255,\n" + "            \"auto\": false,\n"
+			+ "            \"nillable\": true,\n" + "            \"readOnly\": false,\n"
+			+ "            \"labelAttribute\": false,\n" + "            \"unique\": false,\n"
+			+ "            \"visible\": true,\n" + "            \"lookupAttribute\": false,\n"
+			+ "            \"aggregateable\": false\n" + "          }\n" + "        ],\n" + "        \"auto\": false,\n"
+			+ "        \"nillable\": true,\n" + "        \"readOnly\": false,\n"
+			+ "        \"labelAttribute\": false,\n" + "        \"unique\": false,\n" + "        \"visible\": true,\n"
+			+ "        \"lookupAttribute\": false,\n" + "        \"aggregateable\": false\n" + "      }\n" + "    ],\n"
+			+ "    \"labelAttribute\": \"id\",\n" + "    \"idAttribute\": \"id\",\n" + "    \"lookupAttributes\": [],\n"
+			+ "    \"isAbstract\": false,\n" + "    \"writable\": false\n" + "  },\n"
+			+ "  \"_href\": \"/api/v2/entity/0\",\n" + "  \"compound_attr0\": \"compoundAttr0Str\"\n" + "}";
+
+	private String resourcePartialAttributeInCompoundInCompoundResponse = "{\n" + "  \"_meta\": {\n"
+			+ "    \"href\": \"/api/v2/entity\",\n" + "    \"hrefCollection\": \"/api/v2/entity\",\n"
+			+ "    \"name\": \"entity\",\n" + "    \"label\": \"entity\",\n" + "    \"attributes\": [\n" + "      {\n"
+			+ "        \"href\": \"/api/v2/entity/meta/compound\",\n" + "        \"fieldType\": \"COMPOUND\",\n"
+			+ "        \"name\": \"compound\",\n" + "        \"label\": \"compound\",\n" + "        \"attributes\": [\n"
+			+ "          {\n" + "            \"href\": \"/api/v2/entity/meta/compound_attrcompound\",\n"
+			+ "            \"fieldType\": \"COMPOUND\",\n" + "            \"name\": \"compound_attrcompound\",\n"
+			+ "            \"label\": \"compound_attrcompound\",\n" + "            \"attributes\": [\n"
+			+ "              {\n" + "                \"href\": \"/api/v2/entity/meta/compound_attrcompound_attr0\",\n"
+			+ "                \"fieldType\": \"STRING\",\n"
+			+ "                \"name\": \"compound_attrcompound_attr0\",\n"
+			+ "                \"label\": \"compound_attrcompound_attr0\",\n" + "                \"attributes\": [],\n"
+			+ "                \"maxLength\": 255,\n" + "                \"auto\": false,\n"
+			+ "                \"nillable\": true,\n" + "                \"readOnly\": false,\n"
+			+ "                \"labelAttribute\": false,\n" + "                \"unique\": false,\n"
+			+ "                \"visible\": true,\n" + "                \"lookupAttribute\": false,\n"
+			+ "                \"aggregateable\": false\n" + "              }\n" + "            ],\n"
+			+ "            \"auto\": false,\n" + "            \"nillable\": true,\n"
+			+ "            \"readOnly\": false,\n" + "            \"labelAttribute\": false,\n"
+			+ "            \"unique\": false,\n" + "            \"visible\": true,\n"
+			+ "            \"lookupAttribute\": false,\n" + "            \"aggregateable\": false\n" + "          }\n"
+			+ "        ],\n" + "        \"auto\": false,\n" + "        \"nillable\": true,\n"
+			+ "        \"readOnly\": false,\n" + "        \"labelAttribute\": false,\n" + "        \"unique\": false,\n"
+			+ "        \"visible\": true,\n" + "        \"lookupAttribute\": false,\n"
+			+ "        \"aggregateable\": false\n" + "      }\n" + "    ],\n" + "    \"labelAttribute\": \"id\",\n"
+			+ "    \"idAttribute\": \"id\",\n" + "    \"lookupAttributes\": [],\n" + "    \"isAbstract\": false,\n"
+			+ "    \"writable\": false\n" + "  },\n" + "  \"_href\": \"/api/v2/entity/0\",\n"
+			+ "  \"compound_attrcompound_attr0\": \"compoundAttrCompoundAttr0Str\"\n" + "}";
 
 	private String resourcePartialSubAttributeResponse = "{\n" + "  \"_meta\": {\n"
 			+ "    \"href\": \"/api/v2/entity\",\n" + "    \"hrefCollection\": \"/api/v2/entity\",\n"


### PR DESCRIPTION
- REST API returns only meta data of compound and atomic attributes that are actually requested
