### PR TITLE
Fix #5906 Unclear error message deleting ref entity that is in use

### DIFF
--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlExceptionTranslator.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlExceptionTranslator.java
@@ -321,22 +321,39 @@ class PostgreSqlExceptionTranslator extends SQLErrorCodeSQLExceptionTranslator i
 		String value = m.group(1);
 
 		String constraintViolationMessageTemplate;
+		String attrName;
 		if (detailMessage.contains("still referenced from"))
 		{
 			// ERROR: update or delete on table "x" violates foreign key constraint "y" on table "z"
 			// Detail: Key (k)=(v) is still referenced from table "x".
 			constraintViolationMessageTemplate = "Value '%s' for attribute '%s' is referenced by entity '%s'.";
+			String refTableName = getRefTableFromForeignKeyPsqlException(pSqlException);
+			attrName = getAttributeName(refTableName, colName);
 		}
 		else
 		{
 			// ERROR: insert or update on table "x" violates foreign key constraint "y"
 			// Detail: Key (k)=(v) is not present in table "z".
 			constraintViolationMessageTemplate = "Unknown xref value '%s' for attribute '%s' of entity '%s'.";
+			attrName = getAttributeName(tableName, colName);
 		}
 		ConstraintViolation constraintViolation = new ConstraintViolation(
-				format(constraintViolationMessageTemplate, value, getAttributeName(tableName, colName),
-						getEntityTypeName(tableName)), null);
+				format(constraintViolationMessageTemplate, value, attrName, getEntityTypeName(tableName)), null);
 		return new MolgenisValidationException(singleton(constraintViolation));
+	}
+
+	private String getRefTableFromForeignKeyPsqlException(PSQLException pSqlException)
+	{
+		ServerErrorMessage serverErrorMessage = pSqlException.getServerErrorMessage();
+		Matcher messageMatcher = Pattern.compile(
+				"update or delete on table \"(.*)\" violates foreign key constraint \"(.*)\" on table \"(.*)\"")
+				.matcher(serverErrorMessage.getMessage());
+		if (!messageMatcher.matches())
+		{
+			LOG.error("Error translating postgres exception: ", pSqlException);
+			throw new RuntimeException("Error translating exception", pSqlException);
+		}
+		return messageMatcher.group(1);
 	}
 
 	/**

--- a/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/PostgreSqlExceptionTranslatorTest.java
+++ b/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/PostgreSqlExceptionTranslatorTest.java
@@ -194,9 +194,12 @@ public class PostgreSqlExceptionTranslatorTest
 	@Test
 	public void translateForeignKeyViolationStillReferenced()
 	{
+
 		ServerErrorMessage serverErrorMessage = mock(ServerErrorMessage.class);
 		when(serverErrorMessage.getSQLState()).thenReturn("23503");
 		when(serverErrorMessage.getTable()).thenReturn("myTable");
+		when(serverErrorMessage.getMessage()).thenReturn(
+				"update or delete on table \"myDependentTable\" violates foreign key constraint \"myTable_myAttr_fkey\" on table \"myTable\"");
 		when(serverErrorMessage.getDetail())
 				.thenReturn("Key (myColumn)=(myValue) is still referenced from table \"myTable\"");
 		//noinspection ThrowableResultOfMethodCallIgnored


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] Test plan template updated
- [x] Clean commits
