### PR TITLE
Fix #6320 & #6326 Maximum page size reached in elasticsearch queries

### DIFF
--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticsearchServiceTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/ElasticsearchServiceTest.java
@@ -1,0 +1,112 @@
+package org.molgenis.data.elasticsearch;
+
+import org.mockito.Mock;
+import org.molgenis.data.DataService;
+import org.molgenis.data.Entity;
+import org.molgenis.data.elasticsearch.client.ClientFacade;
+import org.molgenis.data.elasticsearch.client.model.SearchHit;
+import org.molgenis.data.elasticsearch.client.model.SearchHits;
+import org.molgenis.data.elasticsearch.generator.ContentGenerators;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.support.QueryImpl;
+import org.molgenis.test.AbstractMockitoTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static java.util.Arrays.asList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+import static org.molgenis.data.elasticsearch.ElasticsearchService.MAX_BATCH_SIZE;
+
+public class ElasticsearchServiceTest extends AbstractMockitoTest
+{
+	private ElasticsearchService elasticsearchService;
+
+	@Mock
+	private ClientFacade clientFacade;
+
+	@Mock
+	private ContentGenerators contentGenerators;
+
+	@Mock
+	private DataService dataService;
+
+	@Mock
+	private EntityType entityType;
+
+	@BeforeMethod
+	public void setUpBeforeMethod()
+	{
+		elasticsearchService = new ElasticsearchService(clientFacade, contentGenerators, dataService);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testBatchingSearchPageSizeZero()
+	{
+		QueryImpl<Entity> query = mock(QueryImpl.class);
+		when(query.getPageSize()).thenReturn(0);
+		when(query.getOffset()).thenReturn(0);
+
+		SearchHits searchHitsBatch = mock(SearchHits.class);
+		when(searchHitsBatch.getHits()).thenReturn(asList(new SearchHit[10000]));
+
+		SearchHits finalSearchHitsBatch = mock(SearchHits.class);
+		when(finalSearchHitsBatch.getHits()).thenReturn(asList(new SearchHit[5000]));
+
+		when(clientFacade.search(any(), eq(0), eq(10000), any(), any())).thenReturn(searchHitsBatch);
+		when(clientFacade.search(any(), eq(10000), anyInt(), any(), any())).thenReturn(searchHitsBatch);
+		when(clientFacade.search(any(), eq(20000), anyInt(), any(), any())).thenReturn(finalSearchHitsBatch);
+
+		elasticsearchService.search(entityType, query);
+
+		verify(clientFacade, times(1)).search(any(), eq(0), eq(MAX_BATCH_SIZE), any(), any());
+		verify(clientFacade, times(1)).search(any(), eq(10000), eq(MAX_BATCH_SIZE), any(), any());
+		verify(clientFacade, times(1)).search(any(), eq(20000), eq(MAX_BATCH_SIZE), any(), any());
+		verifyNoMoreInteractions(clientFacade);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testSingleBatchSearch()
+	{
+		QueryImpl<Entity> query = mock(QueryImpl.class);
+		when(query.getPageSize()).thenReturn(50);
+		when(query.getOffset()).thenReturn(20);
+
+		SearchHits searchHitsBatch = mock(SearchHits.class);
+		when(searchHitsBatch.getHits()).thenReturn(asList(new SearchHit[50]));
+
+		when(clientFacade.search(any(), eq(20), eq(50), any(), any())).thenReturn(searchHitsBatch);
+
+		elasticsearchService.search(entityType, query);
+
+		verify(clientFacade, times(1)).search(any(), eq(20), eq(50), any(), any());
+		verifyNoMoreInteractions(clientFacade);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testBatchingSearchPageSizeLargerThanMax()
+	{
+		QueryImpl<Entity> query = mock(QueryImpl.class);
+		when(query.getPageSize()).thenReturn(10001);
+		when(query.getOffset()).thenReturn(5000);
+
+		SearchHits searchHitsBatch = mock(SearchHits.class);
+		when(searchHitsBatch.getHits()).thenReturn(asList(new SearchHit[10000]));
+
+		SearchHits finalSearchHitsBatch = mock(SearchHits.class);
+		when(finalSearchHitsBatch.getHits()).thenReturn(asList(new SearchHit[1]));
+
+		when(clientFacade.search(any(), eq(5000), eq(MAX_BATCH_SIZE), any(), any())).thenReturn(searchHitsBatch);
+		when(clientFacade.search(any(), eq(15000), eq(1), any(), any())).thenReturn(finalSearchHitsBatch);
+
+		elasticsearchService.search(entityType, query);
+
+		verify(clientFacade, times(1)).search(any(), eq(5000), eq(MAX_BATCH_SIZE), any(), any());
+		verify(clientFacade, times(1)).search(any(), eq(15000), eq(1), any(), any());
+		verifyNoMoreInteractions(clientFacade);
+	}
+}


### PR DESCRIPTION
The new Elasticsearch version doesn't allow search queries with a page size above 10000. 

This is troublesome in a few places:
- The row level secured entities (Attribute, EntityType) need to fetch all rows before being able to filter the accessible rows when doing search
- The ```SemanticSearchService``` queries with ```Integer.MAX_VALUE``` to retrieve ontology hits
- When actually doing a search query with a page size > 10000

The underlying problem is that the ```ElasticsearchService``` doesn't batch the query, which results in an exception from Elasticsearch itself.

This PR is a proposal for a patch that limits the offending queries to the max page size. Impact is considered low.  

Adding batching support should be picked up in the follow-up indexing stories. 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [ nvt] User documentation updated
- [ nvt] (If you have changed REST API interface) view-swagger.ftl updated
- [ nvt] Test plan template updated
- [x] Clean commits
