### PR TITLE
Remove unused molgenis-data dependencies

### DIFF
--- a/molgenis-data/pom.xml
+++ b/molgenis-data/pom.xml
@@ -23,11 +23,6 @@
             <artifactId>spring-orm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.persistence</groupId>
-            <artifactId>javax.persistence</artifactId>
-            <version>2.1.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>
@@ -51,16 +46,6 @@
 			<groupId>com.google.auto.value</groupId>
 			<artifactId>auto-value</artifactId>
 			<version>1.0</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>4.1.8.RELEASE</version>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework</groupId>
-			<artifactId>spring-webmvc</artifactId>
-			<version>4.1.8.RELEASE</version>
 		</dependency>
 	</dependencies>
 </project>


### PR DESCRIPTION
- Reimporting the maven project in Eclipse after this fix will remove the JPA facet from projects which significantly improves Eclipse performance