### PR TITLE
Fix #5969: Cannot do clean install nor update mail settings

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/AbstractSystemRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/AbstractSystemRepositoryDecoratorFactory.java
@@ -1,7 +1,6 @@
 package org.molgenis.data;
 
 import org.molgenis.data.meta.SystemEntityType;
-import org.molgenis.data.support.StaticEntity;
 
 import static java.util.Objects.requireNonNull;
 
@@ -11,7 +10,7 @@ import static java.util.Objects.requireNonNull;
  * @param <E>
  * @param <M>
  */
-public abstract class AbstractSystemRepositoryDecoratorFactory<E extends StaticEntity, M extends SystemEntityType>
+public abstract class AbstractSystemRepositoryDecoratorFactory<E extends Entity, M extends SystemEntityType>
 		implements SystemRepositoryDecoratorFactory<E, M>
 {
 	private final M entityType;

--- a/molgenis-data/src/main/java/org/molgenis/data/SystemRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/SystemRepositoryDecoratorFactory.java
@@ -1,14 +1,13 @@
 package org.molgenis.data;
 
 import org.molgenis.data.meta.SystemEntityType;
-import org.molgenis.data.support.StaticEntity;
 
 /**
  * Repository decorator factory that creates decorated {@link Repository repositories} for specific {@link SystemEntityType system entity types}.
  *
  * @see RepositoryDecoratorFactory
  */
-public interface SystemRepositoryDecoratorFactory<E extends StaticEntity, M extends SystemEntityType>
+public interface SystemRepositoryDecoratorFactory<E extends Entity, M extends SystemEntityType>
 {
 	/**
 	 * Returns system entity type for which repository decorators can be created.

--- a/molgenis-settings/src/main/java/org/molgenis/settings/mail/MailSettingsRepositoryDecorator.java
+++ b/molgenis-settings/src/main/java/org/molgenis/settings/mail/MailSettingsRepositoryDecorator.java
@@ -1,18 +1,19 @@
 package org.molgenis.settings.mail;
 
 import org.molgenis.data.AbstractRepositoryDecorator;
+import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
 import org.molgenis.util.mail.MailSenderFactory;
-import org.molgenis.util.mail.MailSettings;
+
 
 import static java.util.Objects.requireNonNull;
 
-public class MailSettingsRepositoryDecorator extends AbstractRepositoryDecorator<MailSettingsImpl>
+public class MailSettingsRepositoryDecorator extends AbstractRepositoryDecorator<Entity>
 {
-	private final Repository<MailSettingsImpl> decoratedRepository;
+	private final Repository<Entity> decoratedRepository;
 	private final MailSenderFactory mailSenderFactory;
 
-	public MailSettingsRepositoryDecorator(Repository<MailSettingsImpl> decoratedRepository,
+	public MailSettingsRepositoryDecorator(Repository<Entity> decoratedRepository,
 			MailSenderFactory mailSenderFactory)
 	{
 		this.decoratedRepository = requireNonNull(decoratedRepository);
@@ -20,20 +21,20 @@ public class MailSettingsRepositoryDecorator extends AbstractRepositoryDecorator
 	}
 
 	@Override
-	protected Repository<MailSettingsImpl> delegate()
+	protected Repository<Entity> delegate()
 	{
 		return decoratedRepository;
 	}
 
 	@Override
-	public void add(MailSettingsImpl entity)
+	public void add(Entity entity)
 	{
 		validate(entity);
 		delegate().add(entity);
 	}
 
 	@Override
-	public void update(MailSettingsImpl entity)
+	public void update(Entity entity)
 	{
 		validate(entity);
 		delegate().update(entity);
@@ -42,10 +43,11 @@ public class MailSettingsRepositoryDecorator extends AbstractRepositoryDecorator
 	/**
 	 * Validates MailSettings.
 	 *
-	 * @param mailSettings the MailSettings to validate
+	 * @param entity the MailSettings to validate
 	 */
-	private void validate(MailSettings mailSettings)
+	private void validate(Entity entity)
 	{
+		MailSettingsImpl mailSettings = new MailSettingsImpl(entity);
 		if (mailSettings.isTestConnection() && mailSettings.getUsername() != null && mailSettings.getPassword() != null)
 		{
 			mailSenderFactory.validateConnection(mailSettings);

--- a/molgenis-settings/src/main/java/org/molgenis/settings/mail/MailSettingsRepositoryDecoratorFactory.java
+++ b/molgenis-settings/src/main/java/org/molgenis/settings/mail/MailSettingsRepositoryDecoratorFactory.java
@@ -1,6 +1,7 @@
 package org.molgenis.settings.mail;
 
 import org.molgenis.data.AbstractSystemRepositoryDecoratorFactory;
+import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
 import org.molgenis.util.mail.MailSenderFactory;
 import org.springframework.stereotype.Component;
@@ -9,7 +10,7 @@ import static java.util.Objects.requireNonNull;
 
 @Component
 public class MailSettingsRepositoryDecoratorFactory
-		extends AbstractSystemRepositoryDecoratorFactory<MailSettingsImpl, MailSettingsImpl.Meta>
+		extends AbstractSystemRepositoryDecoratorFactory<Entity, MailSettingsImpl.Meta>
 {
 	private final MailSenderFactory mailSenderFactory;
 
@@ -21,7 +22,7 @@ public class MailSettingsRepositoryDecoratorFactory
 	}
 
 	@Override
-	public Repository<MailSettingsImpl> createDecoratedRepository(Repository<MailSettingsImpl> repository)
+	public Repository<Entity> createDecoratedRepository(Repository<Entity> repository)
 	{
 		return new MailSettingsRepositoryDecorator(repository, mailSenderFactory);
 	}

--- a/molgenis-settings/src/test/java/org/molgenis/settings/mail/MailSettingsRepositoryDecoratorTest.java
+++ b/molgenis-settings/src/test/java/org/molgenis/settings/mail/MailSettingsRepositoryDecoratorTest.java
@@ -1,31 +1,41 @@
 package org.molgenis.settings.mail;
 
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
-import org.molgenis.test.AbstractMockitoTest;
 import org.molgenis.util.mail.MailSenderFactory;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
 
-public class MailSettingsRepositoryDecoratorTest extends AbstractMockitoTest
+public class MailSettingsRepositoryDecoratorTest
 {
 	private MailSettingsRepositoryDecorator mailSettingsRepositoryDecorator;
 	@Mock
-	private MailSettingsImpl mailSettings;
+	private Entity entity;
 	@Mock
 	private MailSenderFactory mailSenderFactory;
 	@Mock
-	private Repository<MailSettingsImpl> decorated;
+	private Repository<Entity> decorated;
+
+	@BeforeClass
+	public void beforeClass()
+	{
+		initMocks(this);
+		mailSettingsRepositoryDecorator = new MailSettingsRepositoryDecorator(decorated, mailSenderFactory);
+	}
 
 	@BeforeMethod
 	public void beforeMethod()
 	{
-		mailSettingsRepositoryDecorator = new MailSettingsRepositoryDecorator(decorated, mailSenderFactory);
+		Mockito.reset(entity, mailSenderFactory, decorated);
 	}
 
 	@DataProvider(name = "addDontTest")
@@ -38,41 +48,40 @@ public class MailSettingsRepositoryDecoratorTest extends AbstractMockitoTest
 	@Test(dataProvider = "addDontTest")
 	public void testAddDontTestConnection(boolean testConnection, String username, String password)
 	{
-		when(mailSettings.isTestConnection()).thenReturn(testConnection);
-		when(mailSettings.getUsername()).thenReturn(username);
-		when(mailSettings.getPassword()).thenReturn(password);
-
-		mailSettingsRepositoryDecorator.add(mailSettings);
+		when(entity.getBoolean(MailSettingsImpl.Meta.TEST_CONNECTION)).thenReturn(testConnection);
+		when(entity.getString(MailSettingsImpl.Meta.USERNAME)).thenReturn(username);
+		when(entity.getString(MailSettingsImpl.Meta.PASSWORD)).thenReturn(password);
+		mailSettingsRepositoryDecorator.add(entity);
 		verify(mailSenderFactory, never()).validateConnection(any(MailSettingsImpl.class));
-		verify(decorated).add(mailSettings);
+		verify(decorated).add(entity);
 		verifyNoMoreInteractions(decorated);
 	}
 
 	@Test
 	public void testAddValidSettings()
 	{
-		when(mailSettings.isTestConnection()).thenReturn(true);
-		when(mailSettings.getUsername()).thenReturn("Username");
-		when(mailSettings.getPassword()).thenReturn("password");
+		when(entity.getBoolean(MailSettingsImpl.Meta.TEST_CONNECTION)).thenReturn(true);
+		when(entity.getString(MailSettingsImpl.Meta.USERNAME)).thenReturn("Username");
+		when(entity.getString(MailSettingsImpl.Meta.PASSWORD)).thenReturn("password");
 
-		mailSettingsRepositoryDecorator.add(mailSettings);
+		mailSettingsRepositoryDecorator.add(entity);
 		verify(mailSenderFactory).validateConnection(any(MailSettingsImpl.class));
-		verify(decorated).add(mailSettings);
+		verify(decorated).add(entity);
 		verifyNoMoreInteractions(decorated);
 	}
 
 	@Test
 	public void testAddInvalidSettings()
 	{
-		when(mailSettings.isTestConnection()).thenReturn(true);
-		when(mailSettings.getUsername()).thenReturn("Username");
-		when(mailSettings.getPassword()).thenReturn("password");
+		when(entity.getBoolean(MailSettingsImpl.Meta.TEST_CONNECTION)).thenReturn(true);
+		when(entity.getString(MailSettingsImpl.Meta.USERNAME)).thenReturn("Username");
+		when(entity.getString(MailSettingsImpl.Meta.PASSWORD)).thenReturn("password");
 
 		doThrow(IllegalStateException.class).when(mailSenderFactory).validateConnection(any(MailSettingsImpl.class));
 
 		try
 		{
-			mailSettingsRepositoryDecorator.add(mailSettings);
+			mailSettingsRepositoryDecorator.add(entity);
 			Assert.fail("Should've thrown exception.");
 		}
 		catch (IllegalStateException expected)
@@ -84,40 +93,40 @@ public class MailSettingsRepositoryDecoratorTest extends AbstractMockitoTest
 	@Test(dataProvider = "addDontTest")
 	public void testUpdateDontTestConnection(boolean testConnection, String username, String password)
 	{
-		when(mailSettings.isTestConnection()).thenReturn(testConnection);
-		when(mailSettings.getUsername()).thenReturn(username);
-		when(mailSettings.getPassword()).thenReturn(password);
-		mailSettingsRepositoryDecorator.update(mailSettings);
+		when(entity.getBoolean(MailSettingsImpl.Meta.TEST_CONNECTION)).thenReturn(testConnection);
+		when(entity.getString(MailSettingsImpl.Meta.USERNAME)).thenReturn(username);
+		when(entity.getString(MailSettingsImpl.Meta.PASSWORD)).thenReturn(password);
+		mailSettingsRepositoryDecorator.update(entity);
 		verify(mailSenderFactory, never()).validateConnection(any(MailSettingsImpl.class));
-		verify(decorated).update(mailSettings);
+		verify(decorated).update(entity);
 		verifyNoMoreInteractions(decorated);
 	}
 
 	@Test
 	public void testUpdateValidSettings()
 	{
-		when(mailSettings.isTestConnection()).thenReturn(true);
-		when(mailSettings.getUsername()).thenReturn("Username");
-		when(mailSettings.getPassword()).thenReturn("password");
+		when(entity.getBoolean(MailSettingsImpl.Meta.TEST_CONNECTION)).thenReturn(true);
+		when(entity.getString(MailSettingsImpl.Meta.USERNAME)).thenReturn("Username");
+		when(entity.getString(MailSettingsImpl.Meta.PASSWORD)).thenReturn("password");
 
-		mailSettingsRepositoryDecorator.update(mailSettings);
+		mailSettingsRepositoryDecorator.update(entity);
 		verify(mailSenderFactory).validateConnection(any(MailSettingsImpl.class));
-		verify(decorated).update(mailSettings);
+		verify(decorated).update(entity);
 		verifyNoMoreInteractions(decorated);
 	}
 
 	@Test
 	public void testUpdateInvalidSettings()
 	{
-		when(mailSettings.isTestConnection()).thenReturn(true);
-		when(mailSettings.getUsername()).thenReturn("Username");
-		when(mailSettings.getPassword()).thenReturn("password");
+		when(entity.getBoolean(MailSettingsImpl.Meta.TEST_CONNECTION)).thenReturn(true);
+		when(entity.getString(MailSettingsImpl.Meta.USERNAME)).thenReturn("Username");
+		when(entity.getString(MailSettingsImpl.Meta.PASSWORD)).thenReturn("password");
 
 		doThrow(IllegalStateException.class).when(mailSenderFactory).validateConnection(any(MailSettingsImpl.class));
 
 		try
 		{
-			mailSettingsRepositoryDecorator.update(mailSettings);
+			mailSettingsRepositoryDecorator.update(entity);
 			Assert.fail("Should've thrown exception.");
 		}
 		catch (IllegalStateException expected)
@@ -125,4 +134,5 @@ public class MailSettingsRepositoryDecoratorTest extends AbstractMockitoTest
 			verifyZeroInteractions(decorated);
 		}
 	}
+
 }


### PR DESCRIPTION
If a user try'ed to update the mail settings, the update would fail and a error message would be shown indicating the settings could not be update due the the fact the Dynamic Entity could not
be converted to a MailSettingsImpl.

This update fixes the bug by using a (Dynamic)Entity in the decorators and creating new a
MailSettingsImpl from the (Dynamic)Entity when validating the update.

This commit may be viewed as a workaround, in future we need to design a more coherent way of updating system settings.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
