### PR TITLE
Fix #6253 Deleting entity type without read-only attributes fails

### DIFF
--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlRepositoryCollection.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlRepositoryCollection.java
@@ -141,16 +141,19 @@ public class PostgreSqlRepositoryCollection extends AbstractRepositoryCollection
 		}
 		jdbcTemplate.execute(sqlDropTable);
 
-		String sqlDropFunctionValidateUpdate = getSqlDropFunctionValidateUpdate(entityType);
-		if (LOG.isDebugEnabled())
+		if (getTableAttributesReadonly(entityType).findAny().isPresent())
 		{
-			LOG.debug("Dropping trigger function for entity [{}]", entityType.getId());
-			if (LOG.isTraceEnabled())
+			String sqlDropFunctionValidateUpdate = getSqlDropFunctionValidateUpdate(entityType);
+			if (LOG.isDebugEnabled())
 			{
-				LOG.trace("SQL: {}", sqlDropFunctionValidateUpdate);
+				LOG.debug("Dropping trigger function for entity [{}]", entityType.getId());
+				if (LOG.isTraceEnabled())
+				{
+					LOG.trace("SQL: {}", sqlDropFunctionValidateUpdate);
+				}
 			}
+			jdbcTemplate.execute(sqlDropFunctionValidateUpdate);
 		}
-		jdbcTemplate.execute(sqlDropFunctionValidateUpdate);
 	}
 
 	@Override


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
