### PR TITLE
Throw exception when metadata-manager-service wants to retrieve a non-existing EntityType

### DIFF
--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/service/MetadataManagerService.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/service/MetadataManagerService.java
@@ -17,10 +17,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Collections;
 import java.util.List;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
 import static org.molgenis.data.i18n.LanguageService.getLanguageCodes;
 import static org.molgenis.metadata.manager.service.MetadataManagerService.URI;
@@ -66,6 +66,11 @@ public class MetadataManagerService
 		EntityType entityType = metadataService
 				.getRepository(EntityTypeMetadata.ENTITY_TYPE_META_DATA, EntityType.class).findOneById(entityTypeId);
 
+		if (entityType == null)
+		{
+			throw new UnknownEntityException("Unknown EntityType [" + entityTypeId + "]");
+		}
+
 		return createEntityTypeResponse(entityType);
 	}
 
@@ -97,8 +102,7 @@ public class MetadataManagerService
 	public ErrorMessageResponse handleUnknownEntityException(UnknownEntityException e)
 	{
 		LOG.debug("", e);
-		return new ErrorMessageResponse(
-				Collections.singletonList(new ErrorMessageResponse.ErrorMessage(e.getMessage())));
+		return new ErrorMessageResponse(singletonList(new ErrorMessageResponse.ErrorMessage(e.getMessage())));
 	}
 
 	@ExceptionHandler(RuntimeException.class)
@@ -107,8 +111,7 @@ public class MetadataManagerService
 	public ErrorMessageResponse handleRuntimeException(RuntimeException e)
 	{
 		LOG.error("", e);
-		return new ErrorMessageResponse(
-				Collections.singletonList(new ErrorMessageResponse.ErrorMessage(e.getMessage())));
+		return new ErrorMessageResponse(singletonList(new ErrorMessageResponse.ErrorMessage(e.getMessage())));
 	}
 
 	private List<EditorPackageIdentifier> createPackageListResponse(List<Package> packages)

--- a/molgenis-metadata-manager/src/test/java/org/molgenis/metadata/manager/service/MetadataManagerServiceTest.java
+++ b/molgenis-metadata-manager/src/test/java/org/molgenis/metadata/manager/service/MetadataManagerServiceTest.java
@@ -107,13 +107,27 @@ public class MetadataManagerServiceTest extends AbstractTestNGSpringContextTests
 	}
 
 	@Test
-	public void testGetEntityTypeNotExists() throws Exception
+	public void testGetEntityTypeRepositoryNotExists() throws Exception
 	{
 		when(metaDataService.getRepository(ENTITY_TYPE_META_DATA, EntityType.class))
 				.thenThrow(new UnknownEntityException("Unknown entity [unknownId]"));
+
 		this.mockMvc.perform(get("/metadata-manager-service/entityType/unknownId")).andExpect(status().isBadRequest())
 				.andExpect(content().contentType(APPLICATION_JSON))
 				.andExpect(content().string("{\"errors\":[{\"message\":\"Unknown entity [unknownId]\"}]}"));
+	}
+
+	@Test
+	public void testGetEntityTypeEntityDoesNotExist() throws Exception
+	{
+		Repository<EntityType> repository = mock(Repository.class);
+		when(repository.findOneById("unknownId")).thenReturn(null);
+
+		when(metaDataService.getRepository(ENTITY_TYPE_META_DATA, EntityType.class)).thenReturn(repository);
+
+		mockMvc.perform(get("/metadata-manager-service/entityType/unknownId")).andExpect(status().isBadRequest())
+				.andExpect(content().contentType(APPLICATION_JSON))
+				.andExpect(content().string("{\"errors\":[{\"message\":\"Unknown EntityType [unknownId]\"}]}"));
 	}
 
 	@Test


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
