### PR TITLE
Fix #6011 Feedback plugin header escapes HTML while offering a HTML editor to edit the header text

### DIFF
--- a/molgenis-core-ui/src/main/resources/templates/view-feedback.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/view-feedback.ftl
@@ -27,7 +27,8 @@
     <#if content?has_content>
     <div class="row">
         <div class="col-md-12">
-        ${content?html}
+        <#-- Do *not* HTML escape content else text formatting won't work -->
+            ${content}
         </div>
     </div>
     </#if>

--- a/molgenis-core-ui/src/main/resources/templates/view-staticcontent.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/view-staticcontent.ftl
@@ -5,7 +5,7 @@
 <#if content?has_content>
 <div class="row">
     <div class="col-md-12">
-    <#-- Do *not* HTML escape content -->
+    <#-- Do *not* HTML escape content else text formatting won't work -->
 			${content}
     </div>
 </div>


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
