### PR TITLE
[1.16] Rename migration step 27 to 26

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppConfig.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppConfig.java
@@ -28,7 +28,7 @@ import org.molgenis.migrate.version.v1_13.Step22RemoveDiseaseMatcher;
 import org.molgenis.migrate.version.v1_14.Step23RebuildElasticsearchIndex;
 import org.molgenis.migrate.version.v1_15.Step24UpdateApplicationSettings;
 import org.molgenis.migrate.version.v1_15.Step25LanguagesPermissions;
-import org.molgenis.migrate.version.v1_16.Step27migrateJpaBackend;
+import org.molgenis.migrate.version.v1_16.Step26migrateJpaBackend;
 import org.molgenis.ui.MolgenisWebAppConfig;
 import org.molgenis.util.DependencyResolver;
 import org.molgenis.util.GsonConfig;
@@ -102,7 +102,7 @@ public class WebAppConfig extends MolgenisWebAppConfig
 		upgradeService.addUpgrade(step23RebuildElasticsearchIndex);
 		upgradeService.addUpgrade(new Step24UpdateApplicationSettings(dataSource, idGenerator));
 		upgradeService.addUpgrade(new Step25LanguagesPermissions(dataService));
-		upgradeService.addUpgrade(new Step27migrateJpaBackend(dataSource, MysqlRepositoryCollection.NAME));
+		upgradeService.addUpgrade(new Step26migrateJpaBackend(dataSource, MysqlRepositoryCollection.NAME));
 	}
 
 	@Override

--- a/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/MolgenisVersionService.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/MolgenisVersionService.java
@@ -39,7 +39,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class MolgenisVersionService
 {
-	public static final int CURRENT_VERSION = 27;
+	public static final int CURRENT_VERSION = 26;
 
 	private static final Logger LOG = LoggerFactory.getLogger(MolgenisVersionService.class);
 

--- a/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/v1_16/Step26migrateJpaBackend.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/migrate/version/v1_16/Step26migrateJpaBackend.java
@@ -1,25 +1,25 @@
 package org.molgenis.migrate.version.v1_16;
 
+import static java.util.Objects.requireNonNull;
+
+import javax.sql.DataSource;
+
 import org.molgenis.framework.MolgenisUpgrade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
 
-import javax.sql.DataSource;
-
-import static java.util.Objects.requireNonNull;
-
-public class Step27migrateJpaBackend extends MolgenisUpgrade
+public class Step26migrateJpaBackend extends MolgenisUpgrade
 {
 	private final JdbcTemplate template;
-	private final Logger LOG = LoggerFactory.getLogger(Step27migrateJpaBackend.class);
+	private final Logger LOG = LoggerFactory.getLogger(Step26migrateJpaBackend.class);
 	private final String backend;
 
 	@Autowired
-	public Step27migrateJpaBackend(DataSource dataSource, String backend)
+	public Step26migrateJpaBackend(DataSource dataSource, String backend)
 	{
-		super(26, 27);
+		super(25, 26);
 		requireNonNull(dataSource);
 		this.template = new JdbcTemplate(dataSource);
 		this.backend = backend;


### PR DESCRIPTION
- Step 26 was going to be used by the decorator migration, but is not in this release
- Don't forget to decrease the version in molgenis-server.properties if you're at version 27