### PR TITLE
Fix #5426 Indexing a single entity with non-string id

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/index/job/IndexJob.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/index/job/IndexJob.java
@@ -9,6 +9,7 @@ import org.molgenis.data.index.meta.IndexActionGroupMetaData;
 import org.molgenis.data.index.meta.IndexActionMetaData;
 import org.molgenis.data.jobs.Job;
 import org.molgenis.data.jobs.Progress;
+import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.QueryImpl;
 import org.slf4j.Logger;
@@ -23,6 +24,7 @@ import static java.util.stream.Collectors.toList;
 import static org.molgenis.data.QueryRule.Operator.EQUALS;
 import static org.molgenis.data.index.meta.IndexActionGroupMetaData.INDEX_ACTION_GROUP;
 import static org.molgenis.data.index.meta.IndexActionMetaData.*;
+import static org.molgenis.util.EntityUtils.getTypedValue;
 
 /**
  * {@link Job} that executes a bunch of {@link IndexActionMetaData} stored in a {@link IndexActionGroupMetaData}.
@@ -168,23 +170,28 @@ class IndexJob extends Job
 	/**
 	 * Indexes one single entity instance.
 	 *
-	 * @param entityFullName the fully qualified name of the entity's repository
-	 * @param entityId       the identifier of the entity to update
+	 * @param entityFullName  the fully qualified name of the entity's repository
+	 * @param untypedEntityId the identifier of the entity to update
 	 */
-	private void rebuildIndexOneEntity(String entityFullName, String entityId)
+	private void rebuildIndexOneEntity(String entityFullName, String untypedEntityId)
 	{
-		LOG.trace("Indexing [{}].[{}]... ", entityFullName, entityId);
+		LOG.trace("Indexing [{}].[{}]... ", entityFullName, untypedEntityId);
+
+		// convert entity id string to typed entity id
+		EntityType entityType = dataService.getEntityType(entityFullName);
+		Object entityId =
+				entityType != null ? getTypedValue(untypedEntityId, entityType.getIdAttribute()) : untypedEntityId;
+
 		Entity actualEntity = dataService.findOneById(entityFullName, entityId);
 
 		if (null == actualEntity)
 		{
 			// Delete
 			LOG.debug("Index delete [{}].[{}].", entityFullName, entityId);
-			searchService.deleteById(entityId, dataService.getMeta().getEntityType(entityFullName));
+			searchService.deleteById(entityId.toString(), entityType);
 			return;
 		}
 
-		EntityType entityType = actualEntity.getEntityType();
 		boolean indexEntityExists = searchService.hasMapping(entityType);
 		if (!indexEntityExists)
 		{

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/index/job/IndexJobTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/index/job/IndexJobTest.java
@@ -85,6 +85,7 @@ public class IndexJobTest extends AbstractMolgenisSpringTest
 		testEntityType = harness.createDynamicRefEntityType();
 		when(mds.getEntityType("test")).thenReturn(testEntityType);
 		toIndexEntity = harness.createTestRefEntities(testEntityType, 1).get(0);
+		when(dataService.getEntityType("test")).thenReturn(testEntityType);
 		when(dataService.findOneById("test", "entityId")).thenReturn(toIndexEntity);
 	}
 

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
@@ -1043,14 +1043,13 @@ public class RestController
 		}
 		Object id = getTypedValue(untypedId, meta.getIdAttribute());
 
-		Entity existing = dataService.findOneById(entityName, id, MetaUtils.getEntityTypeFetch());
+		Entity existing = dataService.findOneById(entityName, id, new Fetch().field(meta.getIdAttribute().getName()));
 		if (existing == null)
 		{
 			throw new UnknownEntityException("Entity of type " + entityName + " with id " + id + " not found");
 		}
 
 		Entity entity = this.restService.toEntity(meta, entityMap);
-		entity.set(meta.getIdAttribute().getName(), existing.getIdValue());
 
 		dataService.update(entityName, entity);
 		restService.updateMappedByEntities(entity, existing);

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
@@ -177,7 +177,7 @@ public class RestControllerTest extends AbstractTestNGSpringContextTests
 		when(dataService.getEntityNames()).thenReturn(Stream.of(ENTITY_NAME));
 		when(dataService.getRepository(ENTITY_NAME)).thenReturn(repo);
 
-		when(dataService.findOneById(ENTITY_NAME, ENTITY_UNTYPED_ID, getEntityTypeFetch())).thenReturn(entity);
+		when(dataService.findOneById(eq(ENTITY_NAME), eq(ENTITY_UNTYPED_ID), any(Fetch.class))).thenReturn(entity);
 		when(dataService.findOneById(ENTITY_NAME, ENTITY_UNTYPED_ID)).thenReturn(entity);
 
 		Query<Entity> q = new QueryImpl<>().eq("name", "Piet").pageSize(10).offset(5);
@@ -540,7 +540,7 @@ public class RestControllerTest extends AbstractTestNGSpringContextTests
 	@Test
 	public void updateInternalRepoExistingIsNull() throws Exception
 	{
-		when(dataService.findOneById(ENTITY_NAME, ENTITY_UNTYPED_ID, getEntityTypeFetch())).thenReturn(null);
+		when(dataService.findOneById(eq(ENTITY_NAME), eq(ENTITY_UNTYPED_ID), any(Fetch.class))).thenReturn(null);
 
 		mockMvc.perform(put(HREF_ENTITY_ID).content("{name:Klaas}").contentType(APPLICATION_JSON))
 				.andExpect(status().isNotFound());


### PR DESCRIPTION
Partial fix for #5426, editing rows containing computed attributes still not working.

#### Checklist
- [x] Unit tests
