### PR TITLE
Fix #6124 Permissions lost when doing something transactional in the …

### DIFF
--- a/molgenis-jobs/src/main/java/org/molgenis/data/jobs/Job.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/data/jobs/Job.java
@@ -6,91 +6,44 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.TransactionException;
-import org.springframework.transaction.support.TransactionTemplate;
+import org.springframework.transaction.support.TransactionOperations;
 
 import java.util.Objects;
 import java.util.concurrent.Callable;
 
 /**
- * Superclass for molgenis jobs that keeps track of their progress.
+ * Superclass for molgenis jobs.
  */
 public abstract class Job<Result> implements Callable<Result>
 {
 	private static final Logger LOG = LoggerFactory.getLogger(Job.class);
 	private final Progress progress;
-	private TransactionTemplate transactionTemplate;
+	private TransactionOperations transactionOperations;
 	private Authentication authentication;
 
-	public Job(Progress progress, TransactionTemplate transactionTemplate, Authentication authentication)
+	/**
+	 * Creates a new Job instance.
+	 *
+	 * @param progress              {@link Progress} instance to report job progress to
+	 * @param transactionOperations A {@link TransactionOperations} to execute in. If null, the job will run without a transaction.
+	 * @param authentication        The {@link Authentication} to run under
+	 */
+	public Job(Progress progress, TransactionOperations transactionOperations, Authentication authentication)
 	{
 		this.progress = Objects.requireNonNull(progress);
-		this.transactionTemplate = transactionTemplate;
+		this.transactionOperations = transactionOperations;
 		this.authentication = Objects.requireNonNull(authentication);
 	}
 
 	@Override
 	public Result call()
 	{
-		if (transactionTemplate != null)
-		{
-			return transactionTemplate.execute((status) -> doCallInTransaction());
-		}
-		else
-		{
-			return doCallInTransaction();
-		}
-	}
-
-	private Result doCallInTransaction()
-	{
-		progress.start();
-		try
-		{
-			Result result = tryRunWithAuthentication();
-			progress.success();
-			return result;
-		}
-		catch (JobExecutionException ex)
-		{
-			Exception cause = (Exception) ex.getCause();
-			LOG.warn("Error executing job", cause);
-			progress.failed(cause);
-			throw ex;
-		}
-		catch (TransactionException te)
-		{
-			LOG.error("Error rolling back transaction for failed job execution", te);
-			progress.failed(te);
-			throw te;
-		}
-		catch (Exception other)
-		{
-			LOG.error("Error logging job success", other);
-			progress.failed(other);
-			throw other;
-		}
-	}
-
-	private Result tryRunWithAuthentication()
-	{
-		try
-		{
-			return runWithAuthentication();
-		}
-		catch (Exception e)
-		{
-			throw new JobExecutionException(e);
-		}
-	}
-
-	private Result runWithAuthentication() throws Exception
-	{
-		SecurityContext originalContext = SecurityContextHolder.getContext();
+		final SecurityContext originalContext = SecurityContextHolder.getContext();
 		try
 		{
 			SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
 			SecurityContextHolder.getContext().setAuthentication(authentication);
-			return call(progress);
+			return authenticatedCall();
 		}
 		finally
 		{
@@ -98,11 +51,50 @@ public abstract class Job<Result> implements Callable<Result>
 		}
 	}
 
+	private Result authenticatedCall()
+	{
+		if (transactionOperations != null)
+		{
+			try
+			{
+				return transactionOperations.execute((status) -> tryCall());
+			}
+			catch (TransactionException te)
+			{
+				LOG.error("Transaction error while running job", te);
+				progress.failed(te);
+				throw te;
+			}
+
+		}
+		else
+		{
+			return tryCall();
+		}
+	}
+
+	private Result tryCall() throws JobExecutionException
+	{
+		progress.start();
+		try
+		{
+			Result result = call(progress);
+			progress.success();
+			return result;
+		}
+		catch (Exception ex)
+		{
+			LOG.warn("Error executing job", ex);
+			progress.failed(ex);
+			throw new JobExecutionException(ex);
+		}
+	}
+
 	/**
-	 * Executes this job. For concrete subclasses to implement.
+	 * Executes this Job. For concrete subclasses to implement.
 	 *
-	 * @param progress
-	 * @throws Exception
+	 * @param progress The {@link Progress} to report job progress to
+	 * @throws Exception if something goes wrong. If an exception is thrown here, the job status will be set to failed.
 	 */
 	public abstract Result call(Progress progress) throws Exception;
 }

--- a/molgenis-jobs/src/main/java/org/molgenis/data/jobs/Job.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/data/jobs/Job.java
@@ -31,18 +31,22 @@ public abstract class Job<Result> implements Callable<Result>
 	@Override
 	public Result call()
 	{
+		if (transactionTemplate != null)
+		{
+			return transactionTemplate.execute((status) -> doCallInTransaction());
+		}
+		else
+		{
+			return doCallInTransaction();
+		}
+	}
+
+	private Result doCallInTransaction()
+	{
 		progress.start();
 		try
 		{
-			Result result;
-			if (transactionTemplate != null)
-			{
-				result = transactionTemplate.execute((status) -> tryRunWithAuthentication());
-			}
-			else
-			{
-				result = tryRunWithAuthentication();
-			}
+			Result result = tryRunWithAuthentication();
 			progress.success();
 			return result;
 		}

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/JobTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/JobTest.java
@@ -1,0 +1,188 @@
+package org.molgenis.data.jobs;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.stubbing.Answer;
+import org.molgenis.data.MolgenisDataException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.transaction.TransactionException;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.TransactionTimedOutException;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionOperations;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.Callable;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.testng.Assert.*;
+
+public class JobTest
+{
+	@Mock
+	Callable<Authentication> callable;
+
+	@Mock
+	Progress progress;
+
+	@Mock
+	Authentication authentication;
+
+	@Mock
+	TransactionStatus transactionStatus;
+
+	@Mock
+	TransactionOperations transactionOperations;
+
+	@Captor
+	ArgumentCaptor<TransactionCallback<Authentication>> actionCaptor;
+
+	// sneaky trick to capture the authentication the job executes under: Store it in the job result
+	private Answer<Authentication> authenticationAnswer = (call) -> SecurityContextHolder.getContext()
+			.getAuthentication();
+
+	private Job<Authentication> job;
+	private Job<Authentication> jobWithoutTransaction;
+
+	@BeforeClass
+	public void beforeClass()
+	{
+		initMocks(this);
+		job = new Job<Authentication>(progress, transactionOperations, authentication)
+		{
+			@Override
+			public Authentication call(Progress progress) throws Exception
+			{
+				return callable.call();
+			}
+		};
+
+		jobWithoutTransaction = new Job<Authentication>(progress, null, authentication)
+		{
+			@Override
+			public Authentication call(Progress progress) throws Exception
+			{
+				return callable.call();
+			}
+		};
+	}
+
+	@BeforeMethod
+	public void beforeMethod()
+	{
+		reset(callable, progress, transactionOperations);
+	}
+
+	@Test
+	public void testTransactionTimeout()
+	{
+		TransactionException transactionException = new TransactionTimedOutException("Transaction timeout test.");
+		when(transactionOperations.execute(any())).thenThrow(transactionException);
+		try
+		{
+			job.call();
+			fail("TransactionException should be thrown");
+		}
+		catch (TransactionException expected)
+		{
+			assertSame(expected, transactionException);
+		}
+		verify(transactionOperations).execute(any());
+		verify(progress).failed(transactionException);
+		verifyNoMoreInteractions(callable, progress, transactionOperations);
+	}
+
+	@Test
+	public void testTransactionalJob() throws Exception
+	{
+		when(transactionOperations.execute(actionCaptor.capture()))
+				.thenAnswer((call) -> actionCaptor.getValue().doInTransaction(transactionStatus));
+		when(callable.call()).thenAnswer(authenticationAnswer);
+		Authentication result = job.call();
+
+		assertEquals(result, authentication);
+		verify(progress).start();
+		verify(progress).success();
+		verify(transactionOperations).execute(any());
+		verify(callable).call();
+		verifyNoMoreInteractions(callable, progress, transactionOperations);
+	}
+
+	@Test
+	public void testTransactionOperationsIsCalledWithCorrectAuthentication() throws Exception
+	{
+		when(transactionOperations.execute(actionCaptor.capture())).thenAnswer(authenticationAnswer);
+		Authentication result = job.call();
+
+		assertEquals(result, authentication, "Entire transaction should run with specified authentication, see #6124");
+		verify(transactionOperations).execute(any());
+		verifyNoMoreInteractions(callable, progress, transactionOperations);
+	}
+
+	@Test
+	public void testNontransactionalJob() throws Exception
+	{
+		when(callable.call()).thenAnswer(authenticationAnswer);
+		Authentication actual = jobWithoutTransaction.call();
+
+		assertSame(actual, authentication, "Job should run with authentication");
+
+		verify(progress).start();
+		verify(progress).success();
+		verify(callable).call();
+		verifyNoMoreInteractions(callable, progress, transactionOperations);
+	}
+
+	@Test
+	public void testTransactionalJobFailure() throws Exception
+	{
+		when(transactionOperations.execute(actionCaptor.capture()))
+				.thenAnswer((call) -> actionCaptor.getValue().doInTransaction(transactionStatus));
+		MolgenisDataException mde = new MolgenisDataException();
+		when(callable.call()).thenThrow(mde);
+
+		try
+		{
+			job.call();
+			fail("Job call should throw exception if subclass execution fails.");
+		}
+		catch (JobExecutionException ex)
+		{
+			assertSame(ex.getCause(), mde);
+		}
+
+		verify(transactionOperations).execute(any());
+		verify(progress).start();
+		verify(callable).call();
+		verify(progress).failed(mde);
+		verifyNoMoreInteractions(callable, progress, transactionOperations);
+	}
+
+	@Test
+	public void testNontransactionalJobFailure() throws Exception
+	{
+		MolgenisDataException mde = new MolgenisDataException();
+		when(callable.call()).thenThrow(mde);
+
+		try
+		{
+			jobWithoutTransaction.call();
+			fail("Job call should throw exception if subclass execution fails.");
+		}
+		catch (JobExecutionException ex)
+		{
+			assertSame(ex.getCause(), mde);
+		}
+
+		verify(progress).start();
+		verify(callable).call();
+		verify(progress).failed(mde);
+		verifyNoMoreInteractions(callable, progress, transactionOperations);
+	}
+}


### PR DESCRIPTION
…afterCommit handler of a Job

The idea is to turn the order around, do the permission switch outside the transaction instead of the other way around.

Before:
![Before](https://www.websequencediagrams.com/cgi-bin/cdraw?lz=dGl0bGUgT2xkIGJ1Z2d5IHNpdHVhdGlvbgoKSm9iIEV4ZWN1dG9yIC0-IEpvYjogY2FsbCgpCmFjdGl2YXRlIEpvYgAkBi0-IFRyYW5zYWN0aW9uVGVtcGxhdGU6IGUAPQVlACgMABUTIAoKAAIUAG4IdHJ5UnVuV2l0aEF1dGhlbnRpYwCBIAUAew8gAIECCVNlY3VyaXR5Q29udGV4dDogc2V0ACEaAB8PCgAvDyAtAIF3BwpkZQAcGABxCgAkBQCBBw9ub3RlIHJpZ2h0IG9mAIJDBnN1YmNsYXNzIGRvZXMgdGhlIGFjdHVhbCB3b3JrOlxuTWFwIG1hcCBtYXAAgloHAIJ7CAB6DACBVx5yZXN0b3JlAIEUZQCDaRcAgz8YAIQhC0xpc3RlbmVyOiBhZnRlckNvbW1pdACEGRcAJAgAgkMPADkVUnVucyB3aXRob3V0IHBlcm1pc3Npb25zAIReDAB0CACBJhoAg2gLACQUAIUhFwCEHhMAhWAWAINPCwCGZAkAhFsNSm9i&s=rose)

After:
![After](https://www.websequencediagrams.com/cgi-bin/cdraw?lz=dGl0bGUgRml4CgpKb2IgRXhlY3V0b3IgLT4gSm9iOiBjYWxsKCkKYWN0aXZhdGUgSm9iACQGABkIdHJ5UnVuV2l0aEF1dGhlbnRpY2F0aW9uACYPIAAtCVNlY3VyaXR5Q29udGV4dDogc2V0ACEaAB8PCgAvDyAtAIEiBwpkZQAcGABxClRyYW5zYWN0aW9uVGVtcGxhdGU6IGUAgW4FZQCBWQwAFRMgCgoAAhQAdggAgVwPbm90ZSByaWdodCBvZgCCQwZzdWJjbGFzcyBkb2VzIHRoZSBhY3R1YWwgd29yazpcbk1hcCBtYXAgbWFwAIJaBwCBGhcAgV4MAIMJBQCBARcAgWILTGlzdGVuZXI6IGFmdGVyQ29tbWl0AIFaFwAkCACBNQ8AORVSdW5zIHdpdGggcGVybWlzc2lvbnMAghwMAHEIAIEoJQAkFACCXxcAg2ITAIMeFgCEXBhyZXN0b3JlAIQbXQCDPQoAhkUFAIMpDwCGCQgAhmMGAIZvCgCDUBA&s=rose)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
