### PR TITLE
Fix #4296: Aggregates with threshold smaller than rendered wrong

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/MolgenisWebAppConfig.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/MolgenisWebAppConfig.java
@@ -331,7 +331,7 @@ public abstract class MolgenisWebAppConfig extends WebMvcConfigurerAdapter
 		FreeMarkerViewResolver resolver = new FreeMarkerViewResolver();
 		resolver.setCache(true);
 		resolver.setSuffix(".ftl");
-
+		resolver.setContentType("text/html;charset=UTF-8");
 		return resolver;
 	}
 

--- a/molgenis-core-ui/src/main/resources/js/select2-patched.js
+++ b/molgenis-core-ui/src/main/resources/js/select2-patched.js
@@ -3508,8 +3508,8 @@ the specific language governing permissions and limitations under the Apache Lic
          formatInputTooShort: function (input, min) { var n = min - input.length; return "Please enter " + n + " or more character" + (n == 1 ? "" : "s"); },
          formatInputTooLong: function (input, max) { var n = input.length - max; return "Please delete " + n + " character" + (n == 1 ? "" : "s"); },
          formatSelectionTooBig: function (limit) { return "You can only select " + limit + " item" + (limit == 1 ? "" : "s"); },
-         formatLoadMore: function (pageNumber) { return "Loading more results\u2026"; },
-         formatSearching: function () { return "Searching\u2026"; }
+         formatLoadMore: function (pageNumber) { return "Loading more results…"; },
+         formatSearching: function () { return "Searching…"; }
     };
 
     $.extend($.fn.select2.defaults, $.fn.select2.locales['en']);


### PR DESCRIPTION
This works for me locally, still needs to be tested on a VM with apache httpd and tomcat instead of jetty.
Make sure to clear your cache when testing.

Also fixes #3252 which I've closed as a duplicate.

The fix changes the encoding used to serve all FreeMarker views from iso-latin-1 to UTF-8, so the potential impact is across the board, wherever non-ascii characters are served. Still, I'd argue that this is how we want and expect the views to be served.