### PR TITLE
Fix #5805: RSQL encodes too many characters, making it harder to read than is strictly necessary

### DIFF
--- a/molgenis-core-ui/package.json
+++ b/molgenis-core-ui/package.json
@@ -33,6 +33,7 @@
     "jquery-validation": "1.14.0",
     "jquery.cookie": "^1.4.1",
     "jquery.fancytree": "2.14.0",
+    "mdurl": "^1.0.1",
     "moment": "2.11.2",
     "moment-duration-format": "^1.3.0",
     "pegjs": "^0.10.0",

--- a/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/createHumanReadable.js
+++ b/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/createHumanReadable.js
@@ -21,7 +21,7 @@ function getHumanReadableFragment(constraint) {
 }
 
 function getSimpleFilterLineHumanReadableFragment(constraint) {
-    return constraint.selector + getComparisonHumanReadable(constraint.comparison) + decodeURIComponent(constraint.arguments)
+    return constraint.selector + getComparisonHumanReadable(constraint.comparison) + constraint.arguments
 }
 
 function getComplexFilterLineHumanReadableFragment(constraint) {

--- a/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/index.js
+++ b/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/index.js
@@ -1,8 +1,23 @@
-import parser from "./parser"
-import transformer from "./transformer"
-import { createRsqlQuery, createRsqlAggregateQuery } from "./createRsqlQuery"
-import { getHumanReadable } from "./createHumanReadable"
+import parser from "./parser";
+import transformer from "./transformer";
+import {
+    createRsqlQuery,
+    createRsqlAggregateQuery,
+    containsRsqlReservedCharacter,
+    rsqlEscape,
+    encodeRsqlValue
+} from "./createRsqlQuery";
+import {getHumanReadable} from "./createHumanReadable";
 
-export { parser, transformer, createRsqlQuery, createRsqlAggregateQuery, getHumanReadable }
+export {
+    parser,
+    transformer,
+    createRsqlQuery,
+    createRsqlAggregateQuery,
+    getHumanReadable,
+    containsRsqlReservedCharacter,
+    rsqlEscape,
+    encodeRsqlValue
+}
 
-export default { parser, transformer, createRsqlQuery, createRsqlAggregateQuery, getHumanReadable }
+export default {parser, transformer, createRsqlQuery, createRsqlAggregateQuery, getHumanReadable, encodeRsqlValue}

--- a/molgenis-core-ui/src/test/javascript/index.js
+++ b/molgenis-core-ui/src/test/javascript/index.js
@@ -6,3 +6,4 @@
 import './modules/rest-client/rsql/parserTest'
 import './modules/rest-client/rsql/transformerTest'
 import './modules/rest-client/rsql/createHumanReadableTest'
+import './modules/rest-client/rsql/createRsqlQueryTest'

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/createHumanReadableTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/createHumanReadableTest.js
@@ -17,12 +17,3 @@ test("Test translating a complex RSQL string into a human readable string", asse
     assert.deepEqual(actual, expected);
     assert.end();
 })
-
-//
-test("Test translating url encoded IDs decodes the encoded string", assert => {
-    const actual = getHumanReadable("biobank==bbmri-eric%3AID%3ASE_1721")
-    const expected = "biobank equals bbmri-eric:ID:SE_1721"
-
-    assert.deepEqual(actual, expected);
-    assert.end();
-})

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/createRsqlQueryTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/createRsqlQueryTest.js
@@ -1,0 +1,64 @@
+import {containsRsqlReservedCharacter, rsqlEscape, createRsqlQuery, encodeRsqlValue} from "rest-client/rsql";
+import test from "tape";
+
+test('Test if containsRsqlReservedCharacter checks for reserved characters', assert => {
+    assert.ok(containsRsqlReservedCharacter("abc\"def"), "Checks for \"")
+    assert.ok(containsRsqlReservedCharacter("abc'def"), "Checks for '")
+    assert.ok(containsRsqlReservedCharacter("abc(def"), "Checks for (")
+    assert.ok(containsRsqlReservedCharacter("abc)def"), "Checks for )")
+    assert.ok(containsRsqlReservedCharacter("abc;def"), "Checks for ;")
+    assert.ok(containsRsqlReservedCharacter("abc,def"), "Checks for ,")
+    assert.ok(containsRsqlReservedCharacter("abc=def"), "Checks for =")
+    assert.ok(containsRsqlReservedCharacter("abc!def"), "Checks for !")
+    assert.ok(containsRsqlReservedCharacter("abc~def"), "Checks for ~")
+    assert.ok(containsRsqlReservedCharacter("abc<def"), "Checks for <")
+    assert.ok(containsRsqlReservedCharacter("abc>def"), "Checks for >")
+    assert.ok(!containsRsqlReservedCharacter("@#&"), "Doesn't check for other characters")
+    assert.end()
+})
+
+test('rsqlEscape escapes rsql strings properly', assert => {
+    assert.equals(rsqlEscape("abc\"def"), "'abc\"def'", "Picks ' as delimiter to escape \"")
+    assert.equals(rsqlEscape("abc'def"), "\"abc'def\"", "Picks \" as delimiter to escape '")
+    assert.equals(rsqlEscape("abc=def"), "'abc=def'", "Prefers ' as delimiter")
+    assert.equals(rsqlEscape("abc\"'def"), "'abc\"\\'def'", "Escapes delimiter if it occurs inside the string")
+    assert.end()
+})
+
+test('createRsqlQuery', assert => {
+    assert.equals(createRsqlQuery([]), "", "Empty query")
+    assert.equals(createRsqlQuery([{operator: 'EQUALS', field: 'field', value: 5}]), "field==5", "field==5")
+    assert.equals(createRsqlQuery([
+        {operator: 'EQUALS', field: 'field1', value: 5},
+        {operator: 'AND'},
+        {operator: 'IN', field: 'field2', value: [6, 7]}]), "field1==5;field2=in=(6,7)", "field1==5;field2=in=(6,7)")
+    assert.equals(createRsqlQuery([
+        {operator: 'EQUALS', field: 'fiel=d', value: 5},
+        {operator: 'AND'},
+        {operator: 'IN', field: 'field2', value: ["va(*&lue", "value\""]}
+    ]), "'fiel=d'==5;field2=in=('va(*&lue','value\"')", "Escapes field names and values")
+    assert.equals(createRsqlQuery([
+        {
+            operator: 'NESTED',
+            nestedRules: [{operator: 'EQUALS', field: 'field', value: 5}]
+        }]), "field==5", "Simplifies single nested rule")
+    assert.equals(createRsqlQuery([
+        {
+            operator: 'NESTED',
+            nestedRules: [{operator: 'EQUALS', field: 'field', value: 5},
+                {operator: 'OR'},
+                {operator: 'EQUALS', field: 'field', value: 6}]
+        },
+        {operator: 'AND'},
+        {operator: 'EQUALS', field: 'field', value: 7}]), "(field==5,field==6);field==7", "(field==5,field==6);field==7")
+    assert.end()
+})
+
+test('encodeRsqlValue', assert => {
+    assert.equals(encodeRsqlValue('=:;,-()"\'~<>'), '=:;,-()"\'~<>', 'Leaves rsql syntax =:;,-()"\'~<> readable')
+    assert.equals(encodeRsqlValue('a==b&'), 'a==b%26', 'Encodes &')
+    assert.equals(encodeRsqlValue('a==b#'), 'a==b%23', 'Encodes #')
+    assert.equals(encodeRsqlValue('a==b+'), 'a==b%2B', 'Encodes +')
+    assert.equals(encodeRsqlValue('a=="b lah"'), 'a=="b%20lah"', 'Encodes space')
+    assert.end()
+})

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
@@ -452,12 +452,13 @@ $.when($,
                 }
             }
 
-            // Prevent $.param double encoding RSQL attributes and values. The RestclientV2 also encodes the RSQL
+            // Use special encoding for the rsql
             var filter = state.filter
             delete cleanState.filter
 
             // update browser state
-            if (filter) history.pushState(state, '', molgenis.getContextUrl() + '?' + $.param(cleanState) + '&filter=' + filter);
+            if (filter) history.pushState(state, '', molgenis.getContextUrl() + '?' + $.param(cleanState)
+                + '&filter=' + molgenis.rsql.encodeRsqlValue(filter));
             else history.pushState(state, '', molgenis.getContextUrl() + '?' + $.param(cleanState));
         }
 


### PR DESCRIPTION
Don’t URL encode the arguments when parsing and transforming the filter values.
URLencode the rsql parameter value before writing it to the URL query string, but only encode those characters that are strictly necessary to encode in query param values.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Test plan template updated
- [x] Clean commits
