### PR TITLE
Fix #5814 Genome browser produces 500 error when processing an abstract entity 

### DIFF
--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -16,6 +16,7 @@ import org.molgenis.dataexplorer.download.DataExplorerDownloadHandler;
 import org.molgenis.dataexplorer.galaxy.GalaxyDataExportException;
 import org.molgenis.dataexplorer.galaxy.GalaxyDataExportRequest;
 import org.molgenis.dataexplorer.galaxy.GalaxyDataExporter;
+import org.molgenis.dataexplorer.service.GenomeBrowserService;
 import org.molgenis.dataexplorer.settings.DataExplorerSettings;
 import org.molgenis.security.core.MolgenisPermissionService;
 import org.molgenis.security.core.Permission;
@@ -100,6 +101,9 @@ public class DataExplorerController extends MolgenisPluginController
 
 	@Autowired
 	private AttributeFactory attrMetaFactory;
+
+	@Autowired
+	private GenomeBrowserService genomeBrowserService;
 
 	public DataExplorerController()
 	{
@@ -311,7 +315,7 @@ public class DataExplorerController extends MolgenisPluginController
 	private Map<String, String> getGenomeBrowserEntities()
 	{
 		Map<String, String> genomeEntities = new HashMap<>();
-		dataService.getMeta().getEntityTypes().filter(this::isGenomeBrowserEntity).forEach(entityType ->
+		genomeBrowserService.getGenomeBrowserEntities().forEach(entityType ->
 		{
 			boolean canRead = molgenisPermissionService.hasPermissionOnEntity(entityType.getFullyQualifiedName(), READ);
 			boolean canWrite = molgenisPermissionService
@@ -322,15 +326,6 @@ public class DataExplorerController extends MolgenisPluginController
 			}
 		});
 		return genomeEntities;
-	}
-
-	private boolean isGenomeBrowserEntity(EntityType entityType)
-	{
-		Attribute attributeStartPosition = genomicDataSettings
-				.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_POS, entityType);
-		Attribute attributeChromosome = genomicDataSettings
-				.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_CHROM, entityType);
-		return attributeStartPosition != null && attributeChromosome != null;
 	}
 
 	@RequestMapping(value = "/download", method = POST)

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/service/GenomeBrowserService.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/service/GenomeBrowserService.java
@@ -1,0 +1,56 @@
+package org.molgenis.dataexplorer.service;
+
+import org.molgenis.data.DataService;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.support.GenomicDataSettings;
+import org.springframework.stereotype.Component;
+
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Service implements genomeBrowser specific business logic.
+ */
+@Component
+public class GenomeBrowserService
+{
+
+	private DataService dataService;
+
+	private GenomicDataSettings genomicDataSettings;
+
+
+	public GenomeBrowserService(
+			DataService dataService,
+			GenomicDataSettings genomicDataSettings
+	)
+	{
+		this.dataService = requireNonNull(dataService);
+		this.genomicDataSettings = requireNonNull(genomicDataSettings);
+	}
+
+	//TODO Improve performance by rewriting to query that returns all genomic entities instead of retrieving all entities and determining which one is genomic
+	/**
+	 * Fetch all non abstract genomeBrowser entities
+	 * these are defined as being non abstract and having a ATTRS_POS and ATTRS_CHROM attribute.
+	 *
+	 * @return from entity name to entityLabel
+	 */
+	public Stream<EntityType> getGenomeBrowserEntities()
+	{
+		return dataService.getMeta().getEntityTypes()
+				.filter(entityType -> !entityType.isAbstract())
+				.filter(this::isGenomeBrowserEntity);
+	}
+
+	private boolean isGenomeBrowserEntity(EntityType entityType)
+	{
+		Attribute attributeStartPosition = genomicDataSettings
+				.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_POS, entityType);
+		Attribute attributeChromosome = genomicDataSettings
+				.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_CHROM, entityType);
+		return attributeStartPosition != null && attributeChromosome != null;
+	}
+}

--- a/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/service/GenomeBrowserServiceTest.java
+++ b/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/service/GenomeBrowserServiceTest.java
@@ -1,0 +1,81 @@
+package org.molgenis.dataexplorer.service;
+
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.molgenis.data.DataService;
+import org.molgenis.data.EntityCollection;
+import org.molgenis.data.meta.MetaDataService;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.meta.model.EntityTypeFactory;
+import org.molgenis.data.support.GenomicDataSettings;
+import org.molgenis.security.core.MolgenisPermissionService;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.*;
+
+
+public class GenomeBrowserServiceTest
+{
+	@Mock
+	DataService dataService;
+
+	@Mock
+	GenomicDataSettings genomicDataSettings;
+
+
+	@InjectMocks
+	GenomeBrowserService genomeBrowserService;
+
+	@BeforeMethod
+	public void beforeMethode ()
+	{
+		dataService = mock(DataService.class);
+		genomicDataSettings = mock(GenomicDataSettings.class);
+		initMocks(this);
+	}
+
+	@Test
+	public void testGetGenomeBrowserEntities() throws Exception
+	{
+		MetaDataService metaDataService = mock(MetaDataService.class);
+		when(dataService.getMeta()).thenReturn(metaDataService);
+
+		EntityType genomeEntityType = mock(EntityType.class);
+		when(genomeEntityType.isAbstract()).thenReturn(false);
+		when(genomeEntityType.getFullyQualifiedName()).thenReturn("FullyQualifiedName");
+		when(genomeEntityType.getLabel()).thenReturn("Label");
+		EntityType abtractGenomeEntityType = mock(EntityType.class);
+		when(abtractGenomeEntityType.isAbstract()).thenReturn(true);
+		EntityType nonGenomeEntityType = mock(EntityType.class);
+		when(nonGenomeEntityType.isAbstract()).thenReturn(false);
+
+		Attribute attribute = mock(Attribute.class);
+
+		when(genomicDataSettings.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_POS, genomeEntityType)).thenReturn(attribute);
+		when(genomicDataSettings.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_CHROM, genomeEntityType)).thenReturn(attribute);
+		when(genomicDataSettings.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_POS, abtractGenomeEntityType)).thenReturn(attribute);
+		when(genomicDataSettings.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_CHROM, abtractGenomeEntityType)).thenReturn(attribute);
+		when(genomicDataSettings.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_POS, nonGenomeEntityType)).thenReturn(null);
+		when(genomicDataSettings.getAttributeMetadataForAttributeNameArray(GenomicDataSettings.Meta.ATTRS_CHROM, nonGenomeEntityType)).thenReturn(null);
+
+		Stream<EntityType> entityTypes = Stream.of(genomeEntityType, abtractGenomeEntityType, nonGenomeEntityType);
+		when(metaDataService.getEntityTypes()).thenReturn(entityTypes);
+
+		List<EntityType> resultList =  genomeBrowserService.getGenomeBrowserEntities().collect(Collectors.toList());
+		assertEquals(resultList.size(), 1);
+		assertEquals(resultList.get(0), genomeEntityType);
+
+	}
+
+}


### PR DESCRIPTION
Filter out abstract entities, as these can not be displayed.

+ Move logic to service
+ Add unit test

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [ ] Clean commits
