### PR TITLE
M4616: When parsing VCF, if the ID is the empty string, replace it with “.”

### DIFF
--- a/molgenis-gavin/src/main/java/org/molgenis/gavin/job/input/Parser.java
+++ b/molgenis-gavin/src/main/java/org/molgenis/gavin/job/input/Parser.java
@@ -240,10 +240,14 @@ public class Parser
 		String chrom = parseChrom(columns[CHROM_INDEX].trim());
 		Long pos = parsePos(columns[POS_INDEX].trim());
 		String id = columns[VCF_ID_INDEX].trim();
+		if (isEmpty(id))
+		{
+			id = ".";
+		}
 		String ref = parseRef(columns[VCF_REF_INDEX].trim());
 		String alt = parseAlt(columns[VCF_ALT_INDEX].trim());
 
-		if (anyNull(chrom, pos, ref, alt) || isEmpty(id))
+		if (anyNull(chrom, pos, ref, alt))
 		{
 			return null;
 		}

--- a/molgenis-gavin/src/test/java/org/molgenis/gavin/job/input/ParserTest.java
+++ b/molgenis-gavin/src/test/java/org/molgenis/gavin/job/input/ParserTest.java
@@ -61,7 +61,8 @@ public class ParserTest
 						VcfVariant.create("20", 14370, ".", "G", "A") }, { "", null },
 				{ "X\t123\tA\tC\t213.23\tblah", null }, { "X\t123\tA\tC\t213.23", null },
 				{ " X \t 123 \t rsblah \t A \t C \t 213.23", VcfVariant.create("X", 123, "rsblah", "A", "C") },
-				{ "20\t14370\tG\t.\t2.2\t3.234", CaddVariant.create("20", 14370, "G", ".", 2.2, 3.234) } };
+				{ "20\t14370\tG\t.\t2.2\t3.234", CaddVariant.create("20", 14370, "G", ".", 2.2, 3.234) },
+				{ "X\t123\t\tA\tC\t213.23", VcfVariant.create("X", 123, ".", "A", "C") } };
 	}
 
 	@Test(dataProvider = "line")


### PR DESCRIPTION
#### Checklist
- [x] Unit tests
- [ ] Updated testplan

