### PR TITLE
Fix #5509: Wrong error message when converting INT to MREF

### DIFF
--- a/molgenis-data-platform/src/main/java/org/molgenis/data/platform/decorators/MolgenisRepositoryDecoratorFactory.java
+++ b/molgenis-data-platform/src/main/java/org/molgenis/data/platform/decorators/MolgenisRepositoryDecoratorFactory.java
@@ -191,21 +191,19 @@ public class MolgenisRepositoryDecoratorFactory implements RepositoryDecoratorFa
 		}
 		else if (repo.getName().equals(ATTRIBUTE_META_DATA))
 		{
-			repo = (Repository<Entity>) (Repository<? extends Entity>) new AttributeRepositoryValidationDecorator(
-					(Repository<Attribute>) (Repository<? extends Entity>) repo, attributeValidator);
-
 			repo = (Repository<Entity>) (Repository<? extends Entity>) new AttributeRepositoryDecorator(
 					(Repository<Attribute>) (Repository<? extends Entity>) repo, systemEntityTypeRegistry, dataService,
 					permissionService);
+			repo = (Repository<Entity>) (Repository<? extends Entity>) new AttributeRepositoryValidationDecorator(
+					(Repository<Attribute>) (Repository<? extends Entity>) repo, attributeValidator);
 		}
 		else if (repo.getName().equals(ENTITY_TYPE_META_DATA))
 		{
-			repo = (Repository<Entity>) (Repository<? extends Entity>) new EntityTypeRepositoryValidationDecorator(
-					(Repository<EntityType>) (Repository<? extends Entity>) repo, entityTypeValidator);
-
 			repo = (Repository<Entity>) (Repository<? extends Entity>) new EntityTypeRepositoryDecorator(
 					(Repository<EntityType>) (Repository<? extends Entity>) repo, dataService, systemEntityTypeRegistry,
 					permissionService);
+			repo = (Repository<Entity>) (Repository<? extends Entity>) new EntityTypeRepositoryValidationDecorator(
+					(Repository<EntityType>) (Repository<? extends Entity>) repo, entityTypeValidator);
 		}
 		else if (repo.getName().equals(PACKAGE))
 		{


### PR DESCRIPTION
#### Checklist
- [ ] Unit tests
- [ ] Updated testplan

The Decorators for Attribute and EntityType are added in the wrong order. You need to add the inner decorator first.