### PR TITLE
Fix #4974: Update GAVIN logic to match algorithm in last version of the paper

### DIFF
--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/Category.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/Category.java
@@ -1,6 +1,0 @@
-package org.molgenis.data.annotation.entity.impl.gavin;
-
-public enum Category
-{
-    N1, N2, T1, T2, I1, I2, I3, C1, C2, C3, C4, C5
-}

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
@@ -82,27 +82,28 @@ public class GavinAlgorithm
 		// CADD score based classification, calibrated
 		if(caddScaled != null)
 		{
-			if((category.equals(Category.C1) || category.equals(Category.C2)))
+			switch(category)
 			{
-				if(caddScaled > meanPathogenicCADDScore)
-				{
-					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+meanPathogenicCADDScore+" in a gene for which CADD scores are informative.");
-				}
-				else if(caddScaled < meanPopulationCADDScore)
-				{
-					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+meanPopulationCADDScore+" in a gene for which CADD scores are informative.");
-				}
-			}
-			else if((category.equals(Category.C3) || category.equals(Category.C4) || category.equals(Category.C5)))
-			{
-				if(caddScaled > spec95thPerCADDThreshold)
-				{
-					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+spec95thPerCADDThreshold+" for this gene.");
-				}
-				else if(caddScaled < sens95thPerCADDThreshold)
-				{
-					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+sens95thPerCADDThreshold+" for this gene.");
-				}
+				case C1: case C2:
+					if(caddScaled > meanPathogenicCADDScore)
+					{
+						return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+meanPathogenicCADDScore+" in a gene for which CADD scores are informative.");
+					}
+					else if(caddScaled < meanPopulationCADDScore)
+					{
+						return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+meanPopulationCADDScore+" in a gene for which CADD scores are informative.");
+					}
+					break;
+				case C3: case C4: case C5:
+					if(caddScaled > spec95thPerCADDThreshold)
+					{
+						return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+spec95thPerCADDThreshold+" for this gene.");
+					}
+					else if(caddScaled < sens95thPerCADDThreshold)
+					{
+						return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+sens95thPerCADDThreshold+" for this gene.");
+					}
+					break;
 			}
 		}
 

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
@@ -118,19 +118,19 @@ public class GavinAlgorithm
 		// Impact based classification, calibrated
 		if(impact != null)
 		{
-			if(category.equals(Category.I1) && impact.equals(Impact.HIGH))
+			if(category == Category.I1 && impact == Impact.HIGH)
 			{
 				return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant is of high impact, while there are no known high impact variants in the population. Also, " + mafReason);
 			}
-			else if(category.equals(Category.I2) && (impact.equals(Impact.MODERATE) || impact.equals(Impact.HIGH)))
+			else if(category == Category.I2 && (impact == Impact.MODERATE || impact == Impact.HIGH))
 			{
 				return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant is of high/moderate impact, while there are no known high/moderate impact variants in the population. Also, " + mafReason);
 			}
-			else if(category.equals(Category.I3) && (impact.equals(Impact.LOW) || impact.equals(Impact.MODERATE) || impact.equals(Impact.HIGH)))
+			else if(category == Category.I3 && (impact == Impact.LOW || impact == Impact.MODERATE || impact == Impact.HIGH))
 			{
 				return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant is of high/moderate/low impact, while there are no known high/moderate/low impact variants in the population. Also, " + mafReason);
 			}
-			else if(impact.equals(Impact.MODIFIER))
+			else if(impact == Impact.MODIFIER)
 			{
 				return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant is of 'modifier' impact, and therefore unlikely to be pathogenic. However, " + mafReason);
 			}
@@ -157,7 +157,7 @@ public class GavinAlgorithm
 		{
 			return new Judgment(Judgment.Classification.Benign, Method.genomewide, gene, "Variant MAF of "+exacMAF+" is not rare enough to generally be considered pathogenic.");
 		}
-		if(impact.equals(Impact.MODIFIER))
+		if(impact == Impact.MODIFIER)
 		{
 			return new Judgment(Judgment.Classification.Benign, Method.genomewide, gene, "Variant is of 'modifier' impact, and therefore unlikely to be pathogenic.");
 		}

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
@@ -75,8 +75,6 @@ public class GavinAlgorithm
 			}
 		}
 
-		String mafReason = "the variant MAF of " + exacMAF + " is less than a MAF of "+ pathoMAFThreshold + ".";
-
 		// CADD score based classification, calibrated
 		if(caddScaled != null)
 		{
@@ -84,22 +82,22 @@ public class GavinAlgorithm
 			{
 				if(caddScaled > meanPathogenicCADDScore)
 				{
-					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+meanPathogenicCADDScore+" in a gene for which CADD scores are informative. Also, " + mafReason);
+					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+meanPathogenicCADDScore+" in a gene for which CADD scores are informative.");
 				}
 				else if(caddScaled < meanPopulationCADDScore)
 				{
-					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+meanPopulationCADDScore+" in a gene for which CADD scores are informative, although " + mafReason);
+					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+meanPopulationCADDScore+" in a gene for which CADD scores are informative.");
 				}
 			}
 			else if((category.equals(Category.C3) || category.equals(Category.C4) || category.equals(Category.C5)))
 			{
 				if(caddScaled > spec95thPerCADDThreshold)
 				{
-					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+spec95thPerCADDThreshold+" for this gene. Also, " + mafReason);
+					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+spec95thPerCADDThreshold+" for this gene.");
 				}
 				else if(caddScaled < sens95thPerCADDThreshold)
 				{
-					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+sens95thPerCADDThreshold+" for this gene, although " + mafReason);
+					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+sens95thPerCADDThreshold+" for this gene.");
 				}
 			}
 		}
@@ -109,6 +107,8 @@ public class GavinAlgorithm
 		{
 			return new Judgment(Judgment.Classification.Benign, Method.calibrated, gene, "Variant MAF of " + exacMAF + " is greater than "+pathoMAFThreshold+".");
 		}
+
+		String mafReason = "the variant MAF of " + exacMAF + " is less than a MAF of "+ pathoMAFThreshold + ".";
 
 		// Impact based classification, calibrated
 		if(impact != null)
@@ -160,7 +160,7 @@ public class GavinAlgorithm
 		{
 			if(caddScaled != null && caddScaled > GENOMEWIDE_CADD_THRESHOLD)
 			{
-				return new Judgment(Judgment.Classification.Pathogenic, Method.genomewide, gene, "Variant MAF of "+exacMAF+" is rare enough to be potentially pathogenic and the CADDscore of "+caddScaled+ " is greater than a global threshold of "+GENOMEWIDE_CADD_THRESHOLD+".");
+				return new Judgment(Judgment.Classification.Pathogenic, Method.genomewide, gene, "Variant MAF of "+exacMAF+" is rare enough to be potentially pathogenic and its CADD score of "+caddScaled+ " is greater than a global threshold of "+GENOMEWIDE_CADD_THRESHOLD+".");
 			}
 			else if(caddScaled != null && caddScaled <= GENOMEWIDE_CADD_THRESHOLD)
 			{
@@ -168,7 +168,7 @@ public class GavinAlgorithm
 			}
 			else
 			{
-				return new Judgment(Judgment.Classification.VOUS, Method.genomewide, gene, "Unable to classify variant as benign or pathogenic. The combination of "+impact+" impact, a CADD score "+caddScaled +" and MAF of " + exacMAF + " in " + gene + " is inconclusive.");
+				return new Judgment(Judgment.Classification.VOUS, Method.genomewide, gene, "Unable to classify variant as benign or pathogenic. The combination of "+impact+" impact, a CADD score of "+caddScaled +" and MAF of " + exacMAF + " in " + gene + " is inconclusive.");
 			}
 		}
 	}

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
@@ -2,7 +2,11 @@ package org.molgenis.data.annotation.entity.impl.gavin;
 
 import org.molgenis.data.Entity;
 import org.molgenis.data.annotation.entity.impl.gavin.Judgment.Method;
+import org.molgenis.data.annotation.entity.impl.gavin.GavinEntry.Category;
 import org.molgenis.data.annotation.entity.impl.snpEff.Impact;
+import org.molgenis.data.annotation.entity.impl.snpEff.SnpEffRunner;
+
+import java.util.HashMap;
 
 public class GavinAlgorithm
 {
@@ -12,115 +16,122 @@ public class GavinAlgorithm
 
 	public static final String PATHOMAFTHRESHOLD = "PathoMAFThreshold";
 	public static final String MEANPATHOGENICCADDSCORE = "MeanPathogenicCADDScore";
+	public static final String MEANPOPULATIONCADDSCORE = "MeanPopulationCADDScore";
 	public static final String SPEC95THPERCADDTHRESHOLD = "Spec95thPerCADDThreshold";
+	public static final String SENS95THPERCADDTHRESHOLD = "Sens95thPerCADDThreshold";
 	private static final String CATEGORY = "Category";
 
 	public static final String CLASSIFICATION = "Classification";
 	public static final String CONFIDENCE = "Confidence";
 	public static final String REASON = "Reason";
 	public static final String VARIANT_ENTITY = "Variant";
-
-	public static final int CADD_MAXIMUM_THRESHOLD = 25;
-	public static final int CADD_MINIMUM_THRESHOLD = 5;
-	public static final double MAF_THRESHOLD = 0.00474;
+	public static final double GENOMEWIDE_MAF_THRESHOLD = 0.00474;
+	public static final int GENOMEWIDE_CADD_THRESHOLD = 15;
 
 	/**
 	 *
 	 * @param impact
 	 * @param caddScaled
 	 * @param exacMAF
-	 * @param category
 	 * @param gene
 	 * @param annotationSourceEntity
 	 * @return
 	 */
-	public Judgment classifyVariant(Impact impact, Double caddScaled, Double exacMAF, Category category,
-									String gene, Entity annotationSourceEntity)
+	public Judgment classifyVariant(Impact impact, Double caddScaled, Double exacMAF,
+									String gene, Entity annotationSourceEntity, HashMap<String, GavinEntry> geneToEntry)
 	{
+		Double pathoMAFThreshold, meanPathogenicCADDScore, meanPopulationCADDScore, spec95thPerCADDThreshold, sens95thPerCADDThreshold = null;
+		Category category = null;
 
-		Double pathoMAFThreshold = annotationSourceEntity.getDouble(PATHOMAFTHRESHOLD);
-		Double meanPathogenicCADDScore = annotationSourceEntity.getDouble(MEANPATHOGENICCADDSCORE);
-		Double spec95thPerCADDThreshold = annotationSourceEntity.getDouble(SPEC95THPERCADDTHRESHOLD);
+		//at 5, GAVIN is 92% sensitive and 78% specific, whereas at 1, GAVIN is 89% sensitive and 83% specific. However sensitivity is more important. (don't want to miss anything)
+		int extraSensitivityFactor = 5;
 
-		// MAF based classification, calibrated
-		if (exacMAF > pathoMAFThreshold)
+		if(geneToEntry == null)
 		{
-			return new Judgment(Judgment.Classification.Benign, Judgment.Method.calibrated, "Variant MAF of " + exacMAF
-					+ " is greater than the pathogenic 95th percentile MAF of " + pathoMAFThreshold + ".");
+			//get data from entity
+			pathoMAFThreshold = annotationSourceEntity.getDouble(PATHOMAFTHRESHOLD) * extraSensitivityFactor * 2;
+			meanPathogenicCADDScore = annotationSourceEntity.getDouble(MEANPATHOGENICCADDSCORE) - extraSensitivityFactor;
+			meanPopulationCADDScore = annotationSourceEntity.getDouble(MEANPATHOGENICCADDSCORE) - extraSensitivityFactor;
+			spec95thPerCADDThreshold = annotationSourceEntity.getDouble(SPEC95THPERCADDTHRESHOLD) - extraSensitivityFactor;
+			sens95thPerCADDThreshold = annotationSourceEntity.getDouble(SPEC95THPERCADDTHRESHOLD) - extraSensitivityFactor;
+			category = Category.valueOf(annotationSourceEntity.getString(CATEGORY));
+		}
+		else
+		{
+			//get data from map
+			if(!geneToEntry.containsKey(gene))
+			{
+				//if we have no data for this gene, immediately fall back to the genomewide method
+				return genomewideClassifyVariant(impact, caddScaled, exacMAF, gene);
+			}
+			else
+			{
+				pathoMAFThreshold = geneToEntry.get(gene).PathoMAFThreshold != null ? geneToEntry.get(gene).PathoMAFThreshold * extraSensitivityFactor * 2 : null;
+				meanPathogenicCADDScore = geneToEntry.get(gene).MeanPathogenicCADDScore != null ? geneToEntry.get(gene).MeanPathogenicCADDScore - extraSensitivityFactor : null;
+				meanPopulationCADDScore = geneToEntry.get(gene).MeanPopulationCADDScore != null ? geneToEntry.get(gene).MeanPopulationCADDScore - extraSensitivityFactor : null;
+				spec95thPerCADDThreshold = geneToEntry.get(gene).Spec95thPerCADDThreshold != null ? geneToEntry.get(gene).Spec95thPerCADDThreshold - extraSensitivityFactor : null;
+				sens95thPerCADDThreshold = geneToEntry.get(gene).Sens95thPerCADDThreshold != null ? geneToEntry.get(gene).Sens95thPerCADDThreshold - extraSensitivityFactor : null;
+				category = geneToEntry.get(gene).category;
+			}
 		}
 
-		String mafReason = "the variant MAF of " + exacMAF + " is lesser than the pathogenic 95th percentile MAF of "
-				+ pathoMAFThreshold + ".";
-
-		// Impact based classification, calibrated
-		if (impact != null)
-		{
-			if (category.equals(Category.I1) && impact.equals(Impact.HIGH))
-			{
-				return new Judgment(Judgment.Classification.Pathognic, Judgment.Method.calibrated,
-						"Variant is of high impact, while there are no known high impact variants in the population. Also, "
-								+ mafReason);
-			}
-			else if (category.equals(Category.I2)
-					&& (impact.equals(Impact.MODERATE) || impact.equals(Impact.HIGH)))
-			{
-				return new Judgment(Judgment.Classification.Pathognic, Judgment.Method.calibrated,
-						"Variant is of high/moderate impact, while there are no known high/moderate impact variants in the population. Also, "
-								+ mafReason);
-			}
-			else if (category.equals(Category.I3) && (impact.equals(Impact.LOW)
-					|| impact.equals(Impact.MODERATE) || impact.equals(Impact.HIGH)))
-			{
-				return new Judgment(Judgment.Classification.Pathognic, Judgment.Method.calibrated,
-						"Variant is of high/moderate/low impact, while there are no known high/moderate/low impact variants in the population. Also, "
-								+ mafReason);
-			}
-			else if (impact.equals(Impact.MODIFIER))
-			{
-				return new Judgment(Judgment.Classification.Benign, Judgment.Method.calibrated,
-						"Variant is of 'modifier' impact, and therefore unlikely to be pathogenic. However, "
-								+ mafReason);
-			}
-		}
+		String mafReason = "the variant MAF of " + exacMAF + " is less than a MAF of "+ pathoMAFThreshold + ".";
 
 		// CADD score based classification, calibrated
-		if (caddScaled != null)
+		if(caddScaled != null)
 		{
-			if ((category.equals(Category.C1) || category.equals(Category.C2)))
+			if((category.equals(Category.C1) || category.equals(Category.C2)))
 			{
-				if (caddScaled > meanPathogenicCADDScore)
+				if(caddScaled > meanPathogenicCADDScore)
 				{
-					return new Judgment(Judgment.Classification.Pathognic, Judgment.Method.calibrated,
-							"Variant CADD score of " + caddScaled + " is greater than the mean pathogenic score of "
-									+ meanPathogenicCADDScore
-									+ " in a gene for which CADD scores are informative. Also, " + mafReason);
+					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+meanPathogenicCADDScore+" in a gene for which CADD scores are informative. Also, " + mafReason);
 				}
-				else if (caddScaled < meanPathogenicCADDScore)
+				else if(caddScaled < meanPopulationCADDScore)
 				{
-					return new Judgment(Judgment.Classification.Benign, Judgment.Method.calibrated,
-							"Variant CADD score of " + caddScaled + " is lesser than the mean population score of "
-									+ meanPathogenicCADDScore
-									+ " in a gene for which CADD scores are informative, although " + mafReason);
+					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+meanPopulationCADDScore+" in a gene for which CADD scores are informative, although " + mafReason);
 				}
 			}
-			else if ((category.equals(Category.C3) || category.equals(Category.C4) || category.equals(Category.C5)))
+			else if((category.equals(Category.C3) || category.equals(Category.C4) || category.equals(Category.C5)))
 			{
-				if (caddScaled > spec95thPerCADDThreshold)
+				if(caddScaled > spec95thPerCADDThreshold)
 				{
-					return new Judgment(Judgment.Classification.Pathognic, Judgment.Method.calibrated,
-							"Variant CADD score of " + caddScaled + " is greater than the 95% specificity threshold of "
-									+ spec95thPerCADDThreshold + " for this gene. Also, " + mafReason);
+					return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is greater than "+spec95thPerCADDThreshold+" for this gene. Also, " + mafReason);
 				}
-				else if (caddScaled < spec95thPerCADDThreshold)
+				else if(caddScaled < sens95thPerCADDThreshold)
 				{
-					return new Judgment(Judgment.Classification.Benign, Judgment.Method.calibrated,
-							"Variant CADD score of " + caddScaled + " is lesser than the 95% sensitivity threshold of "
-									+ spec95thPerCADDThreshold + " for this gene, although " + mafReason);
+					return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+sens95thPerCADDThreshold+" for this gene, although " + mafReason);
 				}
 			}
 		}
 
-		// if everything so far has failed, we can still fall back to the naive method
+		// MAF based classification, calibrated but slightly relaxed with a factor x
+		if(pathoMAFThreshold != null && exacMAF > pathoMAFThreshold)
+		{
+			return new Judgment(Judgment.Classification.Benign, Method.calibrated, gene, "Variant MAF of " + exacMAF + " is greater than "+pathoMAFThreshold+".");
+		}
+
+		// Impact based classification, calibrated
+		if(impact != null)
+		{
+			if(category.equals(Category.I1) && impact.equals(Impact.HIGH))
+			{
+				return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant is of high impact, while there are no known high impact variants in the population. Also, " + mafReason);
+			}
+			else if(category.equals(Category.I2) && (impact.equals(Impact.MODERATE) || impact.equals(Impact.HIGH)))
+			{
+				return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant is of high/moderate impact, while there are no known high/moderate impact variants in the population. Also, " + mafReason);
+			}
+			else if(category.equals(Category.I3) && (impact.equals(Impact.LOW) || impact.equals(Impact.MODERATE) || impact.equals(Impact.HIGH)))
+			{
+				return new Judgment(Judgment.Classification.Pathogenic,  Method.calibrated, gene, "Variant is of high/moderate/low impact, while there are no known high/moderate/low impact variants in the population. Also, " + mafReason);
+			}
+			else if(impact.equals(Impact.MODIFIER))
+			{
+				return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant is of 'modifier' impact, and therefore unlikely to be pathogenic. However, " + mafReason);
+			}
+		}
+
+		//if everything so far has failed, we can still fall back to the genome-wide method
 		return genomewideClassifyVariant(impact, caddScaled, exacMAF, gene);
 	}
 
@@ -137,33 +148,27 @@ public class GavinAlgorithm
 
 		exacMAF = exacMAF != null ? exacMAF : 0;
 
-		if (exacMAF > GavinAnnotator.MAF_THRESHOLD)
+		if(exacMAF > GENOMEWIDE_MAF_THRESHOLD)
 		{
-			return new Judgment(Judgment.Classification.Benign, Method.genomewide,
-					"MAF > " + GavinAnnotator.MAF_THRESHOLD);
+			return new Judgment(Judgment.Classification.Benign, Method.genomewide, gene, "Variant MAF of "+exacMAF+" is not rare enough to generally be considered pathogenic.");
 		}
-		if (Impact.MODIFIER.equals(impact))
+		if(impact.equals(Impact.MODIFIER))
 		{
-			return new Judgment(Judgment.Classification.Benign, Method.genomewide, "Impact is MODIFIER");
+			return new Judgment(Judgment.Classification.Benign, Method.genomewide, gene, "Variant is of 'modifier' impact, and therefore unlikely to be pathogenic.");
 		}
 		else
 		{
-			if (caddScaled != null && caddScaled > GavinAnnotator.CADD_MAXIMUM_THRESHOLD)
+			if(caddScaled != null && caddScaled > GENOMEWIDE_CADD_THRESHOLD)
 			{
-				return new Judgment(Judgment.Classification.Pathognic, Method.genomewide,
-						"CADDscore > " + GavinAnnotator.CADD_MAXIMUM_THRESHOLD);
+				return new Judgment(Judgment.Classification.Pathogenic, Method.genomewide, gene, "Variant MAF of "+exacMAF+" is rare enough to be potentially pathogenic and the CADDscore of "+caddScaled+ " is greater than a global threshold of "+GENOMEWIDE_CADD_THRESHOLD+".");
 			}
-			else if (caddScaled != null && caddScaled <= GavinAnnotator.CADD_MINIMUM_THRESHOLD)
+			else if(caddScaled != null && caddScaled <= GENOMEWIDE_CADD_THRESHOLD)
 			{
-				return new Judgment(Judgment.Classification.Benign, Method.genomewide,
-						"CADDscore <= " + GavinAnnotator.CADD_MINIMUM_THRESHOLD);
+				return new Judgment(Judgment.Classification.Benign, Method.genomewide, gene, "Variant CADD score of "+caddScaled+ " is less than a global threshold of "+GENOMEWIDE_CADD_THRESHOLD+", although the variant MAF of "+exacMAF+" is rare enough to be potentially pathogenic.");
 			}
 			else
 			{
-				return new Judgment(Judgment.Classification.VOUS, Method.genomewide,
-						"Unable to classify variant as benign or pathogenic. The combination of " + impact
-								+ " impact, a CADD score " + (caddScaled != null ? caddScaled : "[missing]")
-								+ " and MAF of " + exacMAF + " in " + gene + " is inconclusive.");
+				return new Judgment(Judgment.Classification.VOUS, Method.genomewide, gene, "Unable to classify variant as benign or pathogenic. The combination of "+impact+" impact, a CADD score "+caddScaled +" and MAF of " + exacMAF + " in " + gene + " is inconclusive.");
 			}
 		}
 	}

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
@@ -43,12 +43,16 @@ public class GavinAlgorithm
 		Double pathoMAFThreshold, meanPathogenicCADDScore, meanPopulationCADDScore, spec95thPerCADDThreshold, sens95thPerCADDThreshold = null;
 		Category category = null;
 
-		//at 5, GAVIN is 92% sensitive and 78% specific, whereas at 1, GAVIN is 89% sensitive and 83% specific. However sensitivity is more important. (don't want to miss anything)
+		// sensitivity is more important than specificity, so we can adjust this parameter to globally adjust the thresholds
+		// at a setting of 1, ie. default behaviour, GAVIN is 89% sensitive and 83% specific
+		// at a setting of 5, a more sensitive setting, GAVIN is 92% sensitive and 78% specific
+		// technically we lose more than we gain, but having >90% sensitivity is really important
+		// better to have a few more false positives than to miss a true positive
 		int extraSensitivityFactor = 5;
 
 		if(geneToEntry == null)
 		{
-			//get data from entity
+			//get data from entity for the annotator
 			pathoMAFThreshold = annotationSourceEntity.getDouble(PATHOMAFTHRESHOLD) * extraSensitivityFactor * 2;
 			meanPathogenicCADDScore = annotationSourceEntity.getDouble(MEANPATHOGENICCADDSCORE) - extraSensitivityFactor;
 			meanPopulationCADDScore = annotationSourceEntity.getDouble(MEANPATHOGENICCADDSCORE) - extraSensitivityFactor;
@@ -58,7 +62,7 @@ public class GavinAlgorithm
 		}
 		else
 		{
-			//get data from map
+			//get data from map, for reuse in GAVIN-related tools other than the annotator
 			if(!geneToEntry.containsKey(gene))
 			{
 				//if we have no data for this gene, immediately fall back to the genomewide method
@@ -102,7 +106,7 @@ public class GavinAlgorithm
 			}
 		}
 
-		// MAF based classification, calibrated but slightly relaxed with a factor x
+		// MAF-based classification, calibrated
 		if(pathoMAFThreshold != null && exacMAF > pathoMAFThreshold)
 		{
 			return new Judgment(Judgment.Classification.Benign, Method.calibrated, gene, "Variant MAF of " + exacMAF + " is greater than "+pathoMAFThreshold+".");

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAlgorithm.java
@@ -93,6 +93,9 @@ public class GavinAlgorithm
 					{
 						return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+meanPopulationCADDScore+" in a gene for which CADD scores are informative.");
 					}
+					else{
+						//this rule does not classify apparently, just continue onto the next rules
+					}
 					break;
 				case C3: case C4: case C5:
 					if(caddScaled > spec95thPerCADDThreshold)
@@ -102,6 +105,10 @@ public class GavinAlgorithm
 					else if(caddScaled < sens95thPerCADDThreshold)
 					{
 						return new Judgment(Judgment.Classification.Benign,  Method.calibrated, gene, "Variant CADD score of " + caddScaled + " is less than "+sens95thPerCADDThreshold+" for this gene.");
+					}
+					else
+					{
+						//this rule does not classify apparently, just continue onto the next rules
 					}
 					break;
 			}

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAnnotator.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinAnnotator.java
@@ -165,10 +165,8 @@ public class GavinAnnotator
 				{
 					Entity annotationSourceEntity = annotationSourceEntities.iterator().next();
 
-					Category category = Category.valueOf(annotationSourceEntity.getString(CATEGORY));
-
-					Judgment judgment = gavinAlgorithm.classifyVariant(impact, caddScaled, exacMAF, category, gene,
-							annotationSourceEntity);
+					Judgment judgment = gavinAlgorithm.classifyVariant(impact, caddScaled, exacMAF, gene,
+							annotationSourceEntity, null);
 					resultEntity.set(CLASSIFICATION, judgment.getClassification().toString());
 					resultEntity.set(CONFIDENCE, judgment.getConfidence().toString());
 					resultEntity.set(REASON, judgment.getReason());

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinEntry.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/GavinEntry.java
@@ -1,0 +1,85 @@
+package org.molgenis.data.annotation.entity.impl.gavin;
+
+public class GavinEntry
+{
+	public String gene;
+	public Category category;
+	public String chromosome;
+	public int start;
+	public int end;
+	public int NrOfPopulationVariants;
+	public int NrOfPathogenicVariants;
+	public int NrOfOverlappingVariants;
+	public int NrOfFilteredPopVariants;
+	public Double PathoMAFThreshold;
+	public Double PopImpactHighPerc;
+	public Double PopImpactModeratePerc;
+	public Double PopImpactLowPerc;
+	public Double PopImpactModifierPerc;
+	public Double PathoImpactHighPerc;
+	public Double PathoImpactModeratePerc;
+	public Double PathoImpactLowPerc;
+	public Double PathoImpactModifierPerc;
+	public Double PopImpactHighEq;
+	public Double PopImpactModerateEq;
+	public Double PopImpactLowEq;
+	public Double PopImpactModifierEq;
+	public Integer NrOfCADDScoredPopulationVars;
+	public Integer NrOfCADDScoredPathogenicVars;
+	public Double MeanPopulationCADDScore;
+	public Double MeanPathogenicCADDScore;
+	public Double MeanDifference;
+	public Double UTestPvalue;
+	public Double Sens95thPerCADDThreshold;
+	public Double Spec95thPerCADDThreshold;
+	
+	public enum Category{
+		N1, N2, T1, T2, I1, I2, I3, C1, C2, C3, C4, C5
+	}
+	
+	public GavinEntry(String lineFromFile) throws Exception
+	{
+		String[] split = lineFromFile.split("\t", -1);
+		if(split.length != 30)
+		{
+			throw new Exception("not 30 elements");
+		}
+		
+		this.gene = split[0];
+		this.category = Category.valueOf(split[1]);
+		this.chromosome = split[2];
+		this.start = Integer.valueOf(split[3]);
+		this.end = Integer.valueOf(split[4]);
+		this.NrOfPopulationVariants = Integer.valueOf(split[5]);
+		this.NrOfPathogenicVariants = Integer.valueOf(split[6]);
+		this.NrOfOverlappingVariants = Integer.valueOf(split[7]);
+		this.NrOfFilteredPopVariants = Integer.valueOf(split[8]);
+		this.PathoMAFThreshold = split[9].isEmpty() ? null : Double.parseDouble(split[9]);
+		
+		this.PopImpactHighPerc = split[10].isEmpty() ? null : Double.parseDouble(split[10]);
+		this.PopImpactModeratePerc = split[11].isEmpty() ? null : Double.parseDouble(split[11]);
+		this.PopImpactLowPerc = split[12].isEmpty() ? null : Double.parseDouble(split[12]);
+		this.PopImpactModifierPerc = split[13].isEmpty() ? null : Double.parseDouble(split[13]);
+		
+		this.PathoImpactHighPerc = split[14].isEmpty() ? null : Double.parseDouble(split[14]);
+		this.PathoImpactModeratePerc = split[15].isEmpty() ? null : Double.parseDouble(split[15]);
+		this.PathoImpactLowPerc = split[16].isEmpty() ? null : Double.parseDouble(split[16]);
+		this.PathoImpactModifierPerc = split[17].isEmpty() ? null : Double.parseDouble(split[17]);
+	
+		this.PopImpactHighEq = split[18].isEmpty() ? null : Double.parseDouble(split[18]);
+		this.PopImpactModerateEq = split[19].isEmpty() ? null : Double.parseDouble(split[19]);
+		this.PopImpactLowEq = split[20].isEmpty() ? null : Double.parseDouble(split[20]);
+		this.PopImpactModifierEq = split[21].isEmpty() ? null : Double.parseDouble(split[21]);
+		
+		this.NrOfCADDScoredPopulationVars = split[22].isEmpty() ? null : Integer.parseInt(split[22]);
+		this.NrOfCADDScoredPathogenicVars = split[23].isEmpty() ? null : Integer.parseInt(split[23]);
+		
+		this.MeanPopulationCADDScore = split[24].isEmpty() ? null : Double.parseDouble(split[24]);
+		this.MeanPathogenicCADDScore = split[25].isEmpty() ? null : Double.parseDouble(split[25]);
+		this.MeanDifference = split[26].isEmpty() ? null : Double.parseDouble(split[26]);
+		this.UTestPvalue = split[27].isEmpty() ? null : Double.parseDouble(split[27]);
+		this.Sens95thPerCADDThreshold = split[28].isEmpty() ? null : Double.parseDouble(split[28]);
+		this.Spec95thPerCADDThreshold = split[29].isEmpty() ? null : Double.parseDouble(split[29]);
+	}
+		
+}

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/Judgment.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/gavin/Judgment.java
@@ -7,7 +7,7 @@ public class Judgment
 {
 	public enum Classification
 	{
-		Benign, Pathognic, VOUS
+		Benign, Pathogenic, VOUS
 	}
 
 	public enum Method
@@ -18,12 +18,14 @@ public class Judgment
 	String reason;
 	Classification classification;
 	Method method;
+	String gene;
 
-	public Judgment(Classification classification, Method method, String reason)
+	public Judgment(Classification classification, Method method, String gene, String reason)
 	{
 		this.reason = reason;
 		this.classification = classification;
 		this.method = method;
+		this.gene = gene;
 	}
 
 	public String getReason()
@@ -39,6 +41,10 @@ public class Judgment
 	public Method getConfidence()
 	{
 		return method;
+	}
+
+	public String getGene() {
+		return gene;
 	}
 
 	@Override

--- a/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/snpEff/SnpEffRunner.java
+++ b/molgenis-data-annotators/src/main/java/org/molgenis/data/annotation/entity/impl/snpEff/SnpEffRunner.java
@@ -77,11 +77,6 @@ public class SnpEffRunner
 
 	private EffectsMetaData effectsMetaData = new EffectsMetaData();
 
-	public enum Impact
-	{
-		MODIFIER, LOW, MODERATE, HIGH
-	}
-
 	private final JarRunner jarRunner;
 	private final Entity snpEffAnnotatorSettings;
 	private final IdGenerator idGenerator;

--- a/molgenis-data-annotators/src/test/java/org/molgenis/data/annotation/entity/impl/GavinAnnotatorTest.java
+++ b/molgenis-data-annotators/src/test/java/org/molgenis/data/annotation/entity/impl/GavinAnnotatorTest.java
@@ -121,7 +121,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Benign");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "genomewide");
-		expectedEntity.set(GavinAnnotator.REASON, "CADDscore of 1.0 is less than a global threshold of 15, although the variant MAF of 1.0E-5 is rare enough to be potentially pathogenic.");
+		expectedEntity.set(GavinAnnotator.REASON, "Variant CADD score of 1.0 is less than a global threshold of 15, although the variant MAF of 1.0E-5 is rare enough to be potentially pathogenic.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -154,7 +154,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "VOUS");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "genomewide");
 		expectedEntity.set(GavinAnnotator.REASON,
-				"Unable to classify variant as benign or pathogenic. The combination of HIGH impact, a CADD score null and MAF of 1.0E-5 in TFR2 is inconclusive.");
+				"Unable to classify variant as benign or pathogenic. The combination of HIGH impact, a CADD score of null and MAF of 1.0E-5 in TFR2 is inconclusive.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -187,7 +187,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Benign");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "calibrated");
 		expectedEntity.set(GavinAnnotator.REASON,
-				"Variant CADD score of 6.0 is less than 30.35 for this gene, although the variant MAF of 1.0E-5 is less than a MAF of 0.0019269599999999954.");
+				"Variant CADD score of 6.0 is less than 30.35 for this gene.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -219,7 +219,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Pathogenic");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "calibrated");
 		expectedEntity.set(GavinAnnotator.REASON,
-				"Variant CADD score of 80.0 is greater than 30.35 for this gene. Also, the variant MAF of 1.0E-5 is less than a MAF of 0.0019269599999999954.");
+				"Variant CADD score of 80.0 is greater than 30.35 for this gene.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));

--- a/molgenis-data-annotators/src/test/java/org/molgenis/data/annotation/entity/impl/GavinAnnotatorTest.java
+++ b/molgenis-data-annotators/src/test/java/org/molgenis/data/annotation/entity/impl/GavinAnnotatorTest.java
@@ -90,7 +90,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Benign");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "genomewide");
-		expectedEntity.set(GavinAnnotator.REASON, "MAF > 0.00474");
+		expectedEntity.set(GavinAnnotator.REASON, "Variant MAF of 2.0 is not rare enough to generally be considered pathogenic.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -121,7 +121,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		Entity expectedEntity = new MapEntity("expected");
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Benign");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "genomewide");
-		expectedEntity.set(GavinAnnotator.REASON, "CADDscore <= 15");
+		expectedEntity.set(GavinAnnotator.REASON, "CADDscore of 1.0 is less than a global threshold of 15, although the variant MAF of 1.0E-5 is rare enough to be potentially pathogenic.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -154,7 +154,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "VOUS");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "genomewide");
 		expectedEntity.set(GavinAnnotator.REASON,
-				"Unable to classify variant as benign or pathogenic. The combination of HIGH impact, a CADD score [missing] and MAF of 1.0E-5 in TFR2 is inconclusive.");
+				"Unable to classify variant as benign or pathogenic. The combination of HIGH impact, a CADD score null and MAF of 1.0E-5 in TFR2 is inconclusive.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -187,7 +187,7 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Benign");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "calibrated");
 		expectedEntity.set(GavinAnnotator.REASON,
-				"Variant CADD score of 6.0 is lesser than the 95% sensitivity threshold of 35.35 for this gene, although the variant MAF of 1.0E-5 is lesser than the pathogenic 95th percentile MAF of 1.9269599999999953E-4.");
+				"Variant CADD score of 6.0 is less than 30.35 for this gene, although the variant MAF of 1.0E-5 is less than a MAF of 0.0019269599999999954.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));
@@ -216,10 +216,10 @@ public class GavinAnnotatorTest extends AbstractTestNGSpringContextTests
 		assertFalse(results.hasNext());
 
 		Entity expectedEntity = new MapEntity("expected");
-		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Pathognic");
+		expectedEntity.set(GavinAnnotator.CLASSIFICATION, "Pathogenic");
 		expectedEntity.set(GavinAnnotator.CONFIDENCE, "calibrated");
 		expectedEntity.set(GavinAnnotator.REASON,
-				"Variant CADD score of 80.0 is greater than the 95% specificity threshold of 35.35 for this gene. Also, the variant MAF of 1.0E-5 is lesser than the pathogenic 95th percentile MAF of 1.9269599999999953E-4.");
+				"Variant CADD score of 80.0 is greater than 30.35 for this gene. Also, the variant MAF of 1.0E-5 is less than a MAF of 0.0019269599999999954.");
 
 		assertEquals(resultEntity.get(GavinAnnotator.CLASSIFICATION),
 				expectedEntity.get(GavinAnnotator.CLASSIFICATION));


### PR DESCRIPTION
Fixed GAVIN logic, now matches the algorithm used in latest paper version
Refactored the classification function, now used in downstream dependencies, removing duplicated code
Cleanup of Impact class, no longer duplicated
Fixed typo of 'pathogenic'
Added comments and explanations
