### PR TITLE
Fix #5944 Invalid swagger yaml if entity name contains `#`

### DIFF
--- a/molgenis-swagger/src/main/resources/templates/view-swagger.ftl
+++ b/molgenis-swagger/src/main/resources/templates/view-swagger.ftl
@@ -66,7 +66,7 @@ paths:
           required: true
           enum:
 <#list entityTypes as entityType>
-            - ${entityType}
+            - "${entityType?json_string}"
 </#list>
         - name: attrs
           type: array
@@ -142,7 +142,7 @@ paths:
           required: true
           enum:
 <#list entityTypes as entityType>
-            - ${entityType}
+            - "${entityType?json_string}"
 </#list>
         - name: body
           in: body
@@ -181,7 +181,7 @@ paths:
           required: true
           enum:
 <#list entityTypes as entityType>
-            - ${entityType}
+            - "${entityType?json_string}"
 </#list>
         - name: id
           in: path
@@ -259,7 +259,7 @@ paths:
           required: true
           enum:
 <#list entityTypes as entityType>
-            - ${entityType}
+            - "${entityType?json_string}"
 </#list>
         - name: body
           schema:


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
