### PR TITLE
Fix/4354 User with edit permission on home plugin can't edit

### DIFF
--- a/molgenis-app/src/test/java/org/molgenis/app/controller/ContentControllersTest.java
+++ b/molgenis-app/src/test/java/org/molgenis/app/controller/ContentControllersTest.java
@@ -177,7 +177,7 @@ public class ContentControllersTest extends AbstractTestNGSpringContextTests
 	private void initEditGetMethodTest(MockMvc mockMvc, String uri, String uniqueReference) throws Exception
 	{
 		when(this.staticContentService.getContent(any(String.class))).thenReturn("staticcontent");
-		when(this.staticContentService.isCurrentUserCanEdit()).thenReturn(true);
+		when(this.staticContentService.isCurrentUserCanEdit("staticcontent")).thenReturn(true);
 
 		mockMvc.perform(MockMvcRequestBuilders.get(uri + "/edit")).andExpect(MockMvcResultMatchers.status().isOk())
 				.andExpect(view().name("view-staticcontent-edit")).andExpect(model().attributeExists("content"));

--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/AbstractStaticContentController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/AbstractStaticContentController.java
@@ -1,5 +1,6 @@
 package org.molgenis.ui.controller;
 
+import org.molgenis.data.MolgenisDataAccessException;
 import org.molgenis.ui.MolgenisPluginController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,7 +35,7 @@ public abstract class AbstractStaticContentController extends MolgenisPluginCont
 		try
 		{
 			model.addAttribute("content", this.staticContentService.getContent(uniqueReference));
-			model.addAttribute("isCurrentUserCanEdit", this.staticContentService.isCurrentUserCanEdit());
+			model.addAttribute("isCurrentUserCanEdit", this.staticContentService.isCurrentUserCanEdit(uniqueReference));
 		}
 		catch (RuntimeException re)
 		{
@@ -45,10 +46,10 @@ public abstract class AbstractStaticContentController extends MolgenisPluginCont
 		return "view-staticcontent";
 	}
 
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@RequestMapping(value = "/edit", method = RequestMethod.GET)
 	public String initEditView(final Model model)
 	{
+		this.staticContentService.checkPermissions(this.uniqueReference);
 		try
 		{
 			model.addAttribute("content", this.staticContentService.getContent(this.uniqueReference));
@@ -62,11 +63,11 @@ public abstract class AbstractStaticContentController extends MolgenisPluginCont
 		return "view-staticcontent-edit";
 	}
 
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@RequestMapping(value = "/edit", method = RequestMethod.POST)
 	public String submitContent(@RequestParam(value = "content", required = true) final String content,
 			final Model model)
 	{
+		this.staticContentService.checkPermissions(this.uniqueReference);
 		try
 		{
 			this.staticContentService.submitContent(this.uniqueReference, content);

--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/StaticContentService.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/StaticContentService.java
@@ -16,5 +16,7 @@ public interface StaticContentService
 
 	boolean submitContent(final String uniqueReference, final String content);
 
-	boolean isCurrentUserCanEdit();
+	boolean isCurrentUserCanEdit(String pluginId);
+
+	void checkPermissions(String pluginId);
 }

--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/StaticContentServiceImpl.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/StaticContentServiceImpl.java
@@ -90,7 +90,7 @@ public class StaticContentServiceImpl implements StaticContentService
 
 	public void checkPermissions(String pluginId){
 		if(!this.isCurrentUserCanEdit(pluginId)){
-			throw new MolgenisDataAccessException("No write permissions on static content");
+			throw new MolgenisDataAccessException("No write permissions on static content page");
 		}
 	}
 }

--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/StaticContentServiceImpl.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/controller/StaticContentServiceImpl.java
@@ -1,8 +1,17 @@
 package org.molgenis.ui.controller;
 
+import org.molgenis.auth.User;
 import org.molgenis.data.DataService;
+import org.molgenis.data.MolgenisDataAccessException;
+import org.molgenis.security.core.MolgenisPermissionService;
+import org.molgenis.security.core.Permission;
 import org.molgenis.security.core.runas.RunAsSystemProxy;
 import org.molgenis.security.core.utils.SecurityUtils;
+import org.molgenis.security.permission.PermissionManagerService;
+import org.molgenis.security.permission.PermissionManagerServiceImpl;
+import org.molgenis.security.permission.Permissions;
+import org.molgenis.security.user.UserAccountService;
+import org.molgenis.ui.admin.permission.PermissionManagerController;
 import org.molgenis.ui.settings.StaticContent;
 import org.molgenis.ui.settings.StaticContentFactory;
 import org.slf4j.Logger;
@@ -26,18 +35,22 @@ public class StaticContentServiceImpl implements StaticContentService
 	private final DataService dataService;
 	private final StaticContentFactory staticContentFactory;
 
+	private final MolgenisPermissionService molgenisPermissionService;
+
 	@Autowired
-	public StaticContentServiceImpl(DataService dataService, StaticContentFactory staticContentFactory)
+	public StaticContentServiceImpl(DataService dataService, StaticContentFactory staticContentFactory,
+			MolgenisPermissionService molgenisPermissionService)
 	{
+		this.molgenisPermissionService = requireNonNull(molgenisPermissionService);
 		this.dataService = requireNonNull(dataService);
 		this.staticContentFactory = staticContentFactory;
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU','ROLE_SYSTEM')")
 	@Transactional
 	public boolean submitContent(String key, String content)
 	{
+		this.checkPermissions(key);
 		try
 		{
 			StaticContent staticContent = dataService.findOneById(STATIC_CONTENT, key, StaticContent.class);
@@ -62,9 +75,9 @@ public class StaticContentServiceImpl implements StaticContentService
 	}
 
 	@Override
-	public boolean isCurrentUserCanEdit()
+	public boolean isCurrentUserCanEdit(String pluginId)
 	{
-		return SecurityUtils.currentUserIsAuthenticated() && SecurityUtils.currentUserIsSu();
+		return SecurityUtils.currentUserIsAuthenticated() && molgenisPermissionService.hasPermissionOnPlugin(pluginId, Permission.WRITE);
 	}
 
 	@Override
@@ -73,5 +86,11 @@ public class StaticContentServiceImpl implements StaticContentService
 		StaticContent staticContent = RunAsSystemProxy
 				.runAsSystem(() -> dataService.findOneById(STATIC_CONTENT, key, StaticContent.class));
 		return staticContent != null ? staticContent.getContent() : null;
+	}
+
+	public void checkPermissions(String pluginId){
+		if(!this.isCurrentUserCanEdit(pluginId)){
+			throw new MolgenisDataAccessException("No write permissions on static content");
+		}
 	}
 }

--- a/molgenis-core-ui/src/test/java/org/molgenis/ui/controller/StaticContentServiceImplTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/ui/controller/StaticContentServiceImplTest.java
@@ -2,7 +2,9 @@ package org.molgenis.ui.controller;
 
 import org.molgenis.data.DataService;
 import org.molgenis.data.populate.EntityPopulator;
+import org.molgenis.security.core.MolgenisPermissionService;
 import org.molgenis.security.core.utils.SecurityUtils;
+import org.molgenis.security.permission.MolgenisPermissionServiceImpl;
 import org.molgenis.security.user.UserDetailsService;
 import org.molgenis.ui.settings.StaticContent;
 import org.molgenis.ui.settings.StaticContentFactory;
@@ -49,21 +51,21 @@ public class StaticContentServiceImplTest extends AbstractTestNGSpringContextTes
 	public void isCurrentUserCanEdit_SuperUser()
 	{
 		this.setSecurityContextSuperUser();
-		assertTrue(this.staticContentService.isCurrentUserCanEdit());
+		assertTrue(this.staticContentService.isCurrentUserCanEdit("home"));
 	}
 
 	@Test
 	public void isCurrentUserCanEdit_NonSuperUser()
 	{
 		this.setSecurityContextNonSuperUser();
-		assertFalse(this.staticContentService.isCurrentUserCanEdit());
+		assertFalse(this.staticContentService.isCurrentUserCanEdit("home"));
 	}
 
 	@Test
 	public void isCurrentUserCanEdit_AnonymousUsers()
 	{
 		this.setSecurityContextAnonymousUsers();
-		assertFalse(this.staticContentService.isCurrentUserCanEdit());
+		assertFalse(this.staticContentService.isCurrentUserCanEdit("home"));
 	}
 
 	@Test
@@ -124,6 +126,11 @@ public class StaticContentServiceImplTest extends AbstractTestNGSpringContextTes
 	public static class Config extends WebSecurityConfigurerAdapter
 	{
 		@Bean
+		public MolgenisPermissionService molgenisPermissionService(){
+			return new MolgenisPermissionServiceImpl();
+		}
+
+		@Bean
 		public StaticContentFactory staticContentFactory()
 		{
 			return new StaticContentFactory(mock(StaticContentMeta.class), mock(EntityPopulator.class));
@@ -132,7 +139,7 @@ public class StaticContentServiceImplTest extends AbstractTestNGSpringContextTes
 		@Bean
 		public StaticContentService staticContentService()
 		{
-			return new StaticContentServiceImpl(dataService(), staticContentFactory());
+			return new StaticContentServiceImpl(dataService(), staticContentFactory(), molgenisPermissionService());
 		}
 
 		@Bean


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [nvt ] User documentation updated
- [nvt ] (If you have changed REST API interface) view-swagger.ftl updated
- [nvt ] Test plan template updated
- [will fix by squasing at merge ] Clean commits
