### PR TITLE
Collect the ReindexActions in memory until the transaction commits.

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfig.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfig.java
@@ -17,6 +17,7 @@ import org.molgenis.data.elasticsearch.reindex.job.ReindexJobFactory;
 import org.molgenis.data.elasticsearch.transaction.ReindexTransactionListener;
 import org.molgenis.data.jobs.JobExecutionUpdater;
 import org.molgenis.data.jobs.JobExecutionUpdaterImpl;
+import org.molgenis.data.reindex.ReindexActionRegisterService;
 import org.molgenis.data.transaction.MolgenisTransactionManager;
 import org.molgenis.security.user.MolgenisUserService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,10 +48,10 @@ public class EmbeddedElasticSearchConfig
 	private ElasticsearchEntityFactory elasticsearchEntityFactory;
 
 	@Autowired
-	public MolgenisTransactionManager molgenisTransactionManager;
+	private MolgenisTransactionManager molgenisTransactionManager;
 
 	@Autowired
-	private MolgenisUserService molgenisUserService;
+	private ReindexActionRegisterService reindexActionRegisterService;
 
 	@Bean(destroyMethod = "close")
 	public EmbeddedElasticSearchServiceFactory embeddedElasticSearchServiceFactory()
@@ -87,7 +88,7 @@ public class EmbeddedElasticSearchConfig
 	public ReindexTransactionListener reindexTransactionListener()
 	{
 		final ReindexTransactionListener reindexTransactionListener = new ReindexTransactionListener(
-				rebuildIndexService());
+				rebuildIndexService(), reindexActionRegisterService);
 		molgenisTransactionManager.addTransactionListener(reindexTransactionListener);
 		return reindexTransactionListener;
 	}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfigTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/config/EmbeddedElasticSearchConfigTest.java
@@ -16,6 +16,7 @@ import org.molgenis.data.elasticsearch.factory.EmbeddedElasticSearchServiceFacto
 import org.molgenis.data.elasticsearch.index.EntityToSourceConverter;
 import org.molgenis.data.elasticsearch.index.SourceToEntityConverter;
 import org.molgenis.data.jobs.JobExecutionUpdater;
+import org.molgenis.data.reindex.ReindexActionRegisterService;
 import org.molgenis.data.support.DataServiceImpl;
 import org.molgenis.data.transaction.MolgenisTransactionManager;
 import org.molgenis.security.user.MolgenisUserService;
@@ -96,6 +97,12 @@ public class EmbeddedElasticSearchConfigTest
 		public MolgenisUserService molgenisUserService()
 		{
 			return mock(MolgenisUserService.class);
+		}
+
+		@Bean
+		public ReindexActionRegisterService reindexActionRegisterService()
+		{
+			return mock(ReindexActionRegisterService.class);
 		}
 	}
 

--- a/molgenis-data/src/test/java/org/molgenis/data/reindex/ReindexActionRegisterServiceTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/reindex/ReindexActionRegisterServiceTest.java
@@ -2,15 +2,13 @@ package org.molgenis.data.reindex;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;
@@ -26,6 +24,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.stream.Stream;
 
 public class ReindexActionRegisterServiceTest
 {
@@ -50,18 +50,20 @@ public class ReindexActionRegisterServiceTest
 	@Test
 	public void createLog()
 	{
-		Entity entity = reindexActionRegisterService.createReindexActionJob("1");
+		Entity entity = reindexActionRegisterService.createReindexActionJob("1", 5);
 		assertEquals(entity.get(ReindexActionJobMetaData.ID), "1");
-		assertEquals(entity.get(ReindexActionJobMetaData.COUNT), 0);
+		assertEquals(entity.get(ReindexActionJobMetaData.COUNT), 5);
 	}
 
 	@Test
 	public void createReindexAction()
 	{
-		Entity reindexActionJob = reindexActionRegisterService.createReindexActionJob("1");
+		Entity reindexActionJob = reindexActionRegisterService.createReindexActionJob("1", 2);
 
-		Entity reindexAction = reindexActionRegisterService.createReindexAction(reindexActionJob, "full_entity_name",
-				CudType.CREATE, DataType.DATA, "123", 1);
+		when(dataService.findOneById(ReindexActionJobMetaData.ENTITY_NAME, "1")).thenReturn(reindexActionJob);
+
+		Entity reindexAction = reindexActionRegisterService
+				.createReindexAction("1", "full_entity_name", CudType.CREATE, DataType.DATA, "123", 1);
 		assertNotNull(reindexAction.get(ReindexActionMetaData.REINDEX_ACTION_GROUP));
 		assertEquals(reindexAction.getInt(ReindexActionMetaData.ACTION_ORDER), Integer.valueOf(1));
 		assertEquals(reindexAction.getString(ReindexActionMetaData.ENTITY_FULL_NAME), "full_entity_name");
@@ -70,8 +72,8 @@ public class ReindexActionRegisterServiceTest
 		assertEquals(reindexAction.get(ReindexActionMetaData.DATA_TYPE), DataType.DATA.name());
 		assertEquals(reindexAction.get(ReindexActionMetaData.REINDEX_STATUS), ReindexStatus.PENDING.name());
 
-		Entity reindexAction2 = reindexActionRegisterService.createReindexAction(reindexActionJob, "full_entity_name",
-				CudType.DELETE, DataType.METADATA, null, 2);
+		Entity reindexAction2 = reindexActionRegisterService
+				.createReindexAction("1", "full_entity_name", CudType.DELETE, DataType.METADATA, null, 2);
 		assertNotNull(reindexAction2.get(ReindexActionMetaData.REINDEX_ACTION_GROUP));
 		assertEquals(reindexAction2.getInt(ReindexActionMetaData.ACTION_ORDER), Integer.valueOf(2));
 		assertEquals(reindexAction2.getString(ReindexActionMetaData.ENTITY_FULL_NAME), "full_entity_name");
@@ -82,18 +84,44 @@ public class ReindexActionRegisterServiceTest
 	}
 
 	@Test
-	public void testLog()
+	public void testLogAndStore()
 	{
-		DefaultEntity reindexActionJob = reindexActionRegisterService.createReindexActionJob("1");
+		DefaultEntity reindexActionJob = reindexActionRegisterService.createReindexActionJob("1", 1);
 		when(dataService.findOneById(ReindexActionJobMetaData.ENTITY_NAME, "1")).thenReturn(reindexActionJob);
 
 		EntityMetaData entityMetaData = mock(EntityMetaData.class);
 		when(entityMetaData.getName()).thenReturn("non_log_entity");
 
 		reindexActionRegisterService.register(entityMetaData.getName(), CudType.CREATE, DataType.DATA, "123");
-		
-		verify(dataService).update(eq(ReindexActionJobMetaData.ENTITY_NAME), any(Entity.class));
-		verify(dataService).add(eq(ReindexActionMetaData.ENTITY_NAME), any(Entity.class));
+
+		verifyZeroInteractions(dataService);
+
+		reindexActionRegisterService.storeReindexActions("1");
+
+		verify(dataService).add(eq(ReindexActionJobMetaData.ENTITY_NAME), any(Entity.class));
+		verify(dataService).add(eq(ReindexActionMetaData.ENTITY_NAME), any(Stream.class));
+	}
+
+	@Test
+	public void testLogAndForget()
+	{
+		DefaultEntity reindexActionJob = reindexActionRegisterService.createReindexActionJob("1", 1);
+		when(dataService.findOneById(ReindexActionJobMetaData.ENTITY_NAME, "1")).thenReturn(reindexActionJob);
+
+		EntityMetaData entityMetaData = mock(EntityMetaData.class);
+		when(entityMetaData.getName()).thenReturn("non_log_entity");
+
+		reindexActionRegisterService.register(entityMetaData.getName(), CudType.CREATE, DataType.DATA, "123");
+
+		verifyZeroInteractions(dataService);
+
+		reindexActionRegisterService.forgetReindexActions("1");
+
+		verifyZeroInteractions(dataService);
+
+		reindexActionRegisterService.storeReindexActions("1");
+
+		verifyZeroInteractions(dataService);
 	}
 
 	@Test


### PR DESCRIPTION
This should be quicker and, more importantly, solve bootstrapping issues.