### PR TITLE
Fix #4596: Selecting from tables with lots of data and multiple MREFs is very slow

### DIFF
--- a/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
+++ b/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
@@ -12,6 +12,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -711,10 +712,7 @@ public class MysqlRepository extends AbstractRepository
 					// TODO needed when autoids are used to join
 					if (att.getDataType() instanceof MrefField)
 					{
-						select.append("GROUP_CONCAT(DISTINCT(").append('`').append(att.getName()).append('`')
-								.append('.').append('`').append(att.getName()).append('`').append(") ORDER BY `")
-								.append(att.getName()).append("`.`order`) AS ").append('`').append(att.getName())
-								.append('`');
+						select.append(MessageFormat.format("GROUP_CONCAT(DISTINCT(`{0}`.`{0}`) ORDER BY `{0}`.`order`) AS `{0}`", att.getName()));
 					}
 					else
 					{

--- a/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
+++ b/molgenis-data-mysql/src/main/java/org/molgenis/data/mysql/MysqlRepository.java
@@ -701,6 +701,7 @@ public class MysqlRepository extends AbstractRepository
 		StringBuilder select = new StringBuilder("SELECT ");
 		StringBuilder group = new StringBuilder();
 		int count = 0;
+		AttributeMetaData idAttribute = getEntityMetaData().getIdAttribute();
 		for (AttributeMetaData att : getEntityMetaData().getAtomicAttributes())
 		{
 			if (q.getFetch() == null || q.getFetch().hasField(att.getName()))
@@ -712,7 +713,11 @@ public class MysqlRepository extends AbstractRepository
 					// TODO needed when autoids are used to join
 					if (att.getDataType() instanceof MrefField)
 					{
-						select.append(MessageFormat.format("GROUP_CONCAT(DISTINCT(`{0}`.`{0}`) ORDER BY `{0}`.`order`) AS `{0}`", att.getName()));
+						select.append(MessageFormat
+								.format("(SELECT GROUP_CONCAT(DISTINCT(`{0}`.`{0}`) ORDER BY `{0}`.`order`) "
+												+ "FROM `{1}_{0}` AS `{0}` "
+												+ "WHERE (this.`{2}` = `{0}`.`{2}`) ) AS `{0}`", att.getName(),
+										getTableName(), idAttribute.getName()));
 					}
 					else
 					{
@@ -1500,22 +1505,6 @@ public class MysqlRepository extends AbstractRepository
 		AttributeMetaData idAttribute = getEntityMetaData().getIdAttribute();
 		List<String> mrefQueryFields = Lists.newArrayList();
 		getMrefQueryFields(q.getRules(), mrefQueryFields);
-
-		for (AttributeMetaData att : getEntityMetaData().getAtomicAttributes())
-		{
-			if (q.getFetch() == null || q.getFetch().hasField(att.getName()))
-			{
-				if (att.getDataType() instanceof MrefField)
-				{
-					from.append(" LEFT JOIN ").append('`').append(getTableName()).append('_').append(att.getName())
-							.append('`').append(" AS ").append('`').append(att.getName()).append('`')
-							.append(" ON (this.").append('`').append(idAttribute.getName()).append('`').append(" = ")
-							.append('`').append(att.getName()).append('`').append('.').append('`')
-							.append(idAttribute.getName()).append('`').append(')');
-
-				}
-			}
-		}
 
 		for (int i = 0; i < mrefQueryFields.size(); i++)
 		{

--- a/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryMrefTest.java
+++ b/molgenis-data-mysql/src/test/java/org/molgenis/data/mysql/MysqlRepositoryMrefTest.java
@@ -129,11 +129,13 @@ public class MysqlRepositoryMrefTest extends MysqlRepositoryAbstractDatatypeTest
 
 		Assert.assertEquals(mrefRepo.getSelectSql(new QueryImpl(), Lists.newArrayList()),
 				"SELECT this.`identifier`, "
-						+ "GROUP_CONCAT(DISTINCT(`stringRef`.`stringRef`) ORDER BY `stringRef`.`order`) AS `stringRef`, "
-						+ "GROUP_CONCAT(DISTINCT(`intRef`.`intRef`) ORDER BY `intRef`.`order`) AS `intRef` "
+						+ "(SELECT GROUP_CONCAT(DISTINCT(`stringRef`.`stringRef`) ORDER BY `stringRef`.`order`) "
+						+ "FROM `MrefTest_stringRef` AS `stringRef` "
+						+ "WHERE (this.`identifier` = `stringRef`.`identifier`) ) AS `stringRef`, "
+						+ "(SELECT GROUP_CONCAT(DISTINCT(`intRef`.`intRef`) ORDER BY `intRef`.`order`) "
+						+ "FROM `MrefTest_intRef` AS `intRef` "
+						+ "WHERE (this.`identifier` = `intRef`.`identifier`) ) AS `intRef` "
 						+ "FROM `MrefTest` AS this "
-						+ "LEFT JOIN `MrefTest_stringRef` AS `stringRef` ON (this.`identifier` = `stringRef`.`identifier`) "
-						+ "LEFT JOIN `MrefTest_intRef` AS `intRef` ON (this.`identifier` = `intRef`.`identifier`) "
 						+ "GROUP BY this.`identifier`");
 
 		assertEquals(mrefRepo.query().eq("identifier", "one").count(), Long.valueOf(1));


### PR DESCRIPTION
#### Checklist
- [x] Unit tests
- [x] Updated testplan
