### PR TITLE
Fix #4355 #3965 #4368 + small vcf import entity/attribute name improvements/checks

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/OptionsWizardPage.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/OptionsWizardPage.java
@@ -73,6 +73,11 @@ public class OptionsWizardPage extends AbstractWizardPage
 			try
 			{
 				MetaValidationUtils.validateName(userGivenName);
+				if (dataService.hasRepository(userGivenName))
+				{
+					result.addError(new ObjectError("wizard", "An entity with this name already exists."));
+					return null;
+				}
 			}
 			catch (MolgenisDataException e)
 			{

--- a/molgenis-data-import/src/main/resources/templates/OptionsWizardPage.ftl
+++ b/molgenis-data-import/src/main/resources/templates/OptionsWizardPage.ftl
@@ -4,6 +4,7 @@
 		<div class="col-md-4">
 			<div class="form-group">
             	<label class="control-label" for="name">Entity name *</label>
+                <i>(Only letters (a-z, A-Z), digits (0-9), underscores (_) and hashes (#) are allowed.)</i>
             	<input type="text" class="form-control" name="name" required placeholder="Enter entity name"
 					   value="${wizard.file.name
 					   ?replace("\\.vcf|\\.vcf\\.gz",'','r') <#-- remove extention -->

--- a/molgenis-data-import/src/main/resources/templates/OptionsWizardPage.ftl
+++ b/molgenis-data-import/src/main/resources/templates/OptionsWizardPage.ftl
@@ -6,11 +6,11 @@
             	<label class="control-label" for="name">Entity name *</label>
             	<input type="text" class="form-control" name="name" required placeholder="Enter entity name"
 					   value="${wizard.file.name
-					   ?keep_before_last(".")
-					   ?js_string[0..*29]
-					   ?replace("\\.|\\*|\\$|\\&|\\%|\\^|\\(|\\)|\\#|\\!|\\@|\\?",'_','r')
-					   ?replace("^[0-9]",'_','r')
-					   }">
+					   ?replace("\\.vcf|\\.vcf\\.gz",'','r') <#-- remove extention -->
+					   ?js_string[0..*21] <#-- maximum length is 30 chars, but we need to take into account that the samples are postfixed "_SAMPLES" -->
+					   ?replace("\\-|\\.|\\*|\\$|\\&|\\%|\\^|\\(|\\)|\\#|\\!|\\@|\\?",'_','r')<#-- remove illegal chars -->
+					   ?replace("^[0-9]",'_','r') <#-- we don't allow entitynames starting with a number -->
+					   }" maxlength="22">
         	</div>
         </div>
     </div>

--- a/molgenis-data-import/src/main/resources/templates/OptionsWizardPage.ftl
+++ b/molgenis-data-import/src/main/resources/templates/OptionsWizardPage.ftl
@@ -7,7 +7,7 @@
                 <i>(Only letters (a-z, A-Z), digits (0-9), underscores (_) and hashes (#) are allowed.)</i>
             	<input type="text" class="form-control" name="name" required placeholder="Enter entity name"
 					   value="${wizard.file.name
-					   ?replace("\\.vcf|\\.vcf\\.gz",'','r') <#-- remove extention -->
+					   ?replace("\\.vcf\\.gz|\\.vcf",'','r') <#-- remove extention -->
 					   ?js_string[0..*21] <#-- maximum length is 30 chars, but we need to take into account that the samples are postfixed "_SAMPLES" -->
 					   ?replace("\\-|\\.|\\*|\\$|\\&|\\%|\\^|\\(|\\)|\\#|\\!|\\@|\\?",'_','r')<#-- remove illegal chars -->
 					   ?replace("^[0-9]",'_','r') <#-- we don't allow entitynames starting with a number -->

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/format/VcfToEntity.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/format/VcfToEntity.java
@@ -79,8 +79,9 @@ public class VcfToEntity
 			result.addAttributeMetaData(nameAttributeMetaData);
 			for (VcfMetaFormat meta : formatMetaData)
 			{
-				AttributeMetaData attributeMetaData = new DefaultAttributeMetaData(meta.getId(),
-						vcfFieldTypeToMolgenisFieldType(meta)).setAggregateable(true);
+				AttributeMetaData attributeMetaData = new DefaultAttributeMetaData(
+						meta.getId().replaceAll("[-.*$&%^()#!@?]", "_"), vcfFieldTypeToMolgenisFieldType(meta))
+								.setAggregateable(true).setLabel(meta.getId());
 				result.addAttributeMetaData(attributeMetaData);
 			}
 		}

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/format/VcfToEntity.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/format/VcfToEntity.java
@@ -82,13 +82,15 @@ public class VcfToEntity
 			for (VcfMetaFormat meta : formatMetaData)
 			{
 				String name = meta.getId();
-				if(MetaValidationUtils.KEYWORDS.contains(name) || MetaValidationUtils.KEYWORDS.contains(name.toUpperCase())){
+				if (MetaValidationUtils.KEYWORDS.contains(name)
+						|| MetaValidationUtils.KEYWORDS.contains(name.toUpperCase()))
+				{
 					name = name + "_";
 				}
 				AttributeMetaData attributeMetaData = new DefaultAttributeMetaData(
 						name.replaceAll("[-.*$&%^()#!@?]", "_"), vcfFieldTypeToMolgenisFieldType(meta))
 								.setAggregateable(true).setLabel(meta.getId());
-				
+
 				result.addAttributeMetaData(attributeMetaData);
 			}
 		}
@@ -124,7 +126,13 @@ public class VcfToEntity
 					postFix = "_" + entityName;
 				}
 			}
-			DefaultAttributeMetaData attributeMetaData = new DefaultAttributeMetaData(info.getId() + postFix,
+			String name = info.getId();
+			if (MetaValidationUtils.KEYWORDS.contains(name)
+					|| MetaValidationUtils.KEYWORDS.contains(name.toUpperCase()))
+			{
+				name = name + "_";
+			}
+			DefaultAttributeMetaData attributeMetaData = new DefaultAttributeMetaData(name + postFix,
 					vcfReaderFormatToMolgenisType(info)).setAggregateable(true);
 
 			attributeMetaData.setDescription(StringUtils.isBlank(info.getDescription())

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/format/VcfToEntity.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/format/VcfToEntity.java
@@ -24,6 +24,7 @@ import static org.molgenis.data.vcf.VcfRepository.SAMPLES;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.molgenis.MolgenisFieldTypes;
@@ -31,6 +32,7 @@ import org.molgenis.data.AttributeMetaData;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.MolgenisDataException;
+import org.molgenis.data.meta.MetaValidationUtils;
 import org.molgenis.data.support.DefaultAttributeMetaData;
 import org.molgenis.data.support.DefaultEntityMetaData;
 import org.molgenis.data.support.MapEntity;
@@ -79,9 +81,14 @@ public class VcfToEntity
 			result.addAttributeMetaData(nameAttributeMetaData);
 			for (VcfMetaFormat meta : formatMetaData)
 			{
+				String name = meta.getId();
+				if(MetaValidationUtils.KEYWORDS.contains(name) || MetaValidationUtils.KEYWORDS.contains(name.toUpperCase())){
+					name = name + "_";
+				}
 				AttributeMetaData attributeMetaData = new DefaultAttributeMetaData(
-						meta.getId().replaceAll("[-.*$&%^()#!@?]", "_"), vcfFieldTypeToMolgenisFieldType(meta))
+						name.replaceAll("[-.*$&%^()#!@?]", "_"), vcfFieldTypeToMolgenisFieldType(meta))
 								.setAggregateable(true).setLabel(meta.getId());
+				
 				result.addAttributeMetaData(attributeMetaData);
 			}
 		}


### PR DESCRIPTION
improvements:
- replaces illegal column names in Sample and INFO fields, leaving the label the same as the name in the file
- limits the entityname taking into account the postfix "_SAMPLES"
- generates a default name based on both ".vcf" and ".vcf.gz" (was only working for ".vcf")
- adds replacing "-" in the default entity name, this one was missing from the regex.
- checks for exisiting entities with the same name, showing an meaningful message