### PR TITLE
Fix #4586 GoNL annotator writes non-standard separators and missing values

### DIFF
--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/GoNLAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/GoNLAnnotator.java
@@ -154,12 +154,12 @@ public class GoNLAnnotator
 					if (!Iterables.all(alleleMatches, Predicates.isNull()))
 					{
 						afs = alleleMatches.stream()
-								.map(gonl -> gonl == null ? ""
+								.map(gonl -> gonl == null ? "."
 										: Double.toString(gonl.getDouble(INFO_AC) / gonl.getDouble(INFO_AN)))
-								.collect(Collectors.joining("|"));
-
-						gtcs = alleleMatches.stream().map(gonl -> gonl == null ? "" : gonl.getString(INFO_GTC))
-								.collect(Collectors.joining("|"));
+								.collect(Collectors.joining(","));
+						//update GTC field to separate allele combinations by pipe instead of comma, since we use comma to separate alt allele info
+						gtcs = alleleMatches.stream().map(gonl -> gonl == null ? "." : gonl.getString(INFO_GTC).replace(",", "|"))
+								.collect(Collectors.joining(","));
 					}
 
 				}

--- a/molgenis-data-annotators/src/test/java/org/molgenis/data/annotation/entity/impl/GoNLAnnotatorTest.java
+++ b/molgenis-data-annotators/src/test/java/org/molgenis/data/annotation/entity/impl/GoNLAnnotatorTest.java
@@ -91,7 +91,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.013052208835341365");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "485,13,0");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "485|13|0");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -114,7 +114,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.8674698795180723");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "6,120,372");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "6|120|372");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -136,8 +136,8 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 		assertFalse(results.hasNext());
 
 		Entity expectedEntity = new MapEntity("expected");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "||0.015136226034308779");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "||7,11,33");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, ".,.,0.015136226034308779");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, ".,.,7|11|33");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -160,7 +160,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.30823293172690763");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "241,207,50");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "241|207|50");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -182,8 +182,8 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 		assertFalse(results.hasNext());
 
 		Entity expectedEntity = new MapEntity("expected");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.9969909729187563||");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "1,4,496||");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.9969909729187563,.,.");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "1|4|496,.,.");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -205,8 +205,8 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 		assertFalse(results.hasNext());
 
 		Entity expectedEntity = new MapEntity("expected");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "|0.09538152610441768|");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "|412,77,9|");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, ".,0.09538152610441768,.");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, ".,412|77|9,.");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -252,7 +252,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.9989939637826962");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "0,1,496");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "0|1|496");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -275,7 +275,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.0030120481927710845");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "495,3,0");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "495|3|0");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -321,7 +321,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.9969879518072289");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "0,3,495");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "0|3|495");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -344,7 +344,7 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.02610441767068273");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "472,26,0");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "472|26|0");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),
@@ -366,8 +366,8 @@ public class GoNLAnnotatorTest extends AbstractTestNGSpringContextTests
 		assertFalse(results.hasNext());
 
 		Entity expectedEntity = new MapEntity("expected");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.22188755020080322||");
-		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "306,163,29||");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_AF, "0.22188755020080322,.,.");
+		expectedEntity.set(GoNLAnnotator.GONL_GENOME_GTC, "306|163|29,.,.");
 
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_AF), expectedEntity.get(GoNLAnnotator.GONL_GENOME_AF));
 		assertEquals(resultEntity.get(GoNLAnnotator.GONL_GENOME_GTC),


### PR DESCRIPTION
Fix for issue "GoNL annotator writes non-standard separators and missing values". Updated writing of missing values, allele separators and genotype counts to be the same as other population based annotators.