### PR TITLE
Fix #5532 Error editing entity with attribute of type FILE

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Input.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Input.js
@@ -83,44 +83,70 @@ var Input = React.createClass({
             }
         } else {
             if (this._isFile()) {
-                // see http://www.abeautifulsite.net/whipping-file-inputs-into-shape-with-bootstrap-3/
-                return (
-                    div({className: 'input-group'},
-                        span({className: 'input-group-btn'},
-                            span({
-                                    className: 'btn btn-primary',
-                                    style: {position: 'relative', overflow: 'hidden'}
-                                }, 'Browse...',
-                                input(_.extend(inputProps, {
-                                    onChange: this._handleFileBrowseClick,
-                                    style: {
-                                        position: 'absolute',
-                                        top: 0,
-                                        right: 0,
-                                        minWidth: '100%',
-                                        minHeight: '100%',
-                                        fontSize: 100,
-                                        textAlign: 'right',
-                                        opacity: 0,
-                                        outline: 'none',
-                                        background: 'white',
-                                        cursor: 'inherit',
-                                        display: 'block'
+                if (inputProps.value && !this.state.setByUser) {
+                    return (
+                        div({className: 'input-group'},
+                            span({className: 'input-group-btn'},
+                                span({
+                                        onClick: this._handleClearButtonClick,
+                                        className: 'btn btn-primary',
+                                        style: {position: 'relative', overflow: 'hidden'}
                                     }
-                                }))
-                            )
-                        ),
-                        input({
-                            type: 'text',
-                            className: 'form-control',
-                            readOnly: true,
-                            style: {backgroundColor: 'white !important', cursor: 'text !important'},
-                            value: this.state.value ? this.state.value.filename : null,
-                            ref: 'fileTextInput'
-                        })
-                    )
-                );
-            } else {
+                                    , 'Change'
+                                )
+                            ),
+                            input(_.extend(inputProps, {
+                                type: 'text',
+                                className: 'form-control',
+                                readOnly: true,
+                                style: {backgroundColor: 'white !important', cursor: 'text !important'},
+                                value: this.state.value ? this.state.value : null,
+                                ref: 'fileTextInput'
+                            }))
+                        )
+                    );
+                }
+                else {
+                    // see http://www.abeautifulsite.net/whipping-file-inputs-into-shape-with-bootstrap-3/
+                    return (
+                        div({className: 'input-group'},
+                            span({className: 'input-group-btn'},
+                                span({
+                                        className: 'btn btn-primary',
+                                        style: {position: 'relative', overflow: 'hidden'}
+                                    }, 'Browse...',
+                                    input(_.extend(inputProps, {
+                                        onChange: this._handleFileBrowseClick,
+                                        style: {
+                                            position: 'absolute',
+                                            top: 0,
+                                            right: 0,
+                                            minWidth: '100%',
+                                            minHeight: '100%',
+                                            fontSize: 100,
+                                            textAlign: 'right',
+                                            opacity: 0,
+                                            outline: 'none',
+                                            background: 'white',
+                                            cursor: 'inherit',
+                                            display: 'block'
+                                        }
+                                    }))
+                                )
+                            ),
+                            input({
+                                type: 'text',
+                                className: 'form-control',
+                                readOnly: true,
+                                style: {backgroundColor: 'white !important', cursor: 'text !important'},
+                                value: this.state.value ? this.state.value.filename : null,
+                                ref: 'fileTextInput'
+                            })
+                        )
+                    );
+                }
+            }
+            else {
                 return input(inputProps);
             }
         }
@@ -172,8 +198,13 @@ var Input = React.createClass({
             label = this._toFileLabel(value);
         $(this.refs.fileTextInput.getDOMNode()).val(label);
 
-        this.setState({value: value});
+        this.setState({value: value, setByUser: true});
         this._handleChangeOrBlur(value, undefined, this.props.onValueChange);
+    },
+    _handleClearButtonClick: function () {
+        this.state.value = null;
+        this.state.setByUser = false;
+        this._handleChangeOrBlur(undefined, undefined, this.props.onValueChange);
     },
     _toFileLabel: function (value) {
         return value.replace(/\\/g, '/').replace(/.*\//, '');

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
@@ -648,7 +648,7 @@ public class RestController
 					"Attribute '" + attributeName + "' of entity '" + entityTypeId + "' is readonly");
 		}
 
-		Object value = this.restService.toEntityValue(attr, paramValue);
+		Object value = this.restService.toEntityValue(attr, paramValue, id);
 		entity.set(attributeName, value);
 		dataService.update(entityTypeId, entity);
 	}

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
@@ -505,7 +505,7 @@ class RestControllerV2
 					throw createUnknownEntityExceptionNotValidId(id);
 				}
 
-				Object value = this.restService.toEntityValue(attr, entity.get(attributeName));
+				Object value = this.restService.toEntityValue(attr, entity.get(attributeName), id);
 				originalEntity.set(attributeName, value);
 				updatedEntities.add(originalEntity);
 				count++;


### PR DESCRIPTION
Fix bug whereby updating a entity with a file attribute would result in an error.
+
Add tests for revolving file attribute to entity

This PR combines the fix @bartcharbon started whereby the toEntity function of the FILE type entity checks if a file of string ( filename) is send. And if only a name is send is used the stored file.

PR also includes a fix to the front-end that stops the js code form trying to set the value of the stored file in the file input component ( as this results in a error). The js code now sets the value into a text field and add the button for the user to change the value.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
