### PR TITLE
Fix #5985: Job logs can exceed max log size, disastrous consequences

### DIFF
--- a/molgenis-jobs/src/main/java/org/molgenis/data/jobs/JobBootstrapper.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/data/jobs/JobBootstrapper.java
@@ -9,8 +9,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import static java.util.Objects.requireNonNull;
+import static org.apache.commons.lang3.StringUtils.abbreviateMiddle;
+import static org.molgenis.data.jobs.model.JobExecution.MAX_LOG_LENGTH;
 import static org.molgenis.data.jobs.model.JobExecution.Status.FAILED;
 import static org.molgenis.data.jobs.model.JobExecution.Status.RUNNING;
+import static org.molgenis.data.jobs.model.JobExecution.TRUNCATION_BANNER;
 import static org.molgenis.data.jobs.model.JobExecutionMetaData.*;
 import static org.springframework.util.StringUtils.isEmpty;
 
@@ -52,7 +55,8 @@ public class JobBootstrapper
 			log.append('\n');
 		}
 		log.append("FAILED - Application terminated unexpectedly");
-		jobExecutionEntity.set(LOG, log.toString());
+		String abbreviatedLog = abbreviateMiddle(log.toString(), "...\n" + TRUNCATION_BANNER + "\n...", MAX_LOG_LENGTH);
+		jobExecutionEntity.set(LOG, abbreviatedLog);
 		dataService.update(jobExecutionEntity.getEntityType().getId(), jobExecutionEntity);
 	}
 

--- a/molgenis-jobs/src/main/java/org/molgenis/data/jobs/JobExecutionLogAppender.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/data/jobs/JobExecutionLogAppender.java
@@ -32,9 +32,7 @@ public class JobExecutionLogAppender extends AppenderBase<ILoggingEvent>
 	{
 		String formattedMessage = layout.doLayout(eventObject);
 		JobExecution jobExecution = JobExecutionContext.get();
-		String oldLog = jobExecution.getLog();
-		String newLog = oldLog == null ? formattedMessage : oldLog + formattedMessage;
-		jobExecution.setLog(newLog);
+		jobExecution.appendLog(formattedMessage);
 	}
 
 }

--- a/molgenis-jobs/src/main/java/org/molgenis/data/jobs/model/JobExecution.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/data/jobs/model/JobExecution.java
@@ -19,7 +19,15 @@ import static org.molgenis.data.jobs.model.JobExecutionMetaData.*;
 public class JobExecution extends StaticEntity
 {
 	public static final String TRUNCATION_BANNER = "<<< THIS LOG HAS BEEN TRUNCATED >>>";
+	/**
+	 * If the progress message is larger than this value, it will be abbreviated.
+	 * This value shouldn't exceed the max length of the {@link org.molgenis.data.meta.AttributeType#STRING}
+	 */
 	public static final int MAX_PROGRESS_MESSAGE_LENGTH = 255;
+	/**
+	 * If log is larger than this value, it will be truncated.
+	 * This value shouldn't exceed the max length of the {@link org.molgenis.data.meta.AttributeType#TEXT}
+	 */
 	public static final int MAX_LOG_LENGTH = 65535;
 	private boolean logTruncated = false;
 

--- a/molgenis-jobs/src/main/java/org/molgenis/data/jobs/model/JobExecution.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/data/jobs/model/JobExecution.java
@@ -1,13 +1,14 @@
 package org.molgenis.data.jobs.model;
 
+import org.apache.commons.lang3.StringUtils;
 import org.molgenis.auth.User;
 import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
-import org.springframework.util.StringUtils;
 
 import java.time.Instant;
 
+import static org.apache.commons.lang3.StringUtils.*;
 import static org.molgenis.data.jobs.model.JobExecutionMetaData.*;
 
 /**
@@ -17,6 +18,11 @@ import static org.molgenis.data.jobs.model.JobExecutionMetaData.*;
  */
 public class JobExecution extends StaticEntity
 {
+	public static final String TRUNCATION_BANNER = "<<< THIS LOG HAS BEEN TRUNCATED >>>";
+	public static final int MAX_PROGRESS_MESSAGE_LENGTH = 255;
+	public static final int MAX_LOG_LENGTH = 65535;
+	private boolean logTruncated = false;
+
 	public JobExecution(Entity entity)
 	{
 		super(entity);
@@ -129,7 +135,7 @@ public class JobExecution extends StaticEntity
 
 	public void setProgressMessage(String value)
 	{
-		set(PROGRESS_MESSAGE, value);
+		set(PROGRESS_MESSAGE, StringUtils.abbreviate(value, MAX_PROGRESS_MESSAGE_LENGTH));
 	}
 
 	public Integer getProgressMax()
@@ -147,7 +153,7 @@ public class JobExecution extends StaticEntity
 		return getString(LOG);
 	}
 
-	public void setLog(String value)
+	private void setLog(String value)
 	{
 		set(LOG, value);
 	}
@@ -165,7 +171,7 @@ public class JobExecution extends StaticEntity
 	public String[] getSuccessEmail()
 	{
 		String email = getString(SUCCESS_EMAIL);
-		if (StringUtils.isEmpty(email))
+		if (isEmpty(email))
 		{
 			return new String[] {};
 		}
@@ -175,7 +181,7 @@ public class JobExecution extends StaticEntity
 	public String[] getFailureEmail()
 	{
 		String email = getString(FAILURE_EMAIL);
-		if (StringUtils.isEmpty(email))
+		if (isEmpty(email))
 		{
 			return new String[] {};
 		}
@@ -190,6 +196,26 @@ public class JobExecution extends StaticEntity
 	public void setFailureEmail(String failureEmail)
 	{
 		set(FAILURE_EMAIL, failureEmail);
+	}
+
+	/**
+	 * Appends a log message to the execution log.
+	 * The first time the log exceeds MAX_LOG_LENGTH, it gets truncated and the TRUNCATION_BANNER gets added.
+	 * Subsequent calls to appendLog will be ignored.
+	 *
+	 * @param formattedMessage The formatted message to append to the log.
+	 */
+	public void appendLog(String formattedMessage)
+	{
+		if (logTruncated) return;
+		String combined = join(getLog(), formattedMessage);
+		if (combined.length() > MAX_LOG_LENGTH)
+		{
+			String truncated = abbreviate(combined, MAX_LOG_LENGTH - TRUNCATION_BANNER.length() * 2 - 2);
+			combined = join(new String[] { TRUNCATION_BANNER, truncated, TRUNCATION_BANNER }, "\n");
+			logTruncated = true;
+		}
+		setLog(combined);
 	}
 
 	public enum Status

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/JobBootstrapperTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/JobBootstrapperTest.java
@@ -1,5 +1,8 @@
 package org.molgenis.data.jobs;
 
+import org.apache.commons.lang3.RandomStringUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.molgenis.data.AbstractMolgenisSpringTest;
 import org.molgenis.data.DataService;
@@ -20,6 +23,8 @@ import java.util.stream.Stream;
 import static org.mockito.Mockito.*;
 import static org.molgenis.data.jobs.model.JobExecution.Status.RUNNING;
 import static org.molgenis.data.jobs.model.JobExecutionMetaData.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 @ContextConfiguration(classes = { JobBootstrapperTest.Config.class, JobBootstrapper.class })
 public class JobBootstrapperTest extends AbstractMolgenisSpringTest
@@ -43,10 +48,16 @@ public class JobBootstrapperTest extends AbstractMolgenisSpringTest
 	private JobExecution job2;
 
 	@Mock
+	private JobExecution job3;
+
+	@Mock
 	private EntityType jobExecutionType;
 
 	@Mock
 	private Query<Entity> query;
+
+	@Captor
+	private ArgumentCaptor<String> stringCaptor;
 
 	@Test
 	public void testBootstrap()
@@ -61,13 +72,17 @@ public class JobBootstrapperTest extends AbstractMolgenisSpringTest
 		when(query.eq(STATUS, PENDING)).thenReturn(query);
 		when(query.or()).thenReturn(query);
 
-		when(query.findAll()).thenReturn(Stream.of(job1, job2));
+		when(query.findAll()).thenReturn(Stream.of(job1, job2, job3));
 
 		when(job1.get(LOG)).thenReturn("Current log");
 		when(job1.getEntityType()).thenReturn(jobType1);
 
 		when(job2.get(LOG)).thenReturn(null);
 		when(job2.getEntityType()).thenReturn(jobType1);
+
+		String hugeLog = RandomStringUtils.random(JobExecution.MAX_LOG_LENGTH - 10);
+		when(job3.get(LOG)).thenReturn(hugeLog);
+		when(job3.getEntityType()).thenReturn(jobType1);
 
 		jobBootstrapper.bootstrap();
 
@@ -78,6 +93,15 @@ public class JobBootstrapperTest extends AbstractMolgenisSpringTest
 		verify(job2).set(STATUS, FAILED);
 		verify(job2).set(PROGRESS_MESSAGE, "Application terminated unexpectedly");
 		verify(job2).set(LOG, "FAILED - Application terminated unexpectedly");
+
+		verify(job3).set(STATUS, FAILED);
+		verify(job3).set(PROGRESS_MESSAGE, "Application terminated unexpectedly");
+		verify(job3).set(eq(LOG), stringCaptor.capture());
+
+		String log3 = stringCaptor.getValue();
+		assertEquals(log3.length(), JobExecution.MAX_LOG_LENGTH, "Updated log length mustn't exceed MAX_LOG_LENGTH");
+		assertTrue(log3.contains(JobExecution.TRUNCATION_BANNER), "Updated log should contain truncation banner");
+		assertTrue(log3.endsWith("\nFAILED - Application terminated unexpectedly"));
 
 		verify(dataService).update("JobType1", job1);
 		verify(dataService).update("JobType1", job2);

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/JobExecutionTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/JobExecutionTest.java
@@ -1,0 +1,74 @@
+package org.molgenis.data.jobs.model;
+
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.molgenis.data.AbstractMolgenisSpringTest;
+import org.molgenis.data.jobs.model.dummy.DummyJobExecution;
+import org.molgenis.data.jobs.model.dummy.DummyJobExecutionFactory;
+import org.molgenis.data.jobs.model.dummy.DummyJobExecutionMetadata;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@ContextConfiguration(classes = { DummyJobExecutionFactory.class, DummyJobExecutionMetadata.class,
+		JobExecutionMetaData.class })
+public class JobExecutionTest extends AbstractMolgenisSpringTest
+{
+	@Autowired
+	private DummyJobExecutionFactory factory;
+	private DummyJobExecution jobExecution;
+
+	@BeforeMethod
+	public void beforeMethod()
+	{
+		jobExecution = factory.create();
+	}
+
+	@Test
+	public void testAppendLog() throws Exception
+	{
+		String message1 = "Small message 1\n";
+		String message2 = "Small message 2\n";
+
+		jobExecution.appendLog(message1);
+		jobExecution.appendLog(message2);
+
+		assertEquals(jobExecution.getLog(), StringUtils.join(message1, message2));
+	}
+
+	@Test
+	public void testAppendLogTruncates() throws Exception
+	{
+		int i = 0;
+		while (StringUtils.length(jobExecution.getLog()) < JobExecution.MAX_LOG_LENGTH)
+		{
+			jobExecution.appendLog("Small message " + i++ + "\n");
+		}
+		String truncatedLog = jobExecution.getLog();
+		assertEquals(truncatedLog.length(), JobExecution.MAX_LOG_LENGTH, "Log message grows up to MAX_LOG_LENGTH");
+
+		assertTrue(truncatedLog.startsWith(JobExecution.TRUNCATION_BANNER),
+				"Truncated log should start with TRUNCATION_BANNER");
+		assertTrue(truncatedLog.endsWith(JobExecution.TRUNCATION_BANNER),
+				"Truncated log should end with TRUNCATION_BANNER");
+
+		jobExecution.appendLog("Ignored");
+		assertEquals(jobExecution.getLog(), truncatedLog, "Once truncated, the log should stop appending");
+	}
+
+	@Test
+	public void testSetProgressMessageAbbreviates()
+	{
+		String longMessage = RandomStringUtils.random(300);
+		jobExecution.setProgressMessage(longMessage);
+		String actual = jobExecution.getProgressMessage();
+		assertEquals(actual.length(), JobExecution.MAX_PROGRESS_MESSAGE_LENGTH);
+		String common = StringUtils.getCommonPrefix(actual, longMessage);
+		assertEquals(actual, common + "...");
+	}
+
+}

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecution.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecution.java
@@ -1,0 +1,26 @@
+package org.molgenis.data.jobs.model.dummy;
+
+import org.molgenis.data.Entity;
+import org.molgenis.data.jobs.model.JobExecution;
+import org.molgenis.data.meta.model.EntityType;
+
+/**
+ * Dummy subclass plus metadata to instantiate a testable JobExecution.
+ */
+public class DummyJobExecution extends JobExecution
+{
+	public DummyJobExecution(Entity entity)
+	{
+		super(entity);
+	}
+
+	public DummyJobExecution(EntityType entityType)
+	{
+		super(entityType);
+	}
+
+	public DummyJobExecution(String identifier, EntityType entityType)
+	{
+		super(identifier, entityType);
+	}
+}

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecution.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecution.java
@@ -5,7 +5,7 @@ import org.molgenis.data.jobs.model.JobExecution;
 import org.molgenis.data.meta.model.EntityType;
 
 /**
- * Dummy subclass plus metadata to instantiate a testable JobExecution.
+ * Dummy subclass to instantiate testable {@link JobExecution}s.
  */
 public class DummyJobExecution extends JobExecution
 {

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionFactory.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionFactory.java
@@ -6,6 +6,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
+/**
+ * Creates {@link DummyJobExecution}s.
+ */
 public class DummyJobExecutionFactory
 		extends AbstractSystemEntityFactory<DummyJobExecution, DummyJobExecutionMetadata, String>
 {

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionFactory.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionFactory.java
@@ -1,0 +1,17 @@
+package org.molgenis.data.jobs.model.dummy;
+
+import org.molgenis.data.AbstractSystemEntityFactory;
+import org.molgenis.data.populate.EntityPopulator;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DummyJobExecutionFactory
+		extends AbstractSystemEntityFactory<DummyJobExecution, DummyJobExecutionMetadata, String>
+{
+	@Autowired
+	DummyJobExecutionFactory(DummyJobExecutionMetadata metaData, EntityPopulator entityPopulator)
+	{
+		super(DummyJobExecution.class, metaData, entityPopulator);
+	}
+}

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionMetadata.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionMetadata.java
@@ -9,6 +9,9 @@ import static java.util.Objects.requireNonNull;
 import static org.molgenis.data.system.model.RootSystemPackage.PACKAGE_SYSTEM;
 
 @Component
+/**
+ * Metadata for {@link DummyJobExecution}s.
+ */
 public class DummyJobExecutionMetadata extends SystemEntityType
 {
 	private static final String SIMPLE_NAME = "DummyJobExecution";

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionMetadata.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/DummyJobExecutionMetadata.java
@@ -1,0 +1,31 @@
+package org.molgenis.data.jobs.model.dummy;
+
+import org.molgenis.data.jobs.model.JobExecutionMetaData;
+import org.molgenis.data.meta.SystemEntityType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import static java.util.Objects.requireNonNull;
+import static org.molgenis.data.system.model.RootSystemPackage.PACKAGE_SYSTEM;
+
+@Component
+public class DummyJobExecutionMetadata extends SystemEntityType
+{
+	private static final String SIMPLE_NAME = "DummyJobExecution";
+
+	private final JobExecutionMetaData jobExecutionMetaData;
+
+	@Autowired
+	DummyJobExecutionMetadata(JobExecutionMetaData jobExecutionMetaData)
+	{
+		super(SIMPLE_NAME, PACKAGE_SYSTEM);
+		this.jobExecutionMetaData = requireNonNull(jobExecutionMetaData);
+	}
+
+	@Override
+	public void init()
+	{
+		setLabel("Dummy Job Execution");
+		setExtends(jobExecutionMetaData);
+	}
+}

--- a/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/package-info.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/data/jobs/model/dummy/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * This package contains everything you need to create a concrete JobExecution for testing purposes.
+ */
+package org.molgenis.data.jobs.model.dummy;


### PR DESCRIPTION
This is a port from the fix applied to 3.0

#### Checklist
- [ ] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
