### PR TITLE
Data API stream with fetch operation

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/EntityListenerRepositoryDecorator.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/EntityListenerRepositoryDecorator.java
@@ -37,6 +37,12 @@ public class EntityListenerRepositoryDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decoratedRepository.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decoratedRepository.close();

--- a/molgenis-core-ui/src/test/java/org/molgenis/ui/EntityListenerRepositoryDecoratorTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/ui/EntityListenerRepositoryDecoratorTest.java
@@ -251,4 +251,12 @@ public class EntityListenerRepositoryDecoratorTest
 		Stream<Entity> entities = entityListenerRepositoryDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		entityListenerRepositoryDecorator.stream(fetch);
+		verify(decoratedRepository, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/AbstractElasticsearchRepository.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/AbstractElasticsearchRepository.java
@@ -106,7 +106,15 @@ public abstract class AbstractElasticsearchRepository implements Repository
 	@Override
 	public Iterator<Entity> iterator()
 	{
-		return findAll(new QueryImpl()).iterator();
+		Query q = new QueryImpl();
+		return elasticSearchService.searchAsStream(q, getEntityMetaData()).iterator();
+	}
+
+	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		Query q = new QueryImpl().fetch(fetch);
+		return elasticSearchService.searchAsStream(q, getEntityMetaData());
 	}
 
 	@Override

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecorator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecorator.java
@@ -199,6 +199,21 @@ public class ElasticsearchRepositoryDecorator extends AbstractElasticsearchRepos
 	@Override
 	public Stream<Entity> findAll(Query q)
 	{
+		// optimization:
+		// retrieve entities via decorated repository in case query contains no query rules
+		List<QueryRule> queryRules = q.getRules();
+		if (queryRules != null && queryRules.isEmpty())
+		{
+			Fetch fetch = q.getFetch();
+			if (fetch != null)
+			{
+				return decoratedRepo.stream(fetch);
+			}
+			else
+			{
+				return decoratedRepo.stream();
+			}
+		}
 		return super.findAll(q);
 	}
 
@@ -207,6 +222,12 @@ public class ElasticsearchRepositoryDecorator extends AbstractElasticsearchRepos
 	public Iterator<Entity> iterator()
 	{
 		return decoratedRepo.iterator();
+	}
+
+	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decoratedRepo.stream(fetch);
 	}
 
 	@Override

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/AbstractElasticsearchRepositoryTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/AbstractElasticsearchRepositoryTest.java
@@ -20,6 +20,7 @@ import org.molgenis.data.EntityMetaData;
 import org.molgenis.data.Fetch;
 import org.molgenis.data.Query;
 import org.molgenis.data.elasticsearch.ElasticsearchService.IndexingMode;
+import org.molgenis.data.support.QueryImpl;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -164,5 +165,17 @@ public class AbstractElasticsearchRepositoryTest
 		when(searchService.searchAsStream(query, entityMeta)).thenReturn(Stream.of(entity0));
 		Stream<Entity> entities = repository.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
+	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		Entity entity0 = mock(Entity.class);
+		Entity entity1 = mock(Entity.class);
+		when(searchService.searchAsStream(new QueryImpl().fetch(fetch), entityMeta))
+				.thenReturn(Stream.of(entity0, entity1));
+		Stream<Entity> expectedEntities = repository.stream(fetch);
+		assertEquals(expectedEntities.collect(Collectors.toList()), Arrays.asList(entity0, entity1));
 	}
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecoratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticsearchRepositoryDecoratorTest.java
@@ -331,4 +331,12 @@ public class ElasticsearchRepositoryDecoratorTest
 		Stream<Entity> expectedEntities = elasticsearchRepositoryDecorator.findAll(entityIds, fetch);
 		assertEquals(expectedEntities.collect(Collectors.toList()), Arrays.asList(entity0, entity1));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		elasticsearchRepositoryDecorator.stream(fetch);
+		verify(decoratedRepo, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/RepositoryValidationDecorator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/RepositoryValidationDecorator.java
@@ -134,6 +134,12 @@ public class RepositoryValidationDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decoratedRepository.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decoratedRepository.close();

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/RepositoryValidationDecoratorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/RepositoryValidationDecoratorTest.java
@@ -4560,4 +4560,12 @@ public class RepositoryValidationDecoratorTest
 		Stream<Entity> entities = repositoryValidationDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		repositoryValidationDecorator.stream(fetch);
+		verify(decoratedRepo, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/auth/MolgenisUserDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/auth/MolgenisUserDecorator.java
@@ -1,5 +1,12 @@
 package org.molgenis.auth;
 
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Stream;
+
 import org.molgenis.data.AggregateQuery;
 import org.molgenis.data.AggregateResult;
 import org.molgenis.data.DataService;
@@ -16,13 +23,6 @@ import org.molgenis.util.ApplicationContextProvider;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextException;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.io.IOException;
-import java.util.Iterator;
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
 
 public class MolgenisUserDecorator implements Repository
 {
@@ -194,6 +194,12 @@ public class MolgenisUserDecorator implements Repository
 	public Iterator<Entity> iterator()
 	{
 		return decoratedRepository.iterator();
+	}
+
+	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decoratedRepository.stream(fetch);
 	}
 
 	@Override

--- a/molgenis-data/src/main/java/org/molgenis/data/AutoValueRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/AutoValueRepositoryDecorator.java
@@ -68,6 +68,12 @@ public class AutoValueRepositoryDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decoratedRepository.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decoratedRepository.close();

--- a/molgenis-data/src/main/java/org/molgenis/data/ComputedEntityValuesDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ComputedEntityValuesDecorator.java
@@ -86,6 +86,14 @@ public class ComputedEntityValuesDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		Stream<Entity> entities = decoratedRepo.stream(fetch);
+		// compute values with attributes with expressions
+		return toComputedValuesEntities(entities);
+	}
+
+	@Override
 	public Entity findOne(Object id)
 	{
 		Entity entity = decoratedRepo.findOne(id);

--- a/molgenis-data/src/main/java/org/molgenis/data/DataService.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DataService.java
@@ -21,6 +21,31 @@ public interface DataService extends Iterable<Repository>
 		return StreamSupport.stream(spliterator(), false);
 	}
 
+	/**
+	 * Streams the {@link Entity}s
+	 * 
+	 * @param entityName
+	 *            entity name (case insensitive)
+	 * @param fetch
+	 *            fetch defining which attributes to retrieve
+	 * @return Stream of all entities
+	 */
+	Stream<Entity> stream(String entityName, Fetch fetch);
+
+	/**
+	 * Streams the {@link Entity}s
+	 * 
+	 * @param entityName
+	 *            entity name (case insensitive)
+	 * @param fetch
+	 *            fetch defining which attributes to retrieve
+	 * @param clazz
+	 *            typed entity class
+	 * 
+	 * @return Stream of all entities of the give type
+	 */
+	<E extends Entity> Stream<E> stream(String entityName, Fetch fetch, Class<E> clazz);
+
 	void setMeta(MetaDataService metaDataService);
 
 	/**

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityReferenceResolverDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityReferenceResolverDecorator.java
@@ -88,6 +88,14 @@ public class EntityReferenceResolverDecorator implements Repository
 
 	// Resolve entity references
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		Stream<Entity> entities = decoratedRepo.stream(fetch);
+		return resolveEntityReferences(entities, fetch);
+	}
+
+	// Resolve entity references
+	@Override
 	public Entity findOne(Object id)
 	{
 		Entity entity = decoratedRepo.findOne(id);

--- a/molgenis-data/src/main/java/org/molgenis/data/Repository.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/Repository.java
@@ -18,6 +18,15 @@ public interface Repository extends Iterable<Entity>, Closeable
 		return StreamSupport.stream(spliterator(), false);
 	}
 
+	/**
+	 * Streams the {@link Entity}s
+	 * 
+	 * @param fetch
+	 *            fetch defining which attributes to retrieve
+	 * @return Stream of all entities
+	 */
+	Stream<Entity> stream(Fetch fetch);
+
 	Set<RepositoryCapability> getCapabilities();
 
 	String getName();

--- a/molgenis-data/src/main/java/org/molgenis/data/RepositorySecurityDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/RepositorySecurityDecorator.java
@@ -34,6 +34,13 @@ public class RepositorySecurityDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		validatePermission(decoratedRepository.getName(), Permission.READ);
+		return decoratedRepository.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		validatePermission(decoratedRepository.getName(), Permission.WRITE);

--- a/molgenis-data/src/main/java/org/molgenis/data/i18n/I18nStringDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/i18n/I18nStringDecorator.java
@@ -37,6 +37,12 @@ public class I18nStringDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decorated.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decorated.close();
@@ -229,5 +235,4 @@ public class I18nStringDecorator implements Repository
 	{
 		decorated.removeEntityListener(entityListener);
 	}
-
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/i18n/LanguageRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/i18n/LanguageRepositoryDecorator.java
@@ -40,6 +40,12 @@ public class LanguageRepositoryDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decorated.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decorated.close();

--- a/molgenis-data/src/main/java/org/molgenis/data/mem/InMemoryRepository.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/mem/InMemoryRepository.java
@@ -58,6 +58,12 @@ public class InMemoryRepository implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return entities.values().stream();
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataRepositoryDecorator.java
@@ -37,6 +37,12 @@ public class MetaDataRepositoryDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decorated.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decorated.close();
@@ -218,5 +224,4 @@ public class MetaDataRepositoryDecorator implements Repository
 	{
 		decorated.removeEntityListener(entityListener);
 	}
-
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/support/AbstractRepository.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/AbstractRepository.java
@@ -112,7 +112,7 @@ public abstract class AbstractRepository implements Repository
 	private Iterable<Entity> findAllBatched(List<Object> ids, Fetch fetch)
 	{
 		String fieldIdAttributeName = getEntityMetaData().getIdAttribute().getName();
-		if(fetch != null) fetch.field(fieldIdAttributeName);
+		if (fetch != null) fetch.field(fieldIdAttributeName);
 		Query inQuery = new QueryImpl().in(fieldIdAttributeName, Sets.newHashSet(ids)).fetch(fetch);
 		Map<Object, Entity> indexedEntities = uniqueIndex(findAll(inQuery).iterator(), Entity::getIdValue);
 		return filter(transform(ids, id -> lookup(indexedEntities, id)), notNull());
@@ -126,6 +126,13 @@ public abstract class AbstractRepository implements Repository
 			LOG.warn("Lookup: Couldn't find {} for id {}.", getName(), id);
 		}
 		return result;
+	}
+
+	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		// default action: ignore fetch
+		return stream();
 	}
 
 	@Override

--- a/molgenis-data/src/main/java/org/molgenis/data/support/DataServiceImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/DataServiceImpl.java
@@ -276,6 +276,21 @@ public class DataServiceImpl implements DataService
 	}
 
 	@Override
+	public Stream<Entity> stream(String entityName, Fetch fetch)
+	{
+		return getRepository(entityName).stream(fetch);
+	}
+
+	@Override
+	public <E extends Entity> Stream<E> stream(String entityName, Fetch fetch, Class<E> clazz)
+	{
+		Stream<Entity> entities = getRepository(entityName).stream(fetch);
+		return entities.map(entity -> {
+			return EntityUtils.convert(entity, clazz, this);
+		});
+	}
+
+	@Override
 	public Set<RepositoryCapability> getCapabilities(String repositoryName)
 	{
 		return getRepository(repositoryName).getCapabilities();

--- a/molgenis-data/src/main/java/org/molgenis/data/transaction/TransactionLogRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/transaction/TransactionLogRepositoryDecorator.java
@@ -35,6 +35,12 @@ public class TransactionLogRepositoryDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decorated.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decorated.close();

--- a/molgenis-data/src/main/java/org/molgenis/util/MySqlRepositoryExceptionTranslatorDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/util/MySqlRepositoryExceptionTranslatorDecorator.java
@@ -194,6 +194,12 @@ public class MySqlRepositoryExceptionTranslatorDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		return decoratedRepo.stream(fetch);
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decoratedRepo.close();

--- a/molgenis-data/src/test/java/org/molgenis/data/AutoValueRepositoryDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/AutoValueRepositoryDecoratorTest.java
@@ -154,6 +154,14 @@ public class AutoValueRepositoryDecoratorTest
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
 
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		repositoryDecorator.stream(fetch);
+		verify(decoratedRepository, times(1)).stream(fetch);
+	}
+
 	private void validateEntity(Entity entity)
 	{
 		assertNull(entity.getDate(ATTR_DATE_AUTO_DEFAULT));

--- a/molgenis-data/src/test/java/org/molgenis/data/ComputedEntityValuesDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/ComputedEntityValuesDecoratorTest.java
@@ -173,9 +173,46 @@ public class ComputedEntityValuesDecoratorTest
 		when(entity0.getEntityMetaData()).thenReturn(entityMeta);
 		Query query = mock(Query.class);
 		when(decoratedRepo.findAll(query)).thenReturn(Stream.of(entity0));
-		List<Entity> expectedEntities = computedEntityValuesDecorator.findAll(query)
-				.collect(Collectors.toList());
+		List<Entity> expectedEntities = computedEntityValuesDecorator.findAll(query).collect(Collectors.toList());
 		assertEquals(expectedEntities.size(), 1);
 		assertEquals(expectedEntities.get(0).getClass(), EntityWithComputedAttributes.class);
+	}
+
+	@Test
+	public void streamFetchNoComputedAttrs()
+	{
+		Fetch fetch = new Fetch();
+		EntityMetaData entityMeta = mock(EntityMetaData.class);
+		when(entityMeta.hasAttributeWithExpression()).thenReturn(false);
+		when(entityMeta.getAtomicAttributes()).thenReturn(emptyList());
+		when(decoratedRepo.getEntityMetaData()).thenReturn(entityMeta);
+
+		Entity entity0 = mock(Entity.class);
+		when(entity0.getEntityMetaData()).thenReturn(entityMeta);
+		Entity entity1 = mock(Entity.class);
+		when(entity1.getEntityMetaData()).thenReturn(entityMeta);
+		when(decoratedRepo.stream(fetch)).thenReturn(Stream.of(entity0, entity1));
+		Stream<Entity> expectedEntities = computedEntityValuesDecorator.stream(fetch);
+		assertEquals(expectedEntities.collect(Collectors.toList()), Arrays.asList(entity0, entity1));
+	}
+
+	@Test
+	public void streamFetchComputedAttrs()
+	{
+		EntityMetaData entityMeta = mock(EntityMetaData.class);
+		when(entityMeta.hasAttributeWithExpression()).thenReturn(true);
+		when(entityMeta.getAtomicAttributes()).thenReturn(emptyList());
+		when(decoratedRepo.getEntityMetaData()).thenReturn(entityMeta);
+
+		Fetch fetch = new Fetch();
+		Entity entity0 = mock(Entity.class);
+		when(entity0.getEntityMetaData()).thenReturn(entityMeta);
+		Entity entity1 = mock(Entity.class);
+		when(entity1.getEntityMetaData()).thenReturn(entityMeta);
+		when(decoratedRepo.stream(fetch)).thenReturn(Stream.of(entity0, entity1));
+		List<Entity> expectedEntities = computedEntityValuesDecorator.stream(fetch).collect(Collectors.toList());
+		assertEquals(expectedEntities.size(), 2);
+		assertEquals(expectedEntities.get(0).getClass(), EntityWithComputedAttributes.class);
+		assertEquals(expectedEntities.get(1).getClass(), EntityWithComputedAttributes.class);
 	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/DataServiceImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/DataServiceImplTest.java
@@ -33,7 +33,6 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.util.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -281,7 +280,7 @@ public class DataServiceImplTest
 	@Test
 	public void copyRepository()
 	{
-		//setup everything
+		// setup everything
 		Query query = new QueryImpl();
 		AttributeMetaData attr1 = new DefaultAttributeMetaData("attr1", MolgenisFieldTypes.FieldTypeEnum.STRING);
 		AttributeMetaData attr2 = new DefaultAttributeMetaData("attr2", MolgenisFieldTypes.FieldTypeEnum.STRING);
@@ -302,15 +301,37 @@ public class DataServiceImplTest
 		when(repo2.getEntityMetaData()).thenReturn(emd2);
 		when(metaDataService.addEntityMeta(emd2)).thenReturn(repo2);
 
-		//The actual method call
+		// The actual method call
 		Repository copy = dataService.copyRepository(repo1, "Entity2", "testCopyLabel");
 
-		//The test
+		// The test
 		verify(metaDataService).addEntityMeta(copy.getEntityMetaData());
+		@SuppressWarnings(
+		{ "unchecked", "rawtypes" })
 		ArgumentCaptor<Stream<Entity>> argument = ArgumentCaptor.forClass((Class) Stream.class);
 		verify(repo2, times(1)).add(argument.capture());
 		List<Entity> list = argument.getAllValues().get(0).collect(toList());
 		assertEquals(list, Arrays.asList(entity0, entity1));
 	}
 
+	@Test
+	public void streamStringFetch()
+	{
+		Entity entity0 = mock(Entity.class);
+		Fetch fetch = new Fetch();
+		when(repo1.stream(fetch)).thenReturn(Stream.of(entity0));
+		Stream<Entity> entities = dataService.stream("Entity1", fetch);
+		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
+	}
+
+	@Test
+	public void streamStringFetchClass()
+	{
+		Entity entity0 = mock(Entity.class);
+		Class<Entity> clazz = Entity.class;
+		Fetch fetch = new Fetch();
+		when(repo1.stream(fetch)).thenReturn(Stream.of(entity0));
+		Stream<Entity> entities = dataService.stream("Entity1", fetch, clazz);
+		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
+	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/EntityReferenceResolverDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/EntityReferenceResolverDecoratorTest.java
@@ -227,6 +227,22 @@ public class EntityReferenceResolverDecoratorTest
 	}
 
 	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		Entity entity0 = mock(Entity.class);
+		Entity entity1 = mock(Entity.class);
+		Entity entity0WithRefs = mock(Entity.class);
+		Entity entity1WithRefs = mock(Entity.class);
+		Stream<Entity> entities = Stream.of(entity0, entity1);
+		when(decoratedRepo.stream(fetch)).thenReturn(entities);
+		when(entityManager.resolveReferences(entityMeta, entities, fetch))
+				.thenReturn(Stream.of(entity0WithRefs, entity1WithRefs));
+		Stream<Entity> expectedEntities = entityReferenceResolverDecorator.stream(fetch);
+		assertEquals(expectedEntities.collect(Collectors.toList()), Arrays.asList(entity0WithRefs, entity1WithRefs));
+	}
+
+	@Test
 	public void findOneQueryFetchEntity()
 	{
 		Fetch fetch = new Fetch();

--- a/molgenis-data/src/test/java/org/molgenis/data/RepositorySecurityDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/RepositorySecurityDecoratorTest.java
@@ -373,4 +373,34 @@ public class RepositorySecurityDecoratorTest
 		Stream<Entity> entities = repositorySecurityDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", null,
+				"ROLE_ENTITY_READ_" + entityName.toUpperCase());
+		authentication.setAuthenticated(false);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Fetch fetch = new Fetch();
+		Entity entity0 = mock(Entity.class);
+		Entity entity1 = mock(Entity.class);
+		when(decoratedRepository.stream(fetch)).thenReturn(Stream.of(entity0, entity1));
+		Stream<Entity> expectedEntities = repositorySecurityDecorator.stream(fetch);
+		assertEquals(expectedEntities.collect(Collectors.toList()), Arrays.asList(entity0, entity1));
+	}
+
+	@Test(expectedExceptions = MolgenisDataAccessException.class)
+	public void streamFetchNoPermission()
+	{
+		TestingAuthenticationToken authentication = new TestingAuthenticationToken("username", null);
+		authentication.setAuthenticated(false);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		Fetch fetch = new Fetch();
+		Entity entity0 = mock(Entity.class);
+		Entity entity1 = mock(Entity.class);
+		when(decoratedRepository.stream(fetch)).thenReturn(Stream.of(entity0, entity1));
+		repositorySecurityDecorator.stream(fetch);
+	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/i18n/I18nStringDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/i18n/I18nStringDecoratorTest.java
@@ -96,4 +96,12 @@ public class I18nStringDecoratorTest
 		Stream<Entity> entities = i18nStringDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		i18nStringDecorator.stream(fetch);
+		verify(decoratedRepo, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/i18n/LanguageRepositoryDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/i18n/LanguageRepositoryDecoratorTest.java
@@ -123,4 +123,12 @@ public class LanguageRepositoryDecoratorTest
 		Stream<Entity> entities = languageRepositoryDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		languageRepositoryDecorator.stream(fetch);
+		verify(decoratedRepo, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/mem/InMemoryRepositoryTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/mem/InMemoryRepositoryTest.java
@@ -270,4 +270,30 @@ public class InMemoryRepositoryTest
 			inMemoryRepository.close();
 		}
 	}
+
+	@Test
+	public void streamFetch() throws IOException
+	{
+		String idAttrName = "id";
+		EntityMetaData entityMeta = mock(EntityMetaData.class);
+		AttributeMetaData idAttr = when(mock(AttributeMetaData.class).getName()).thenReturn(idAttrName).getMock();
+		when(entityMeta.getIdAttribute()).thenReturn(idAttr);
+		InMemoryRepository inMemoryRepository = new InMemoryRepository(entityMeta);
+		try
+		{
+			Object id0 = Integer.valueOf(0);
+			Entity entity0 = when(mock(Entity.class).get(idAttrName)).thenReturn(id0).getMock();
+			Object id1 = Integer.valueOf(1);
+			Entity entity1 = when(mock(Entity.class).get(idAttrName)).thenReturn(id1).getMock();
+			inMemoryRepository.add(entity0);
+			inMemoryRepository.add(entity1);
+			Fetch fetch = new Fetch();
+			List<Entity> entities = inMemoryRepository.stream(fetch).collect(Collectors.toList());
+			assertEquals(Lists.newArrayList(entities), Arrays.asList(entity0, entity1));
+		}
+		finally
+		{
+			inMemoryRepository.close();
+		}
+	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/MetaDataRepositoryDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/MetaDataRepositoryDecoratorTest.java
@@ -1,6 +1,8 @@
 package org.molgenis.data.meta;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.RepositoryCapability.INDEXABLE;
 import static org.molgenis.data.RepositoryCapability.MANAGABLE;
@@ -9,21 +11,38 @@ import static org.molgenis.data.RepositoryCapability.WRITABLE;
 import static org.testng.Assert.assertEquals;
 
 import org.apache.commons.io.IOUtils;
+import org.molgenis.data.Fetch;
 import org.molgenis.data.Repository;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Sets;
 
 public class MetaDataRepositoryDecoratorTest
 {
+	private Repository repo;
+	private Repository decorator;
+
+	@BeforeMethod
+	public void setUpBeforeMethod()
+	{
+		repo = mock(Repository.class);
+		decorator = new MetaDataRepositoryDecorator(repo);
+	}
 
 	@Test
 	public void getCapabilities()
 	{
-		Repository repo = mock(Repository.class);
 		when(repo.getCapabilities()).thenReturn(Sets.newHashSet(INDEXABLE, QUERYABLE, WRITABLE, MANAGABLE));
-		Repository decorator = new MetaDataRepositoryDecorator(repo);
 		assertEquals(decorator.getCapabilities(), Sets.newHashSet(INDEXABLE, QUERYABLE));
 		IOUtils.closeQuietly(decorator);
+	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		decorator.stream(fetch);
+		verify(repo, times(1)).stream(fetch);
 	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/support/AbstractRepositoryTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/support/AbstractRepositoryTest.java
@@ -117,4 +117,6 @@ public class AbstractRepositoryTest
 		Stream<Entity> expectedEntities = abstractRepository.findAll(entityIds, fetch);
 		assertEquals(expectedEntities.collect(Collectors.toList()), Arrays.asList(entity0, entity1));
 	}
+
+	// Note: streamFetch cannot be tested because mocking default methods is not supported by Mockito
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/transaction/TransactionLogRepositoryDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/transaction/TransactionLogRepositoryDecoratorTest.java
@@ -156,4 +156,12 @@ public class TransactionLogRepositoryDecoratorTest
 		Stream<Entity> entities = transactionLogRepositoryDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		transactionLogRepositoryDecorator.stream(fetch);
+		verify(decoratedRepo, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/util/MySqlRepositoryExceptionTranslatorDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/util/MySqlRepositoryExceptionTranslatorDecoratorTest.java
@@ -170,4 +170,12 @@ public class MySqlRepositoryExceptionTranslatorDecoratorTest
 		Stream<Entity> entities = decorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
 	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		decorator.stream(fetch);
+		verify(decoratedRepo, times(1)).stream(fetch);
+	}
 }

--- a/molgenis-security/src/main/java/org/molgenis/security/owned/OwnedEntityRepositoryDecorator.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/owned/OwnedEntityRepositoryDecorator.java
@@ -46,6 +46,21 @@ public class OwnedEntityRepositoryDecorator implements Repository
 	}
 
 	@Override
+	public Stream<Entity> stream(Fetch fetch)
+	{
+		if (fetch != null)
+		{
+			fetch.field(OwnedEntityMetaData.ATTR_OWNER_USERNAME);
+		}
+		Stream<Entity> entities = decoratedRepo.stream(fetch);
+		if (mustAddRowLevelSecurity())
+		{
+			entities = entities.filter(this::currentUserIsOwner);
+		}
+		return entities;
+	}
+
+	@Override
 	public void close() throws IOException
 	{
 		decoratedRepo.close();

--- a/molgenis-security/src/test/java/org/molgenis/security/user/MolgenisUserDecoratorTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/user/MolgenisUserDecoratorTest.java
@@ -133,7 +133,7 @@ public class MolgenisUserDecoratorTest
 		molgenisUserDecorator.add(entity);
 		verify(passwordEncoder).encode(password);
 		verify(decoratedRepository).add(entity);
-		//verify(userAuthorityRepository, times(1)).add(any(UserAuthority.class));
+		// verify(userAuthorityRepository, times(1)).add(any(UserAuthority.class));
 	}
 
 	@Test
@@ -180,5 +180,13 @@ public class MolgenisUserDecoratorTest
 		when(decoratedRepository.findAll(query)).thenReturn(Stream.of(entity0));
 		Stream<Entity> entities = molgenisUserDecorator.findAll(query);
 		assertEquals(entities.collect(Collectors.toList()), Arrays.asList(entity0));
+	}
+
+	@Test
+	public void streamFetch()
+	{
+		Fetch fetch = new Fetch();
+		molgenisUserDecorator.stream(fetch);
+		verify(decoratedRepository, times(1)).stream(fetch);
 	}
 }


### PR DESCRIPTION
- Data API stream with fetch operation
- Elasticsearch repository decorator optimization that forwards call to stream with fetch for queries with no rules and only a fetch
- This optimization serves as partial workaround for #4478 Searching transactional index missing results