### PR TITLE
Fix #5865 When uploading a table with a type decimal column but not all values are decimals, the importer succeeds, but the table cannot be shown

### DIFF
--- a/docs/user_documentation/ref-emx.md
+++ b/docs/user_documentation/ref-emx.md
@@ -127,7 +127,7 @@ Defines the data type (default: string)
 | text         | When having a string with a length of more than 255 characters, this data type is recommended.| A string with characters with a maximum length of 65535		  |
 | int          | Integers. Natural numbers like 1, 2, 3, -1, -2, -3. rangeMin and rangeMax can be defined.     | Non decimal numbers in range[-2^31 , 2^31 -1]                    |
 | long         | Non-decimal number of type long                                                               | Non decimal numbers in range[-2^63 , 2^63 -1]                    |
-| decimal      | Decimal numbers/floats.                                                                       | Decimal numbers in range[-2^31 , 2^31 -1]                        |
+| decimal      | Decimal numbers/floats.                                                                       | Decimal numbers with [double-precision](https://en.wikipedia.org/wiki/Double-precision_floating-point_format) ('NaN' not allowed)                        |
 | bool         | A boolean value: true/false                                                                   | TRUE/FALSE                                                       |
 | date         | A date                                                                                        | yyyy-mm-dd                                                       |
 | datetime     | Date and time                                                                                 | yyyy-mm-ddThh:mm:ss+timezone e.g. 1985-08-12T11:12:13+0500       |

--- a/molgenis-data/src/main/java/org/molgenis/data/support/DynamicEntity.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/DynamicEntity.java
@@ -269,6 +269,12 @@ public class DynamicEntity implements Entity
 							format("Value [%s] is of type [%s] instead of [%s] for attribute: [%s]", value.toString(),
 									value.getClass().getSimpleName(), Double.class.getSimpleName(), attrName));
 				}
+				if (((Double) value).isNaN())
+				{
+					throw new MolgenisDataException(
+							format("Value [%s] for type [%s] is not allowed for attribute: [%s]", value.toString(),
+									Double.class.getSimpleName(), attrName));
+				}
 				break;
 			case EMAIL:
 			case ENUM:

--- a/molgenis-data/src/test/java/org/molgenis/data/support/DynamicEntityTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/support/DynamicEntityTest.java
@@ -13,8 +13,7 @@ import java.util.Iterator;
 import static com.google.common.collect.Lists.newArrayList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.molgenis.data.meta.AttributeType.ONE_TO_MANY;
-import static org.molgenis.data.meta.AttributeType.XREF;
+import static org.molgenis.data.meta.AttributeType.*;
 
 public class DynamicEntityTest
 {
@@ -35,7 +34,7 @@ public class DynamicEntityTest
 	public static Iterator<Object[]> setExceptionProvider()
 	{
 		return newArrayList(new Object[] { ONE_TO_MANY, mock(Entity.class) },
-				new Object[] { XREF, mock(Iterable.class) }).iterator();
+				new Object[] { XREF, mock(Iterable.class) }, new Object[] { DECIMAL, Double.NaN }).iterator();
 	}
 
 	@Test(dataProvider = "setExceptionProvider", expectedExceptions = MolgenisDataException.class)


### PR DESCRIPTION
Disallow ```NaN``` as decimal values in entities.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
