### PR TITLE
Fix #6223 Failing query when searching for many values in an mref

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/transformer.js
+++ b/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/transformer.js
@@ -16,7 +16,8 @@ function getRsqlFromConstraint(constraint) {
 }
 
 function getRsqlFromSimpleConstraint(constraint) {
-    return toRsqlValue(constraint.selector) + constraint.comparison + toRsqlValue(constraint.arguments)
+    const rsqlValue = constraint.arguments.constructor === Array ? '(' + constraint.arguments.map(toRsqlValue).join(',') + ')' : constraint.arguments
+    return toRsqlValue(constraint.selector) + constraint.comparison + rsqlValue
 }
 
 function getRsqlFromComplexConstraint(constraint) {
@@ -89,7 +90,11 @@ export function transformModelPart(fieldType, labels, constraint) {
 
 export function getArguments(constraint) {
     if (constraint.arguments) {
-        return new Set([constraint.arguments])
+        if (constraint.arguments.constructor === Array) {
+            return new Set(constraint.arguments)
+        } else {
+            return new Set([constraint.arguments])
+        }
     }
     let result = new Set()
     constraint.operands.map(o => getArguments(o).forEach(a => result.add(a)))
@@ -137,7 +142,7 @@ function toSimpleRef(labels, constraint) {
 export function toComplexLine(labels, group) {
     return {
         'operator': group.operator,
-        'values': (group.operands || [group.arguments]).map(o => {
+        'values': (group.operands || (group.arguments.constructor === Array ? group.arguments : [group.arguments])).map(o = > {
             const value = o.arguments || o
             return {'label': labels[value], value}
         })

--- a/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/transformer.js
+++ b/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/transformer.js
@@ -142,7 +142,7 @@ function toSimpleRef(labels, constraint) {
 export function toComplexLine(labels, group) {
     return {
         'operator': group.operator,
-        'values': (group.operands || (group.arguments.constructor === Array ? group.arguments : [group.arguments])).map(o = > {
+        'values': (group.operands || (group.arguments.constructor === Array ? group.arguments : [group.arguments])).map(o => {
             const value = o.arguments || o
             return {'label': labels[value], value}
         })

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
@@ -302,7 +302,7 @@ test("Test getArguments with nested MREF constraint", assert => {
     assert.end();
 })
 
-test("Test getArguments with constraint with multiple values", assert = > {
+test("Test getArguments with constraint with multiple values", assert => {
     const actual = getArguments(parser.parse("xmref=in=(abc,def)"))
     assert.deepEqual(actual, new Set(['abc', 'def']))
 assert.end();

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
@@ -22,6 +22,20 @@ test("Test that a single comparison get transformed back to RSQL", assert => {
     assert.end()
 })
 
+test("Test that a single 'range' comparison with multiple values get transformed back to RSQL", assert = > {
+    const actual = transformToRSQL(groupBySelector(parser.parse('xrange=rng=(2,3)')))
+    const expected = 'xrange=rng=(2,3)'
+    assert.deepEqual(actual, expected)
+assert.end()
+})
+
+test("Test that a single 'in' comparison with multiple values get transformed back to RSQL", assert = > {
+    const actual = transformToRSQL(groupBySelector(parser.parse('xmref=in=(abc,def)')))
+    const expected = 'xmref=in=(abc,def)'
+    assert.deepEqual(actual, expected)
+assert.end()
+})
+
 test('Test that multiple comparisons get mapped', assert => {
     const actual = groupBySelector(parser.parse("xbool==false;(xxref==ref1,xxref==ref2)"))
     const expected = {
@@ -286,4 +300,10 @@ test("Test getArguments with nested MREF constraint", assert => {
     const actual = getArguments(parser.parse("(((xmref==ref1;xmref==ref2);(xmref==ref3,xmref==ref4)),(xmref==ref5,xmref==ref1),((xmref==ref2;xmref==ref3);(xmref==ref4,xmref==ref5)))"))
     assert.deepEqual(actual, new Set(['ref1', 'ref2', 'ref3', 'ref4', 'ref5']))
     assert.end();
+})
+
+test("Test getArguments with constraint with multiple values", assert = > {
+    const actual = getArguments(parser.parse("xmref=in=(abc,def)"))
+    assert.deepEqual(actual, new Set(['abc', 'def']))
+assert.end();
 })

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
@@ -22,14 +22,14 @@ test("Test that a single comparison get transformed back to RSQL", assert => {
     assert.end()
 })
 
-test("Test that a single 'range' comparison with multiple values get transformed back to RSQL", assert = > {
+test("Test that a single 'range' comparison with multiple values get transformed back to RSQL", assert => {
     const actual = transformToRSQL(groupBySelector(parser.parse('xrange=rng=(2,3)')))
     const expected = 'xrange=rng=(2,3)'
     assert.deepEqual(actual, expected)
 assert.end()
 })
 
-test("Test that a single 'in' comparison with multiple values get transformed back to RSQL", assert = > {
+test("Test that a single 'in' comparison with multiple values get transformed back to RSQL", assert => {
     const actual = transformToRSQL(groupBySelector(parser.parse('xmref=in=(abc,def)')))
     const expected = 'xmref=in=(abc,def)'
     assert.deepEqual(actual, expected)

--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlQueryGenerator.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlQueryGenerator.java
@@ -718,6 +718,7 @@ class PostgreSqlQueryGenerator
 					parameters.add("%" + PostgreSqlUtils.getPostgreSqlQueryValue(r.getValue(), attr) + '%');
 					break;
 				case IN:
+				{
 					Object inValue = r.getValue();
 					if (inValue == null)
 					{
@@ -753,9 +754,19 @@ class PostgreSqlQueryGenerator
 						result.append("this");
 					}
 
-					result.append('.').append(getColumnName(entityType.getAttribute(r.getField()))).append(" IN (")
-							.append(in).append(')');
+					Attribute equalsAttr;
+					if (attr.isMappedBy())
+					{
+						equalsAttr = attr.getRefEntity().getIdAttribute();
+					}
+					else
+					{
+						equalsAttr = entityType.getAttribute(r.getField());
+					}
+					result.append('.').append(getColumnName(equalsAttr));
+					result.append(" IN (").append(in).append(')');
 					break;
+				}
 				case NOT:
 					result.append(" NOT ");
 					break;

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-filter-rsql.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-filter-rsql.js
@@ -115,7 +115,13 @@
 
             var simpleFilter = new molgenis.dataexplorer.filter.SimpleFilter(attribute, undefined, undefined)
             $.each(line.values, function () {
-                simpleFilter.getValues().push(this.value)
+                if (this.value.constructor === Array) {
+                    $.each(this.value, function () {
+                        simpleFilter.getValues().push(this)
+                    })
+                } else {
+                    simpleFilter.getValues().push(this.value)
+                }
                 simpleFilter.getLabels().push(this.label)
             })
             simpleFilter.operator = line.operator

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-filter.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-filter.js
@@ -776,25 +776,33 @@
                     }
 
                     if (values.length > 1) {
-                        var nestedRule = {
-                            operator: 'NESTED',
-                            nestedRules: []
-                        };
-
-                        $.each(values, function (index, value) {
-                            if (index > 0) {
-                                nestedRule.nestedRules.push({
-                                    operator: operator || 'OR'
-                                });
-                            }
-
-                            nestedRule.nestedRules.push({
+                        if (attrOperator === 'EQUALS') {
+                            rule = {
                                 field: queryRuleField,
-                                operator: attrOperator,
-                                value: value
+                                operator: 'IN',
+                                value: values
+                            };
+                        } else {
+                            var nestedRule = {
+                                operator: 'NESTED',
+                                nestedRules: []
+                            };
+
+                            $.each(values, function (index, value) {
+                                if (index > 0) {
+                                    nestedRule.nestedRules.push({
+                                        operator: operator || 'OR'
+                                    });
+                                }
+
+                                nestedRule.nestedRules.push({
+                                    field: queryRuleField,
+                                    operator: attrOperator,
+                                    value: value
+                                });
                             });
-                        });
-                        rule = nestedRule;
+                            rule = nestedRule;
+                        }
                     } else {
                         rule = {
                             field: queryRuleField,


### PR DESCRIPTION
Refactor: Use IN query rule instead of multiple OR query rules when filtering on multiple values
Fix: RSQL REST client bugs using IN or RANGE queries with multiple values
Fix: PostgreSQL ONE-TO-MANY fails for IN operator
Fix: Data explorer filter RSQL handles IN or RANGE queries with multiple values incorrectly

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
