### PR TITLE
Fix #5536 Changing the datatype of xstring (TypeTest) to int results in wrong error message

### DIFF
--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/AttributeValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/AttributeValidator.java
@@ -190,7 +190,9 @@ public class AttributeValidator
 			}
 			catch (NumberFormatException e)
 			{
-				throw new MolgenisDataException(format("%s %s", e.getClass().getSimpleName(), e.getMessage()));
+				throw new MolgenisValidationException(new ConstraintViolation(
+						format("Invalid default value [%s] for data type [%s]", value, attr.getDataType())
+				));
 			}
 		}
 	}

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/AttributeValidatorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/AttributeValidatorTest.java
@@ -245,38 +245,24 @@ public class AttributeValidatorTest
 
 	}
 
-	@Test
+	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Invalid default value \\[test\\] for data type \\[INT\\]")
 	public void testDefaultValueInt1()
 	{
 		Attribute attr = mock(Attribute.class);
 		when(attr.getDefaultValue()).thenReturn("test");
 		when(attr.getDataType()).thenReturn(AttributeType.INT);
-		try
-		{
-			attributeValidator.validateDefaultValue(attr);
-			Assert.fail();
-		}
-		catch (MolgenisDataException actual)
-		{
-			assertEquals(actual.getMessage(), "NumberFormatException For input string: \"test\"");
-		}
+		attributeValidator.validateDefaultValue(attr);
+		Assert.fail();
 	}
 
-	@Test
+	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Invalid default value \\[1.0\\] for data type \\[INT\\]")
 	public void testDefaultValueInt2()
 	{
 		Attribute attr = mock(Attribute.class);
 		when(attr.getDefaultValue()).thenReturn("1.0");
 		when(attr.getDataType()).thenReturn(AttributeType.INT);
-		try
-		{
-			attributeValidator.validateDefaultValue(attr);
-			Assert.fail();
-		}
-		catch (MolgenisDataException actual)
-		{
-			assertEquals(actual.getMessage(), "NumberFormatException For input string: \"1.0\"");
-		}
+		attributeValidator.validateDefaultValue(attr);
+		Assert.fail();
 	}
 
 	@Test
@@ -288,21 +274,13 @@ public class AttributeValidatorTest
 		attributeValidator.validateDefaultValue(attr);
 	}
 
-	@Test
+	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Invalid default value \\[test\\] for data type \\[LONG\\]")
 	public void testDefaultValueLong()
 	{
 		Attribute attr = mock(Attribute.class);
 		when(attr.getDefaultValue()).thenReturn("test");
 		when(attr.getDataType()).thenReturn(AttributeType.LONG);
-		try
-		{
-			attributeValidator.validateDefaultValue(attr);
-			Assert.fail();
-		}
-		catch (MolgenisDataException actual)
-		{
-			assertEquals(actual.getMessage(), "NumberFormatException For input string: \"test\"");
-		}
+		attributeValidator.validateDefaultValue(attr);
 	}
 
 	@Test


### PR DESCRIPTION
#### Checklist
- [x] Unit tests