### PR TITLE
Fix #4413 Menu overlaps top of page content

### DIFF
--- a/molgenis-core-ui/src/main/resources/css/molgenis.css
+++ b/molgenis-core-ui/src/main/resources/css/molgenis.css
@@ -177,7 +177,7 @@ body {
 }
 
 /* Change threshold for collapsing the menu, default is 768px*/
-@media (max-width: 768px) {
+@media (max-width: 1127px) {
     .navbar-toggle {
         display: block;
     }

--- a/molgenis-core-ui/src/main/resources/css/molgenis.css
+++ b/molgenis-core-ui/src/main/resources/css/molgenis.css
@@ -175,3 +175,28 @@ body {
 	padding: 7px 0px;
 	height: 26px;
 }
+
+/* Change threshold for collapsing the menu, default is 768px*/
+@media (max-width: 768px) {
+    .navbar-toggle {
+        display: block;
+    }
+    .navbar-collapse.collapse {
+        display: none!important;
+    }
+    .navbar-header {
+        float: none;
+    }
+    .navbar-nav {
+        float: none!important;
+    }
+    .navbar-nav>li {
+        float: none!important;
+    }
+    .navbar-collapse.collapse.in { 
+        display: block!important;
+    }
+    .collapsing {
+        overflow: hidden!important;
+    }
+}


### PR DESCRIPTION
Added some lines to molgenis.css.
The current threshold of the menu to collapse is 768px.
With this addition the user can change this threshold by altering one value (@media (max-width: 768px)) of Molgenis.css.
