### PR TITLE
Fix #5798: Human readable form of filters sent to negotiator contains url-encoded identifiers

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/createHumanReadable.js
+++ b/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/createHumanReadable.js
@@ -21,7 +21,7 @@ function getHumanReadableFragment(constraint) {
 }
 
 function getSimpleFilterLineHumanReadableFragment(constraint) {
-    return constraint.selector + getComparisonHumanReadable(constraint.comparison) + constraint.arguments
+    return constraint.selector + getComparisonHumanReadable(constraint.comparison) + decodeURIComponent(constraint.arguments)
 }
 
 function getComplexFilterLineHumanReadableFragment(constraint) {

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/createHumanReadableTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/createHumanReadableTest.js
@@ -17,3 +17,12 @@ test("Test translating a complex RSQL string into a human readable string", asse
     assert.deepEqual(actual, expected);
     assert.end();
 })
+
+//
+test("Test translating url encoded IDs decodes the encoded string", assert => {
+    const actual = getHumanReadable("biobank==bbmri-eric%3AID%3ASE_1721")
+    const expected = "biobank equals bbmri-eric:ID:SE_1721"
+
+    assert.deepEqual(actual, expected);
+    assert.end();
+})


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Test plan template updated
- [ ] Clean commits
