### PR TITLE
Fix #5983: Mapping to existing entity is broken when existing entity has more than 20.000 rows

### DIFF
--- a/molgenis-data-mapper/src/main/java/org/molgenis/data/mapper/service/impl/MappingServiceImpl.java
+++ b/molgenis-data-mapper/src/main/java/org/molgenis/data/mapper/service/impl/MappingServiceImpl.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -34,7 +35,7 @@ import static com.google.api.client.util.Maps.newHashMap;
 import static java.lang.Boolean.TRUE;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.*;
 import static org.molgenis.data.mapper.meta.MappingProjectMetaData.NAME;
 import static org.molgenis.data.meta.model.EntityType.AttributeCopyMode.DEEP_COPY_ATTRS;
 import static org.molgenis.data.support.EntityTypeUtils.hasSelfReferences;
@@ -369,20 +370,15 @@ public class MappingServiceImpl implements MappingService
 		counter.addAndGet(entities.size());
 	}
 
-	private static void upsertBatch(Repository<Entity> targetRepo, List<Entity> mappedEntities)
+	private static void upsertBatch(Repository<Entity> targetRepo, List<Entity> entities)
 	{
-		mappedEntities.forEach(mappedEntity ->
-		{
-			// FIXME adding/updating row-by-row is a performance bottleneck, this code could do streaming upsert
-			if (targetRepo.findOneById(mappedEntity.getIdValue()) == null)
-			{
-				targetRepo.add(mappedEntity);
-			}
-			else
-			{
-				targetRepo.update(mappedEntity);
-			}
-		});
+		Set<Object> ids = entities.stream().map(Entity::getIdValue).collect(toSet());
+		Fetch idFetch = new Fetch().field(targetRepo.getEntityType().getIdAttribute().getName());
+		Set<Object> existingIDs = targetRepo.findAll(ids.stream(), idFetch).collect(toSet());
+		Map<Boolean, List<Entity>> partitioned = entities.stream()
+				.collect(partitioningBy(entity -> existingIDs.contains(entity.getIdValue())));
+		targetRepo.add(partitioned.get(Boolean.FALSE).stream());
+		targetRepo.update(partitioned.get(Boolean.TRUE).stream());
 	}
 
 	private Stream<Entity> mapEntities(EntityMapping sourceMapping, EntityType targetMetaData, List<Entity> entities)

--- a/molgenis-data/src/main/java/org/molgenis/data/Repository.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/Repository.java
@@ -31,7 +31,7 @@ public interface Repository<E extends Entity> extends Iterable<E>, Closeable
 	default Set<Object> getExistingIDs(Set<Object> ids)
 	{
 		Fetch idFetch = new Fetch().field(getEntityType().getIdAttribute().getName());
-		return findAll(ids.stream(), idFetch).collect(toSet());
+		return findAll(ids.stream(), idFetch).map(Entity::getIdValue).collect(toSet());
 	}
 
 	/**

--- a/molgenis-data/src/main/java/org/molgenis/data/Repository.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/Repository.java
@@ -7,15 +7,48 @@ import org.molgenis.data.meta.model.EntityType;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.stream.Collectors.partitioningBy;
+import static java.util.stream.Collectors.toSet;
 
 /**
  * Repository gives access to a collection of Entity. Synonyms: EntityReader, EntitySource, EntityCollection
  */
 public interface Repository<E extends Entity> extends Iterable<E>, Closeable
 {
+	/**
+	 * Checks if IDs are present in this {@link Repository}.
+	 *
+	 * @param ids the set of ID values to check
+	 * @return the {@link Set} of IDs that are present in the repository
+	 */
+	default Set<Object> getExistingIDs(Set<Object> ids)
+	{
+		Fetch idFetch = new Fetch().field(getEntityType().getIdAttribute().getName());
+		return findAll(ids.stream(), idFetch).collect(toSet());
+	}
+
+	/**
+	 * Upserts a batch of entities into this repository.
+	 * Entities that are already present are updated, new entities are added.
+	 *
+	 * @param entities List of Entities to upsert
+	 */
+	default void upsertBatch(List<E> entities)
+	{
+		Set<Object> existingIDs = getExistingIDs(entities.stream().map(Entity::getIdValue).collect(toSet()));
+		Map<Boolean, List<E>> partitioned = entities.stream()
+				.collect(partitioningBy(entity -> existingIDs.contains(entity.getIdValue())));
+		add(partitioned.get(FALSE).stream());
+		update(partitioned.get(TRUE).stream());
+	}
+
 	/**
 	 * Executes a function for each batch of entities.
 	 *

--- a/molgenis-data/src/main/java/org/molgenis/util/EntityUtils.java
+++ b/molgenis-data/src/main/java/org/molgenis/util/EntityUtils.java
@@ -318,6 +318,26 @@ public class EntityUtils
 	}
 
 	/**
+	 * Returns true if an Iterable equals another Iterable.
+	 *
+	 * @param entityIterable
+	 * @param otherEntityIterable
+	 * @return
+	 */
+	public static boolean equalsEntities(Iterable<Entity> entityIterable, Iterable<Entity> otherEntityIterable)
+	{
+		List<Entity> attrs = newArrayList(entityIterable);
+		List<Entity> otherAttrs = newArrayList(otherEntityIterable);
+
+		if (attrs.size() != otherAttrs.size()) return false;
+		for (int i = 0; i < attrs.size(); ++i)
+		{
+			if (!equals(attrs.get(i), otherAttrs.get(i))) return false;
+		}
+		return true;
+	}
+
+	/**
 	 * Returns true if a Tag equals another Tag.
 	 *
 	 * @param tag


### PR DESCRIPTION
Depends on #6123.

The idea is that since the mapping service is batched anyways, we can add an upsertBatch method to the Repository interface that queries which of the entities of the batch already are present in the repo and depending on the answer does an add or an update.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
