### PR TITLE
Fix #6183 EntityType labels are allowed to consist of only white space or empty string

### DIFF
--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
@@ -301,15 +301,18 @@ public class EntityTypeValidator
 	private static void validateEntityLabel(EntityType entityType)
 	{
 		String label = entityType.getLabel();
-		if (label.isEmpty())
+		if (label != null)
 		{
-			throw new MolgenisValidationException(
-					new ConstraintViolation(format("Label of EntityType [%s] is empty", entityType.getId())));
-		}
-		else if (label.trim().equals(""))
-		{
-			throw new MolgenisValidationException(new ConstraintViolation(
-					format("Label of EntityType [%s] contains only white space", entityType.getId())));
+			if (label.isEmpty())
+			{
+				throw new MolgenisValidationException(
+						new ConstraintViolation(format("Label of EntityType [%s] is empty", entityType.getId())));
+			}
+			else if (label.trim().equals(""))
+			{
+				throw new MolgenisValidationException(new ConstraintViolation(
+						format("Label of EntityType [%s] contains only white space", entityType.getId())));
+			}
 		}
 	}
 

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
@@ -56,6 +56,7 @@ public class EntityTypeValidator
 	public void validate(EntityType entityType)
 	{
 		validateEntityName(entityType);
+		validateEntityLabel(entityType);
 		validatePackage(entityType);
 		validateExtends(entityType);
 		validateOwnAttributes(entityType);
@@ -286,6 +287,29 @@ public class EntityTypeValidator
 			{
 				throw new MolgenisValidationException(new ConstraintViolation(e.getMessage()));
 			}
+		}
+	}
+
+	/**
+	 * Validates the entity label:
+	 * - Validates that the label is not an empty string
+	 * - Validates that the label does not only consist of white space
+	 *
+	 * @param entityType entity meta data
+	 * @throws MolgenisValidationException if the entity label is invalid
+	 */
+	private static void validateEntityLabel(EntityType entityType)
+	{
+		String label = entityType.getLabel();
+		if (label.isEmpty())
+		{
+			throw new MolgenisValidationException(
+					new ConstraintViolation(format("Label of EntityType [%s] is empty", entityType.getId())));
+		}
+		else if (label.trim().equals(""))
+		{
+			throw new MolgenisValidationException(new ConstraintViolation(
+					format("Label of EntityType [%s] contains only white space", entityType.getId())));
 		}
 	}
 

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/EntityTypeValidatorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/EntityTypeValidatorTest.java
@@ -87,7 +87,9 @@ public class EntityTypeValidatorTest
 		Package package_ = when(mock(Package.class).getId()).thenReturn(packageName).getMock();
 		when(entityType.getPackage()).thenReturn(package_);
 		String name = "name";
+		String label = "label";
 		when(entityType.getId()).thenReturn(packageName + PACKAGE_SEPARATOR + name);
+		when(entityType.getLabel()).thenReturn(label);
 		when(entityType.getOwnAllAttributes()).thenReturn(newArrayList(idAttr, labelAttr));
 		when(entityType.getAllAttributes()).thenReturn(newArrayList(idAttr, labelAttr));
 		when(entityType.getOwnIdAttribute()).thenReturn(idAttr);
@@ -96,6 +98,20 @@ public class EntityTypeValidatorTest
 		when(entityType.isAbstract()).thenReturn(false);
 		when(entityType.getExtends()).thenReturn(null);
 		when(entityType.getBackend()).thenReturn(backendName);
+	}
+
+	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Label of EntityType \\[package_name\\] is empty")
+	public void testValidateLabelIsEmpty()
+	{
+		when(entityType.getLabel()).thenReturn("");
+		entityTypeValidator.validate(entityType);
+	}
+
+	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Label of EntityType \\[package_name\\] contains only white space")
+	public void testValidateLabelIsWhiteSpace()
+	{
+		when(entityType.getLabel()).thenReturn("  ");
+		entityTypeValidator.validate(entityType);
 	}
 
 	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Name \\[logout\\] is not allowed because it is a reserved keyword.")


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
