### PR TITLE
Fix #4744: Tooltips stay on screen even after switching tab. blocking parts of the screen

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Popover.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Popover.js
@@ -12,25 +12,34 @@ var Popover = React.createClass({
     propTypes: {
         value: React.PropTypes.string.isRequired,
         popoverValue: React.PropTypes.string.isRequired,
+        animation: React.PropTypes.boolean,
+        container: React.PropTypes.oneOfType(React.PropTypes.string, React.PropTypes.bool),
+        delay: React.PropTypes.oneOfType([React.PropTypes.number, React.PropTypes.object]),
+        html: React.PropTypes.bool,
+        placement: React.PropTypes.oneOfType(React.PropTypes.oneOf('top', 'bottom', 'left', 'right', 'auto'), React.PropTypes.func),
+        template: React.PropTypes.string,
+        title: React.PropTypes.string,
+        viewport: React.PropTypes.oneOfType(React.PropTypes.string, React.PropTypes.object, React.PropTypes.func)
     },
-    componentDidMount: function () {
-        var $container = $(this.refs.popover.getDOMNode());
-        $container.popover({
+    getDefaultProps: function () {
+        return {
             trigger: 'hover click',
             placement: 'bottom',
             container: 'body'
+        }
+    },
+    componentDidMount: function () {
+        const {value, popoverValue, ...otherOptions} = this.props;
+        $(this.getDOMNode()).popover({
+            content: popoverValue,
+            ...otherOptions
         });
     },
     componentWillUnmount: function () {
-        var $container = $(this.refs.popover.getDOMNode());
-        $container.popover('destroy');
+        $(this.getDOMNode()).popover('destroy');
     },
     render: function () {
-        return span({
-            'data-content': this.props.popoverValue,
-            'data-toggle': 'popover',
-            ref: 'popover'
-        }, this.props.value);
+        return span({}, this.props.value);
     }
 });
 

--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Table.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Table.js
@@ -429,7 +429,8 @@ var TableHeaderCell = React.createClass({
 
         var Label = this.props.attr.description ? span(null, Popover({
             value: this.props.attr.label,
-            popoverValue: this.props.attr.description
+            popoverValue: this.props.attr.description,
+            trigger: 'hover'
         })) : this.props.attr.label;
 
         return (


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
