### PR TITLE
fix: #4791 CmdLine Gavin overwrites SnpEff headers AND #4795 CmdLineAnnotator with update=true removes all values if no result was found

### DIFF
--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/AnnotatorImpl.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/AnnotatorImpl.java
@@ -46,7 +46,10 @@ public class AnnotatorImpl extends QueryAnnotatorImpl implements EntityAnnotator
 		{
 			for (AttributeMetaData attr : getInfo().getOutputAttributes())
 			{
-				resultEntity.set(attr.getName(), null);
+				if (!updateMode || resultEntity.get(attr.getName()) == null)
+				{
+					resultEntity.set(attr.getName(), null);
+				}
 			}
 		}
 	}
@@ -54,8 +57,10 @@ public class AnnotatorImpl extends QueryAnnotatorImpl implements EntityAnnotator
 	/**
 	 * Get the resource attribute value for one of this annotator's output attributes.
 	 * 
-	 * @param attr the name of the output attribute
-	 * @param entity the current entity
+	 * @param attr
+	 *            the name of the output attribute
+	 * @param entity
+	 *            the current entity
 	 * @return the value of the attribute to copy from the resource entity
 	 */
 	protected Object getResourceAttributeValue(AttributeMetaData attr, Entity entity)

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/utils/VcfWriterUtils.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/utils/VcfWriterUtils.java
@@ -80,8 +80,8 @@ public class VcfWriterUtils
 	 * @throws IOException
 	 */
 	public static void writeVcfHeader(File inputVcfFile, BufferedWriter outputVCFWriter,
-									  List<AttributeMetaData> addedAttributes, List<String> attributesToInclude)
-			throws MolgenisInvalidFormatException, IOException
+			List<AttributeMetaData> addedAttributes, List<String> attributesToInclude)
+					throws MolgenisInvalidFormatException, IOException
 	{
 		System.out.println("Detecting VCF column header...");
 
@@ -189,26 +189,28 @@ public class VcfWriterUtils
 	{
 		Map<String, AttributeMetaData> annotatorAttributesMap = VcfUtils.getAttributesMapFromList(annotatorAttributes);
 		writeExistingInfoHeaders(outputVCFWriter, infoHeaderLinesMap, annotatorAttributesMap);
-		writeAddedInfoHeaders(outputVCFWriter, attributesToInclude, annotatorAttributesMap);
+		writeAddedInfoHeaders(outputVCFWriter, attributesToInclude, annotatorAttributesMap, infoHeaderLinesMap);
 	}
 
 	private static void writeAddedInfoHeaders(BufferedWriter outputVCFWriter, List<String> attributesToInclude,
-			Map<String, AttributeMetaData> annotatorAttributes) throws IOException
+			Map<String, AttributeMetaData> annotatorAttributes, Map<String, String> infoHeaderLinesMap)
+					throws IOException
 	{
 		for (AttributeMetaData annotatorInfoAttr : annotatorAttributes.values())
 		{
 			if (attributesToInclude.isEmpty() || attributesToInclude.contains(annotatorInfoAttr.getName())
 					|| annotatorInfoAttr.getDataType().equals(XREF) || annotatorInfoAttr.getDataType().equals(MREF))
 			{
-				outputVCFWriter.write(createInfoStringFromAttribute(
-						annotatorAttributes.get(annotatorInfoAttr.getName()), attributesToInclude));
+				outputVCFWriter
+						.write(createInfoStringFromAttribute(annotatorAttributes.get(annotatorInfoAttr.getName()),
+								attributesToInclude, infoHeaderLinesMap.get(annotatorInfoAttr.getName())));
 				outputVCFWriter.newLine();
 			}
 		}
 	}
 
 	private static String createInfoStringFromAttribute(AttributeMetaData infoAttributeMetaData,
-			List<String> attributesToInclude)
+			List<String> attributesToInclude, String currentInfoField)
 	{
 		String attributeName = infoAttributeMetaData.getName();
 		StringBuilder sb = new StringBuilder();
@@ -229,7 +231,11 @@ public class VcfWriterUtils
 			if ((infoAttributeMetaData.getDataType().equals(MREF) || infoAttributeMetaData.getDataType().equals(XREF))
 					&& !attributeName.equals(SAMPLES))
 			{
-				writeAttributesToInfoDescription(infoAttributeMetaData, attributesToInclude, attributeName, sb);
+				String currentAttributesString = currentInfoField != null
+						? currentInfoField.substring((currentInfoField.indexOf("'")+1), currentInfoField.lastIndexOf("'"))
+						: "";
+				writeRefAttributePartsToInfoDescription(infoAttributeMetaData, attributesToInclude, attributeName, sb,
+						currentAttributesString);
 			}
 			else
 			{
@@ -244,12 +250,17 @@ public class VcfWriterUtils
 		return sb.toString();
 	}
 
-	private static void writeAttributesToInfoDescription(AttributeMetaData infoAttributeMetaData,
-			List<String> attributesToInclude, String attributeName, StringBuilder sb)
+	private static void writeRefAttributePartsToInfoDescription(AttributeMetaData infoAttributeMetaData,
+			List<String> attributesToInclude, String attributeName, StringBuilder sb, String existingAttributes)
 	{
 		Iterable<AttributeMetaData> atomicAttributes = infoAttributeMetaData.getRefEntity().getAtomicAttributes();
 		sb.append(attributeName);
 		sb.append(" annotations: '");
+		if (!existingAttributes.isEmpty())
+		{
+			sb.append(existingAttributes);
+			sb.append(" | ");
+		}
 		sb.append(refAttributesToString(atomicAttributes, attributesToInclude).replace("\\", "\\\\")
 				.replace("\"", "\\\"").replace("\n", " "));
 		sb.append("'");


### PR DESCRIPTION
PR accidentally also contains previous PR, please merge in right order.