### PR TITLE
Fix #5165: When importing, lookupAttributes get stored in the entities repository but not in the EntityMetaData POJO

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/meta/EntityMetaDataRepository.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/EntityMetaDataRepository.java
@@ -204,6 +204,7 @@ class EntityMetaDataRepository
 		emd.setAbstract(entityMetaData.isAbstract());
 		emd.setDescription(entityMetaData.getDescription());
 		emd.setBackend(entityMetaData.getBackend() == null ? collection.getName() : entityMetaData.getBackend());
+		emd.setLookupAttributes(stream(entityMetaData.getOwnLookupAttributes().spliterator(), false));
 
 		// Language attributes
 		for (String languageCode : entityMetaData.getDescriptionLanguageCodes())


### PR DESCRIPTION
#### Checklist
- [ ] Unit tests
- [ ] Updated testplan

