### PR TITLE
Add 'allow-script-in-comments' to javadoc plugin settings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,7 +169,7 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.1</version>
                     <configuration>
-                        <additionalparam>-Xdoclint:none</additionalparam>
+                        <additionalparam>-Xdoclint:none --allow-script-in-comments</additionalparam>
                     </configuration>
                 </plugin>
                 <!-- specify plugin version -->


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
