### PR TITLE
Request parameters now usable in templates

### DIFF
--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -44,6 +44,7 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.view.freemarker.FreeMarkerConfigurer;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
 import java.io.File;
@@ -163,7 +164,7 @@ public class DataExplorerController extends MolgenisPluginController
 
 	@RequestMapping(value = "/module/{moduleId}", method = GET)
 	public String getModule(@PathVariable("moduleId") String moduleId, @RequestParam("entity") String entityName,
-			Model model)
+			Model model, HttpServletRequest request)
 	{
 		if (moduleId.equals(MOD_DATA))
 		{
@@ -172,6 +173,10 @@ public class DataExplorerController extends MolgenisPluginController
 		}
 		else if (moduleId.equals(MOD_ENTITIESREPORT))
 		{
+			for(Map.Entry<String, String[]> e: request.getParameterMap().entrySet())
+			{
+				model.addAttribute(e.getKey(), e.getValue()[0]);
+			}
 			model.addAttribute("datasetRepository", dataService.getRepository(entityName));
 			model.addAttribute("viewName", dataExplorerSettings.getEntityReport(entityName));
 		}

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
@@ -94,7 +94,7 @@ function($, molgenis, settingsXhr) {
 		var items = [];
 		items.push('<ul class="nav nav-tabs pull-left" style="width: 100%" role="tablist">');
 		$.each(modules, function() {
-			var href = molgenis.getContextUrl() + '/module/' + this.id+'?entity=' + entity;
+			var href = molgenis.getContextUrl() + '/module/' + this.id+'?entity=' + entity + "&" + window.location.search;
 			items.push('<li data-id="' + this.id + '"><a href="' + href + '" data-target="#tab-' + this.id + '" data-id="' + this.id + '" role="tab" data-toggle="tab"><img src="/img/' + this.icon + '"> ' + this.label + '</a></li>');
 		});
         items.push('<li class="pull-right">');

--- a/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/DataExplorerControllerTest.java
+++ b/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/DataExplorerControllerTest.java
@@ -73,12 +73,12 @@ public class DataExplorerControllerTest extends AbstractTestNGSpringContextTests
 	public void getAnnotatorModuleSuccess() throws Exception
 	{
 		assertEquals("view-dataexplorer-mod-" + DataExplorerController.MOD_ANNOTATORS,
-				controller.getModule(DataExplorerController.MOD_ANNOTATORS, "yes", mock(Model.class)));
+				controller.getModule(DataExplorerController.MOD_ANNOTATORS, "yes", mock(Model.class), null));
 	}
 
 	@Test(expectedExceptions = MolgenisDataAccessException.class)
 	public void getAnnotatorModuleFail() throws Exception
 	{
-		controller.getModule(DataExplorerController.MOD_ANNOTATORS, "no", mock(Model.class));
+		controller.getModule(DataExplorerController.MOD_ANNOTATORS, "no", mock(Model.class), null);
 	}
 }


### PR DESCRIPTION
Request parameters now passed down via dataexplorer.js, and put in model by data explorer controller so that templates can now receive variables via URL. This allows for example a Freemarker template to list certain items, onclick navigate to a URL with the ID of that item, and subsequently construct a parameterized page. This is very handy when you want to list patients with a multi-sample VCF file but only create a report for one patient, selectable with a drop down.