### PR TITLE
Allow http access, we need it!

### DIFF
--- a/molgenis-data-elasticsearch/src/main/resources/elasticsearch.yml
+++ b/molgenis-data-elasticsearch/src/main/resources/elasticsearch.yml
@@ -235,7 +235,7 @@ network.host: localhost
 
 # Disable HTTP completely:
 #
-http.enabled: false
+# http.enabled: false
 
 
 ################################### Gateway ###################################


### PR DESCRIPTION
Tested on local VM and can confirm that setting elasticsearch property network.host=localhost makes ElasticSearch refuse connections from my desktop to my VM.

New PR cause I need my master branch even more than http access to elasticsearch :)
