### PR TITLE
Add optional packageId argument to importApi

### DIFF
--- a/docs/user_documentation/guide-upload.md
+++ b/docs/user_documentation/guide-upload.md
@@ -131,6 +131,8 @@ String url
 entityTypeId: The name of the entity, this only has effect for VCF files (.vcf and .vcf.gz)
 	Default value is the filename.
 
+packageName: The name of the package you want the imported file to be placed under. If package does not exist, an error will be thrown. Not supplying the package will place an imported file under the default package 'base'
+
 action: the database action to import with, options are:
 	ADD: add records, error on duplicate records
 	ADD_UPDATE_EXISTING: add, update existing records

--- a/docs/user_documentation/guide-upload.md
+++ b/docs/user_documentation/guide-upload.md
@@ -131,7 +131,7 @@ String url
 entityTypeId: The name of the entity, this only has effect for VCF files (.vcf and .vcf.gz)
 	Default value is the filename.
 
-packageName: The name of the package you want the imported file to be placed under. If package does not exist, an error will be thrown. Not supplying the package will place an imported file under the default package 'base'
+packageId: The id of the package you want the imported file to be placed under. If package does not exist, an error will be thrown. Not supplying the package will place an imported file under the default package 'base'
 
 action: the database action to import with, options are:
 	ADD: add records, error on duplicate records

--- a/docs/user_documentation/guide-upload.md
+++ b/docs/user_documentation/guide-upload.md
@@ -133,6 +133,8 @@ entityTypeId: The name of the entity, this only has effect for VCF files (.vcf a
 
 packageId: The id of the package you want the imported file to be placed under. If package does not exist, an error will be thrown. Not supplying the package will place an imported file under the default package 'base'
 
+Note: Both entityTypeId and packageId are only used when importing VCF files. EMX files containing their own packages and entities sheet will ignore these two arguments
+
 action: the database action to import with, options are:
 	ADD: add records, error on duplicate records
 	ADD_UPDATE_EXISTING: add, update existing records

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportJob.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportJob.java
@@ -21,11 +21,11 @@ public class ImportJob implements Runnable
 	private final String importRunId;
 	private final ImportRunService importRunService;
 	private final HttpSession session;
-	private final String packageName;
+	private final String packageId;
 
 	public ImportJob(ImportService importService, SecurityContext securityContext, RepositoryCollection source,
 			DatabaseAction databaseAction, String importRunId, ImportRunService importRunService, HttpSession session,
-			String packageName)
+			String packageId)
 	{
 		this.importService = importService;
 		this.securityContext = securityContext;
@@ -34,7 +34,7 @@ public class ImportJob implements Runnable
 		this.importRunId = importRunId;
 		this.importRunService = importRunService;
 		this.session = session;
-		this.packageName = packageName;
+		this.packageId = packageId;
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public class ImportJob implements Runnable
 
 			SecurityContextHolder.setContext(securityContext);
 
-			EntityImportReport importReport = importService.doImport(source, databaseAction, packageName);
+			EntityImportReport importReport = importService.doImport(source, databaseAction, packageId);
 
 			session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext);
 
@@ -92,7 +92,7 @@ public class ImportJob implements Runnable
 		if (importRunService != null ? !importRunService.equals(importJob.importRunService) :
 				importJob.importRunService != null) return false;
 		if (session != null ? !session.equals(importJob.session) : importJob.session != null) return false;
-		return packageName != null ? packageName.equals(importJob.packageName) : importJob.packageName == null;
+		return packageId != null ? packageId.equals(importJob.packageId) : importJob.packageId == null;
 	}
 
 	@Override
@@ -105,7 +105,7 @@ public class ImportJob implements Runnable
 		result = 31 * result + (importRunId != null ? importRunId.hashCode() : 0);
 		result = 31 * result + (importRunService != null ? importRunService.hashCode() : 0);
 		result = 31 * result + (session != null ? session.hashCode() : 0);
-		result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
+		result = 31 * result + (packageId != null ? packageId.hashCode() : 0);
 		return result;
 	}
 }

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportJob.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportJob.java
@@ -72,4 +72,40 @@ public class ImportJob implements Runnable
 			importRunService.failImportRun(importRunId, e.getMessage());
 		}
 	}
+
+	@Override
+	public boolean equals(Object o)
+	{
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+
+		ImportJob importJob = (ImportJob) o;
+
+		if (importService != null ? !importService.equals(importJob.importService) : importJob.importService != null)
+			return false;
+		if (securityContext != null ? !securityContext.equals(importJob.securityContext) :
+				importJob.securityContext != null) return false;
+		if (source != null ? !source.equals(importJob.source) : importJob.source != null) return false;
+		if (databaseAction != importJob.databaseAction) return false;
+		if (importRunId != null ? !importRunId.equals(importJob.importRunId) : importJob.importRunId != null)
+			return false;
+		if (importRunService != null ? !importRunService.equals(importJob.importRunService) :
+				importJob.importRunService != null) return false;
+		if (session != null ? !session.equals(importJob.session) : importJob.session != null) return false;
+		return packageName != null ? packageName.equals(importJob.packageName) : importJob.packageName == null;
+	}
+
+	@Override
+	public int hashCode()
+	{
+		int result = importService != null ? importService.hashCode() : 0;
+		result = 31 * result + (securityContext != null ? securityContext.hashCode() : 0);
+		result = 31 * result + (source != null ? source.hashCode() : 0);
+		result = 31 * result + (databaseAction != null ? databaseAction.hashCode() : 0);
+		result = 31 * result + (importRunId != null ? importRunId.hashCode() : 0);
+		result = 31 * result + (importRunService != null ? importRunService.hashCode() : 0);
+		result = 31 * result + (session != null ? session.hashCode() : 0);
+		result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
+		return result;
+	}
 }

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportJob.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportJob.java
@@ -21,11 +21,11 @@ public class ImportJob implements Runnable
 	private final String importRunId;
 	private final ImportRunService importRunService;
 	private final HttpSession session;
-	private final String defaultPackage;
+	private final String packageName;
 
 	public ImportJob(ImportService importService, SecurityContext securityContext, RepositoryCollection source,
 			DatabaseAction databaseAction, String importRunId, ImportRunService importRunService, HttpSession session,
-			String defaultPackage)
+			String packageName)
 	{
 		this.importService = importService;
 		this.securityContext = securityContext;
@@ -34,7 +34,7 @@ public class ImportJob implements Runnable
 		this.importRunId = importRunId;
 		this.importRunService = importRunService;
 		this.session = session;
-		this.defaultPackage = defaultPackage;
+		this.packageName = packageName;
 	}
 
 	@Override
@@ -47,7 +47,7 @@ public class ImportJob implements Runnable
 
 			SecurityContextHolder.setContext(securityContext);
 
-			EntityImportReport importReport = importService.doImport(source, databaseAction, defaultPackage);
+			EntityImportReport importReport = importService.doImport(source, databaseAction, packageName);
 
 			session.setAttribute("SPRING_SECURITY_CONTEXT", securityContext);
 

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportService.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportService.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public interface ImportService extends Ordered
 {
-	EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String packageName);
+	EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String packageId);
 
 	EntitiesValidationReport validateImport(File file, RepositoryCollection source);
 

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportService.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportService.java
@@ -12,7 +12,7 @@ import java.util.Set;
 
 public interface ImportService extends Ordered
 {
-	EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String defaultPackage);
+	EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String packageName);
 
 	EntitiesValidationReport validateImport(File file, RepositoryCollection source);
 

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/MetaDataParser.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/MetaDataParser.java
@@ -7,11 +7,11 @@ public interface MetaDataParser
 	/**
 	 * Parses the metadata of the entities to import.
 	 *
-	 * @param source           {@link RepositoryCollection} containing the data to parse
-	 * @param packageName , the package where the entities should go. Default if none was supplied
+	 * @param source    {@link RepositoryCollection} containing the data to parse
+	 * @param packageId , the package where the entities should go. Default if none was supplied
 	 * @return {@link ParsedMetaData}
 	 */
-	ParsedMetaData parse(RepositoryCollection source, String packageName);
+	ParsedMetaData parse(RepositoryCollection source, String packageId);
 
 	/**
 	 * Generates a {@link EntitiesValidationReport} by parsing all data from a supplied source

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/MetaDataParser.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/MetaDataParser.java
@@ -8,10 +8,10 @@ public interface MetaDataParser
 	 * Parses the metadata of the entities to import.
 	 *
 	 * @param source           {@link RepositoryCollection} containing the data to parse
-	 * @param defaultPackageId , the package where the entities without a package should go
+	 * @param packageName , the package where the entities should go. Default if none was supplied
 	 * @return {@link ParsedMetaData}
 	 */
-	ParsedMetaData parse(RepositoryCollection source, String defaultPackageId);
+	ParsedMetaData parse(RepositoryCollection source, String packageName);
 
 	/**
 	 * Generates a {@link EntitiesValidationReport} by parsing all data from a supplied source

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportJob.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportJob.java
@@ -19,14 +19,14 @@ public class EmxImportJob
 	// TODO: there is high overlap between report and metaDataChanges
 	public final EntityImportReport report = new EntityImportReport();
 	public final MetaDataChanges metaDataChanges = new MetaDataChanges();
-	public String defaultPackage;
+	public String packageName;
 
 	public EmxImportJob(DatabaseAction dbAction, RepositoryCollection source, ParsedMetaData parsedMetaData,
-			String defaultPackage)
+			String packageName)
 	{
 		this.dbAction = dbAction;
 		this.source = source;
 		this.parsedMetaData = parsedMetaData;
-		this.defaultPackage = defaultPackage;
+		this.packageName = packageName;
 	}
 }

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportJob.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportJob.java
@@ -19,14 +19,14 @@ public class EmxImportJob
 	// TODO: there is high overlap between report and metaDataChanges
 	public final EntityImportReport report = new EntityImportReport();
 	public final MetaDataChanges metaDataChanges = new MetaDataChanges();
-	public String packageName;
+	public String packageId;
 
 	public EmxImportJob(DatabaseAction dbAction, RepositoryCollection source, ParsedMetaData parsedMetaData,
-			String packageName)
+			String packageId)
 	{
 		this.dbAction = dbAction;
 		this.source = source;
 		this.parsedMetaData = parsedMetaData;
-		this.packageName = packageName;
+		this.packageId = packageId;
 	}
 }

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportService.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportService.java
@@ -62,12 +62,12 @@ public class EmxImportService implements ImportService
 
 	@Override
 	public EntityImportReport doImport(final RepositoryCollection source, DatabaseAction databaseAction,
-			String packageName)
+			String packageId)
 	{
-		ParsedMetaData parsedMetaData = parser.parse(source, packageName);
+		ParsedMetaData parsedMetaData = parser.parse(source, packageId);
 
 		// TODO altered entities (merge, see getEntityType)
-		return doImport(new EmxImportJob(databaseAction, source, parsedMetaData, packageName));
+		return doImport(new EmxImportJob(databaseAction, source, parsedMetaData, packageId));
 	}
 
 	/**

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportService.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxImportService.java
@@ -62,12 +62,12 @@ public class EmxImportService implements ImportService
 
 	@Override
 	public EntityImportReport doImport(final RepositoryCollection source, DatabaseAction databaseAction,
-			String defaultPackage)
+			String packageName)
 	{
-		ParsedMetaData parsedMetaData = parser.parse(source, defaultPackage);
+		ParsedMetaData parsedMetaData = parser.parse(source, packageName);
 
 		// TODO altered entities (merge, see getEntityType)
-		return doImport(new EmxImportJob(databaseAction, source, parsedMetaData, defaultPackage));
+		return doImport(new EmxImportJob(databaseAction, source, parsedMetaData, packageName));
 	}
 
 	/**

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxMetaDataParser.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxMetaDataParser.java
@@ -213,19 +213,19 @@ public class EmxMetaDataParser implements MetaDataParser
 
 	@Override
 	//FIXME The source is parsed twice!!! Once by determineImportableEntities and once by doImport
-	public ParsedMetaData parse(final RepositoryCollection source, String defaultPackageId)
+	public ParsedMetaData parse(final RepositoryCollection source, String packageName)
 	{
 		if (source.getRepository(EMX_ATTRIBUTES) != null)
 		{
 			IntermediateParseResults intermediateResults = getEntityTypeFromSource(source);
 			List<EntityType> entities;
-			if (defaultPackageId == null)
+			if (packageName == null)
 			{
 				entities = intermediateResults.getEntities();
 			}
 			else
 			{
-				entities = putEntitiesInDefaultPackage(intermediateResults, defaultPackageId);
+				entities = putEntitiesInDefaultPackage(intermediateResults, packageName);
 			}
 
 			return new ParsedMetaData(entityTypeDependencyResolver.resolve(entities), intermediateResults.getPackages(),

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxMetaDataParser.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxMetaDataParser.java
@@ -213,19 +213,19 @@ public class EmxMetaDataParser implements MetaDataParser
 
 	@Override
 	//FIXME The source is parsed twice!!! Once by determineImportableEntities and once by doImport
-	public ParsedMetaData parse(final RepositoryCollection source, String packageName)
+	public ParsedMetaData parse(final RepositoryCollection source, String packageId)
 	{
 		if (source.getRepository(EMX_ATTRIBUTES) != null)
 		{
 			IntermediateParseResults intermediateResults = getEntityTypeFromSource(source);
 			List<EntityType> entities;
-			if (packageName == null)
+			if (packageId == null)
 			{
 				entities = intermediateResults.getEntities();
 			}
 			else
 			{
-				entities = putEntitiesInDefaultPackage(intermediateResults, packageName);
+				entities = putEntitiesInDefaultPackage(intermediateResults, packageId);
 			}
 
 			return new ParsedMetaData(entityTypeDependencyResolver.resolve(entities), intermediateResults.getPackages(),

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/ImportWriter.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/ImportWriter.java
@@ -89,7 +89,7 @@ public class ImportWriter
 		importEntityTypes(job.parsedMetaData.getEntities(), job.report);
 
 		List<EntityType> resolvedEntityTypes = entityTypeDependencyResolver.resolve(job.parsedMetaData.getEntities());
-		importData(job.report, resolvedEntityTypes, job.source, job.dbAction, job.packageName);
+		importData(job.report, resolvedEntityTypes, job.source, job.dbAction, job.packageId);
 		importI18nStrings(job.report, job.parsedMetaData.getL10nStrings(), job.dbAction);
 
 		return job.report;

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/ImportWriter.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/ImportWriter.java
@@ -89,7 +89,7 @@ public class ImportWriter
 		importEntityTypes(job.parsedMetaData.getEntities(), job.report);
 
 		List<EntityType> resolvedEntityTypes = entityTypeDependencyResolver.resolve(job.parsedMetaData.getEntities());
-		importData(job.report, resolvedEntityTypes, job.source, job.dbAction, job.defaultPackage);
+		importData(job.report, resolvedEntityTypes, job.source, job.dbAction, job.packageName);
 		importI18nStrings(job.report, job.parsedMetaData.getL10nStrings(), job.dbAction);
 
 		return job.report;

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/wizard/ImportWizardController.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/wizard/ImportWizardController.java
@@ -367,6 +367,12 @@ public class ImportWizardController extends AbstractWizardController
 		return role.substring(0, role.indexOf('_')).toLowerCase();
 	}
 
+	/**
+	 * Imports entities present in the submitted file
+	 *
+	 * @param url   URL from which a file is downloaded
+	 * @param @Link importFile
+	 */
 	@RequestMapping(method = RequestMethod.POST, value = "/importByUrl")
 	@ResponseBody
 	public ResponseEntity<String> importFileByUrl(HttpServletRequest request, @RequestParam("url") String url,
@@ -395,6 +401,18 @@ public class ImportWizardController extends AbstractWizardController
 		return createCreatedResponseEntity(importRun);
 	}
 
+	/**
+	 * Imports entities present in the submitted file
+	 *
+	 * @param file         File containing entities. Can be VCF, VCF.gz, or EMX
+	 * @param entityTypeId Only for VCF and VCF.gz. If set, uses this ID for the table name. Is ignored when uploading EMX
+	 * @param packageName  Only for VCF and VCF.gz. If set, places the VCF under the provided package. Is ignored when uploading EMX. If not set, uses the default package 'base'. Throws an error when the supplied package does not exist
+	 * @param action       Specifies the import method. Supported: ADD, ADD_UPDATE
+	 * @param notify       Should admin be notified when the import fails?
+	 * @return ResponseEntity containing the API URL with the current import status
+	 * @throws IOException
+	 * @throws URISyntaxException
+	 */
 	@RequestMapping(method = RequestMethod.POST, value = "/importFile")
 	public ResponseEntity<String> importFile(HttpServletRequest request,
 			@RequestParam(value = "file") MultipartFile file,
@@ -416,7 +434,7 @@ public class ImportWizardController extends AbstractWizardController
 						.body(MessageFormat.format("Package [{0}] does not exist.", packageName));
 			}
 			if (packageName == null) packageName = PACKAGE_DEFAULT;
-			
+
 			importRun = importFile(request, tmpFile, action, notify, packageName);
 		}
 		catch (Exception e)

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/wizard/ImportWizardController.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/wizard/ImportWizardController.java
@@ -377,7 +377,7 @@ public class ImportWizardController extends AbstractWizardController
 	@ResponseBody
 	public ResponseEntity<String> importFileByUrl(HttpServletRequest request, @RequestParam("url") String url,
 			@RequestParam(value = "entityTypeId", required = false) String entityTypeId,
-			@RequestParam(value = "packageName", required = false) String packageName,
+			@RequestParam(value = "packageId", required = false) String packageId,
 			@RequestParam(value = "action", required = false) String action,
 			@RequestParam(value = "notify", required = false) Boolean notify) throws IOException, URISyntaxException
 	{
@@ -385,13 +385,13 @@ public class ImportWizardController extends AbstractWizardController
 		try
 		{
 			File tmpFile = fileLocationToStoredRenamedFile(url, entityTypeId);
-			if (packageName != null && dataService.getMeta().getPackage(packageName) == null)
+			if (packageId != null && dataService.getMeta().getPackage(packageId) == null)
 			{
 				return ResponseEntity.badRequest().contentType(TEXT_PLAIN)
-						.body(MessageFormat.format("Package [{0}] does not exist.", packageName));
+						.body(MessageFormat.format("Package [{0}] does not exist.", packageId));
 			}
-			if (packageName == null) packageName = PACKAGE_DEFAULT;
-			importRun = importFile(request, tmpFile, action, notify, packageName);
+			if (packageId == null) packageId = PACKAGE_DEFAULT;
+			importRun = importFile(request, tmpFile, action, notify, packageId);
 		}
 		catch (Exception e)
 		{
@@ -406,7 +406,7 @@ public class ImportWizardController extends AbstractWizardController
 	 *
 	 * @param file         File containing entities. Can be VCF, VCF.gz, or EMX
 	 * @param entityTypeId Only for VCF and VCF.gz. If set, uses this ID for the table name. Is ignored when uploading EMX
-	 * @param packageName  Only for VCF and VCF.gz. If set, places the VCF under the provided package. Is ignored when uploading EMX. If not set, uses the default package 'base'. Throws an error when the supplied package does not exist
+	 * @param packageId    Only for VCF and VCF.gz. If set, places the VCF under the provided package. Is ignored when uploading EMX. If not set, uses the default package 'base'. Throws an error when the supplied package does not exist
 	 * @param action       Specifies the import method. Supported: ADD, ADD_UPDATE
 	 * @param notify       Should admin be notified when the import fails?
 	 * @return ResponseEntity containing the API URL with the current import status
@@ -417,7 +417,7 @@ public class ImportWizardController extends AbstractWizardController
 	public ResponseEntity<String> importFile(HttpServletRequest request,
 			@RequestParam(value = "file") MultipartFile file,
 			@RequestParam(value = "entityTypeId", required = false) String entityTypeId,
-			@RequestParam(value = "packageName", required = false) String packageName,
+			@RequestParam(value = "packageId", required = false) String packageId,
 			@RequestParam(value = "action", required = false) String action,
 			@RequestParam(value = "notify", required = false) Boolean notify) throws IOException, URISyntaxException
 	{
@@ -428,14 +428,14 @@ public class ImportWizardController extends AbstractWizardController
 			filename = getFilename(file.getOriginalFilename(), entityTypeId);
 			File tmpFile = fileStore.store(file.getInputStream(), filename);
 
-			if (packageName != null && dataService.getMeta().getPackage(packageName) == null)
+			if (packageId != null && dataService.getMeta().getPackage(packageId) == null)
 			{
 				return ResponseEntity.badRequest().contentType(TEXT_PLAIN)
-						.body(MessageFormat.format("Package [{0}] does not exist.", packageName));
+						.body(MessageFormat.format("Package [{0}] does not exist.", packageId));
 			}
-			if (packageName == null) packageName = PACKAGE_DEFAULT;
+			if (packageId == null) packageId = PACKAGE_DEFAULT;
 
-			importRun = importFile(request, tmpFile, action, notify, packageName);
+			importRun = importFile(request, tmpFile, action, notify, packageId);
 		}
 		catch (Exception e)
 		{
@@ -479,7 +479,7 @@ public class ImportWizardController extends AbstractWizardController
 	}
 
 	private ImportRun importFile(HttpServletRequest request, File file, String action, Boolean notify,
-			String packageName)
+			String packageId)
 	{
 		// no action specified? default is ADD just like the importerPlugin
 		ImportRun importRun;
@@ -497,7 +497,7 @@ public class ImportWizardController extends AbstractWizardController
 		importRun = importRunService.addImportRun(SecurityUtils.getCurrentUsername(), Boolean.TRUE.equals(notify));
 		asyncImportJobs.execute(
 				new ImportJob(importService, SecurityContextHolder.getContext(), repositoryCollection, databaseAction,
-						importRun.getId(), importRunService, request.getSession(), packageName));
+						importRun.getId(), importRunService, request.getSession(), packageId));
 
 		return importRun;
 	}

--- a/molgenis-data-import/src/test/java/org/molgenis/data/importer/wizard/ImportWizardControllerTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/importer/wizard/ImportWizardControllerTest.java
@@ -51,9 +51,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
-import java.text.DateFormat;
 import java.text.ParseException;
-import java.text.SimpleDateFormat;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
@@ -110,7 +108,6 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 	private ImportService importService;
 	private Instant date;
 	private EntityType entityType;
-	private String packageName;
 
 	@SuppressWarnings("unchecked")
 	@BeforeMethod
@@ -195,10 +192,10 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 
 		Authentication authentication = mock(Authentication.class);
 		SecurityContextHolder.getContext().setAuthentication(authentication);
-		GrantedAuthority grantedAuthority1 = new SimpleGrantedAuthority(authority1.getRole().toString());
-		GrantedAuthority grantedAuthority2 = new SimpleGrantedAuthority(authority2.getRole().toString());
-		GrantedAuthority grantedAuthority3 = new SimpleGrantedAuthority(authority3.getRole().toString());
-		GrantedAuthority grantedAuthority4 = new SimpleGrantedAuthority(authority4.getRole().toString());
+		GrantedAuthority grantedAuthority1 = new SimpleGrantedAuthority(authority1.getRole());
+		GrantedAuthority grantedAuthority2 = new SimpleGrantedAuthority(authority2.getRole());
+		GrantedAuthority grantedAuthority3 = new SimpleGrantedAuthority(authority3.getRole());
+		GrantedAuthority grantedAuthority4 = new SimpleGrantedAuthority(authority4.getRole());
 		UserDetails userDetails = mock(UserDetails.class);
 		when(userDetails.getUsername()).thenReturn("username");
 		when(userDetails.getPassword()).thenReturn("encoded-password");
@@ -209,7 +206,6 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 				.thenReturn(asList(grantedAuthority1, grantedAuthority2, grantedAuthority3, grantedAuthority4));
 
 		date = Instant.parse("2016-01-01T12:34:28.123Z");
-		packageName = "test";
 
 		when(userAccountService.getCurrentUserGroups()).thenReturn(singletonList(group1));
 
@@ -269,7 +265,6 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 		when(webRequest.getParameter("radio-entity3")).thenReturn(COUNT.toString());
 		when(webRequest.getParameter("radio-entity5")).thenReturn(WRITE.toString());
 		controller.addGroupEntityClassPermissions("ID", webRequest);
-
 	}
 
 	@Test()
@@ -321,7 +316,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 		when(importRunService.addImportRun(SecurityUtils.getCurrentUsername(), false)).thenReturn(importRun);
 
 		// the actual test
-		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, packageName, "add", null);
+		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, null, "add", null);
 		assertEquals(response.getStatusCode(), HttpStatus.CREATED);
 
 		ArgumentCaptor<ImportJob> captor = ArgumentCaptor.forClass(ImportJob.class);
@@ -353,7 +348,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 
 		// the actual test
 		ResponseEntity<String> response = controller
-				.importFile(request, multipartFile, null, packageName, "update", null);
+				.importFile(request, multipartFile, null, null, "update", null);
 		assertEquals(response.getStatusCode(), HttpStatus.CREATED);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 
@@ -386,7 +381,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 
 		// the actual test
 		ResponseEntity<String> response = controller
-				.importFile(request, multipartFile, null, packageName, "addsss", null);
+				.importFile(request, multipartFile, null, null, "addsss", null);
 		assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 
@@ -418,7 +413,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 		when(importRunService.addImportRun(SecurityUtils.getCurrentUsername(), false)).thenReturn(importRun);
 
 		// the actual test
-		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, packageName, "add", null);
+		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, null, "add", null);
 		assertEquals(response.getStatusCode(), HttpStatus.CREATED);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 
@@ -451,7 +446,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 
 		// the actual test
 		ResponseEntity<String> response = controller
-				.importFile(request, multipartFile, "newName", packageName, "add", null);
+				.importFile(request, multipartFile, "newName", null, "add", null);
 		assertEquals(response.getStatusCode(), HttpStatus.CREATED);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 
@@ -483,7 +478,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 		when(importRunService.addImportRun(SecurityUtils.getCurrentUsername(), false)).thenReturn(importRun);
 
 		// the actual test
-		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, packageName, "update", null);
+		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, null, "update", null);
 		assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 
@@ -515,7 +510,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 		when(importRunService.addImportRun(SecurityUtils.getCurrentUsername(), false)).thenReturn(importRun);
 
 		// the actual test
-		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, packageName, "update", null);
+		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, null, "update", null);
 		assertEquals(response.getStatusCode(), HttpStatus.BAD_REQUEST);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 
@@ -524,7 +519,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 	}
 
 	@Test
-	public void testImportAddVCFGZ() throws IOException, URISyntaxException
+	public void testImportIntoDefaultPackageAddVCFGZ() throws IOException, URISyntaxException
 	{
 		// set up the test
 		HttpServletRequest request = mock(HttpServletRequest.class);
@@ -547,7 +542,7 @@ public class ImportWizardControllerTest extends AbstractMolgenisSpringTest
 		when(importRunService.addImportRun(SecurityUtils.getCurrentUsername(), false)).thenReturn(importRun);
 
 		// the actual test
-		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, packageName, "add", null);
+		ResponseEntity<String> response = controller.importFile(request, multipartFile, null, null, "add", null);
 		assertEquals(response.getStatusCode(), HttpStatus.CREATED);
 		assertEquals(response.getHeaders().getContentType(), TEXT_PLAIN);
 

--- a/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/importer/VcfImporterService.java
+++ b/molgenis-data-vcf/src/main/java/org/molgenis/data/vcf/importer/VcfImporterService.java
@@ -53,7 +53,7 @@ public class VcfImporterService implements ImportService
 
 	@Transactional
 	@Override
-	public EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String packageName)
+	public EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction, String packageId)
 	{
 		if (databaseAction != DatabaseAction.ADD) throw new IllegalArgumentException("Only ADD is supported");
 
@@ -65,7 +65,7 @@ public class VcfImporterService implements ImportService
 		{
 			try (Repository<Entity> repo = source.getRepository(it.next()))
 			{
-				report = importVcf(repo, addedEntities, packageName);
+				report = importVcf(repo, addedEntities, packageId);
 			}
 			catch (IOException e)
 			{
@@ -138,7 +138,7 @@ public class VcfImporterService implements ImportService
 	}
 
 	private EntityImportReport importVcf(Repository<Entity> inRepository, List<EntityType> addedEntities,
-			String packageName) throws IOException
+			String packageId) throws IOException
 	{
 		EntityImportReport report = new EntityImportReport();
 		Repository<Entity> sampleRepository;
@@ -152,7 +152,7 @@ public class VcfImporterService implements ImportService
 		EntityType entityType = inRepository.getEntityType();
 		entityType.setBackend(metaDataService.getDefaultBackend().getName());
 
-		Package package_ = dataService.getMeta().getPackage(packageName);
+		Package package_ = dataService.getMeta().getPackage(packageId);
 		if (package_ == null) package_ = defaultPackage;
 		entityType.setPackage(package_);
 

--- a/molgenis-data-vcf/src/test/java/org/molgenis/data/vcf/importer/VcfImporterServiceTest.java
+++ b/molgenis-data-vcf/src/test/java/org/molgenis/data/vcf/importer/VcfImporterServiceTest.java
@@ -12,6 +12,7 @@ import org.mockito.stubbing.Answer;
 import org.molgenis.data.*;
 import org.molgenis.data.importer.EntitiesValidationReport;
 import org.molgenis.data.importer.EntityImportReport;
+import org.molgenis.data.meta.DefaultPackage;
 import org.molgenis.data.meta.MetaDataService;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
@@ -47,6 +48,8 @@ public class VcfImporterServiceTest extends AbstractMockitoTest
 	@Mock
 	private MetaDataService metaDataService;
 	@Mock
+	private DefaultPackage defaultPackage;
+	@Mock
 	private SecurityContext securityContext;
 	@Mock
 	private RepositoryCollection repositoryCollection;
@@ -57,7 +60,8 @@ public class VcfImporterServiceTest extends AbstractMockitoTest
 	@BeforeMethod
 	public void setUpBeforeMethod()
 	{
-		vcfImporterService = new VcfImporterService(dataService, permissionSystemService, metaDataService);
+		vcfImporterService = new VcfImporterService(dataService, permissionSystemService, metaDataService,
+				defaultPackage);
 		when(dataService.getMeta()).thenReturn(metaDataService);
 		SecurityContextHolder.setContext(securityContext);
 		when(metaDataService.getDefaultBackend()).thenReturn(repositoryCollection);

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/importer/OntologyImportService.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/importer/OntologyImportService.java
@@ -41,7 +41,7 @@ public class OntologyImportService implements ImportService
 	@Override
 	@Transactional
 	public EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction,
-			String packageName)
+			String packageId)
 	{
 		if (databaseAction != DatabaseAction.ADD)
 		{

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/importer/OntologyImportService.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/importer/OntologyImportService.java
@@ -41,7 +41,7 @@ public class OntologyImportService implements ImportService
 	@Override
 	@Transactional
 	public EntityImportReport doImport(RepositoryCollection source, DatabaseAction databaseAction,
-			String defaultPackage)
+			String packageName)
 	{
 		if (databaseAction != DatabaseAction.ADD)
 		{


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] Clean commits

#### Context
Allows the diagnostics app to upload VCF's via the import API into a package.
Using this package, the diagnostics app can show all the imported 'patients'
