### PR TITLE
Fix #4598 add *.vcf.zip support

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportWizardController.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportWizardController.java
@@ -418,7 +418,7 @@ public class ImportWizardController extends AbstractWizardController
 		else
 		{
 			filename = entityName + "." + extension;
-			if (!extension.equals("vcf") && (!extension.equals("vcf.gz")))
+			if (!extension.equals("vcf") && (!extension.equals("vcf.gz")&&(!extension.equals("vcf.zip"))))
 				LOG.warn("Specifing a filename for a non-VCF file has no effect on entity names.");
 		}
 		return filename;
@@ -465,7 +465,7 @@ public class ImportWizardController extends AbstractWizardController
 		String extension = FileExtensionUtils.findExtensionFromPossibilities(file.getName(),
 				GenericImporterExtensions.getAll());
 
-		if (extension.equals("vcf") || extension.equals("vcf.gz"))
+		if (extension.equals("vcf") || extension.equals("vcf.gz") || extension.equals("vcf.zip"))
 		{
 			MetaValidationUtils.validateName(file.getName().replace("." + extension, ""));
 			if (!DatabaseAction.ADD.equals(databaseAction))

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/VcfReaderFactoryImpl.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/VcfReaderFactoryImpl.java
@@ -9,7 +9,10 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 import java.util.List;
+import java.util.Enumeration;
 import java.util.zip.GZIPInputStream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.molgenis.data.MolgenisDataException;
 import org.molgenis.vcf.VcfReader;
@@ -41,6 +44,13 @@ public class VcfReaderFactoryImpl implements VcfReaderFactory
 			if (file.getName().endsWith(".gz"))
 			{
 				inputStream = new GZIPInputStream(inputStream);
+			} 
+			else if (file.getName().endsWith(".zip"))
+			{
+				   ZipFile zipFile = new ZipFile(file.getPath());
+				   Enumeration<? extends ZipEntry> e = zipFile.entries();
+				   ZipEntry entry = (ZipEntry) e.nextElement(); // your only file
+				   inputStream = zipFile.getInputStream(entry);
 			}
 			VcfReader reader = new VcfReader(new InputStreamReader(inputStream, Charset.forName("UTF-8")));
 			// register reader so close() can close all readers

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/VcfRepositoryCollection.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/VcfRepositoryCollection.java
@@ -18,7 +18,8 @@ public class VcfRepositoryCollection extends FileRepositoryCollection
 	public static final String NAME = "VCF";
 	private static final String EXTENSION_VCF = "vcf";
 	private static final String EXTENSION_VCF_GZ = "vcf.gz";
-	static final Set<String> EXTENSIONS = ImmutableSet.of(EXTENSION_VCF, EXTENSION_VCF_GZ);
+	private static final String EXTENSION_VCF_ZIP = "vcf.zip";
+	static final Set<String> EXTENSIONS = ImmutableSet.of(EXTENSION_VCF, EXTENSION_VCF_GZ, EXTENSION_VCF_ZIP);
 
 	private final File file;
 	private final String entityName;
@@ -37,6 +38,10 @@ public class VcfRepositoryCollection extends FileRepositoryCollection
 		else if (name.endsWith(EXTENSION_VCF_GZ))
 		{
 			this.entityName = name.substring(0, name.lastIndexOf('.' + EXTENSION_VCF_GZ));
+		}
+		else if (name.endsWith(EXTENSION_VCF_ZIP)) 
+		{
+			this.entityName = name.substring(0, name.lastIndexOf('.' + EXTENSION_VCF_ZIP));
 		}
 		else
 		{

--- a/molgenis-data/src/main/java/org/molgenis/data/support/GenericImporterExtensions.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/GenericImporterExtensions.java
@@ -16,7 +16,7 @@ public enum GenericImporterExtensions
 	OBO_ZIP("obo.zip"), OWL_ZIP("owl.zip"),
 
 	// VCF
-	VCF("vcf"), VCF_GZ("vcf.gz");
+	VCF("vcf"), VCF_GZ("vcf.gz"), VCF_ZIP("vcf.zip");
 
 	private String name;
 
@@ -48,7 +48,7 @@ public enum GenericImporterExtensions
 
 	public static Set<String> getVCF()
 	{
-		return ImmutableSet.of(VCF.toString(), VCF_GZ.toString());
+		return ImmutableSet.of(VCF.toString(), VCF_GZ.toString(), VCF_ZIP.toString());
 	}
 
 	public static Set<String> getJPA()
@@ -64,6 +64,6 @@ public enum GenericImporterExtensions
 	public static Set<String> getAll()
 	{
 		return ImmutableSet.of(CSV.toString(), TXT.toString(), TSV.toString(), ZIP.toString(), XLS.toString(),
-				XLSX.toString(), OBO_ZIP.toString(), OWL_ZIP.toString(), VCF.toString(), VCF_GZ.toString());
+				XLSX.toString(), OBO_ZIP.toString(), OWL_ZIP.toString(), VCF.toString(), VCF_GZ.toString(), VCF_ZIP.toString());
 	}
 }


### PR DESCRIPTION
This change support the file format .vcf.zip (one file in zip only). Which means a zipped vcf file will be accepted. Before this fix the .vcf.zip file will cause import failed. 