### PR TITLE
[1.16] Fix #4412 Cannot delete all OntologyTerm entities

### DIFF
--- a/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
+++ b/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
@@ -1071,7 +1071,8 @@ public class MysqlRepository extends AbstractRepository
 	{
 		Stream<AttributeMetaData> selfReferencingAttrs = StreamSupport
 				.stream(getEntityMetaData().getAtomicAttributes().spliterator(), false)
-				.filter(attr -> attr.getDataType() instanceof XrefField);
+				.filter(attr -> attr.getDataType() instanceof XrefField
+						&& attr.getRefEntity().getName().equals(getEntityMetaData().getName()));
 
 		selfReferencingAttrs.forEach(selfReferencingXrefAttr -> {
 			if (!selfReferencingXrefAttr.isNillable())


### PR DESCRIPTION
Bug prevented any entity with xref fields to have its data deleted