### PR TITLE
Fix #6327: Performance severely reduced after importing a model with many entities and attributes

### DIFF
--- a/molgenis-data-cache/src/main/java/org/molgenis/data/cache/l2/L2Cache.java
+++ b/molgenis-data-cache/src/main/java/org/molgenis/data/cache/l2/L2Cache.java
@@ -9,6 +9,7 @@ import org.molgenis.data.EntityKey;
 import org.molgenis.data.MolgenisDataException;
 import org.molgenis.data.Repository;
 import org.molgenis.data.cache.utils.EntityHydration;
+import org.molgenis.data.meta.MetaDataService;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.transaction.DefaultMolgenisTransactionListener;
 import org.molgenis.data.transaction.TransactionInformation;
@@ -166,10 +167,12 @@ public class L2Cache extends DefaultMolgenisTransactionListener
 	 */
 	private LoadingCache<Object, Optional<Map<String, Object>>> createEntityCache(Repository<Entity> repository)
 	{
-		return CaffeinatedGuava.build(Caffeine.newBuilder()
-											  .recordStats()
-											  .maximumSize(MAX_CACHE_SIZE_PER_ENTITY)
-											  .expireAfterAccess(10, MINUTES), createCacheLoader(repository));
+		Caffeine<Object, Object> cacheBuilder = Caffeine.newBuilder().recordStats().expireAfterAccess(10, MINUTES);
+		if (!MetaDataService.isMetaEntityType(repository.getEntityType()))
+		{
+			cacheBuilder.maximumSize(MAX_CACHE_SIZE_PER_ENTITY);
+		}
+		return CaffeinatedGuava.build(cacheBuilder, createCacheLoader(repository));
 	}
 
 	/**

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/EntityTypeRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/EntityTypeRepositoryDecorator.java
@@ -114,7 +114,7 @@ public class EntityTypeRepositoryDecorator extends AbstractRepositoryDecorator<E
 	{
 		// add row to entities table
 		decoratedRepo.add(entityType);
-		if (!entityType.isAbstract() && !dataService.getMeta().isMetaEntityType(entityType))
+		if (!entityType.isAbstract() && !MetaDataService.isMetaEntityType(entityType))
 		{
 			RepositoryCollection repoCollection = dataService.getMeta().getBackend(entityType);
 			if (repoCollection == null)

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataService.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataService.java
@@ -12,6 +12,11 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.molgenis.data.meta.model.AttributeMetadata.ATTRIBUTE_META_DATA;
+import static org.molgenis.data.meta.model.EntityTypeMetadata.ENTITY_TYPE_META_DATA;
+import static org.molgenis.data.meta.model.PackageMetadata.PACKAGE;
+import static org.molgenis.data.meta.model.TagMetadata.TAG;
+
 public interface MetaDataService extends Iterable<RepositoryCollection>
 {
 	/**
@@ -257,10 +262,21 @@ public interface MetaDataService extends Iterable<RepositoryCollection>
 	 * Returns whether the given {@link EntityType} defines a meta entity such as {@link EntityTypeMetadata} or
 	 * {@link Attribute}.
 	 *
-	 * @param entityTypeData
-	 * @return
+	 * @param entityType the EntityType that is checked
 	 */
-	boolean isMetaEntityType(EntityType entityTypeData);
+	static boolean isMetaEntityType(EntityType entityType)
+	{
+		switch (entityType.getId())
+		{
+			case ENTITY_TYPE_META_DATA:
+			case ATTRIBUTE_META_DATA:
+			case TAG:
+			case PACKAGE:
+				return true;
+			default:
+				return false;
+		}
+	}
 
 	/**
 	 * Returns whether the given {@link EntityType} attributes are compatible with

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataServiceImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataServiceImpl.java
@@ -582,21 +582,6 @@ public class MetaDataServiceImpl implements MetaDataService
 	}
 
 	@Override
-	public boolean isMetaEntityType(EntityType entityType)
-	{
-		switch (entityType.getId())
-		{
-			case ENTITY_TYPE_META_DATA:
-			case ATTRIBUTE_META_DATA:
-			case TAG:
-			case PACKAGE:
-				return true;
-			default:
-				return false;
-		}
-	}
-
-	@Override
 	public Stream<EntityType> getConcreteChildren(EntityType entityType)
 	{
 		if (!entityType.isAbstract())

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataServiceImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataServiceImpl.java
@@ -7,6 +7,7 @@ import org.molgenis.data.meta.model.*;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.meta.persist.PackagePersister;
 import org.molgenis.data.meta.system.SystemEntityTypeRegistry;
+import org.molgenis.data.support.QueryImpl;
 import org.molgenis.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -477,8 +478,18 @@ public class MetaDataServiceImpl implements MetaDataService
 	public Stream<EntityType> getEntityTypes()
 	{
 		List<EntityType> entityTypeList = newArrayList();
-		dataService.getRepository(ENTITY_TYPE_META_DATA, EntityType.class)
-				   .forEachBatched(getEntityTypeFetch(), entityTypeList::addAll, 1000);
+		Fetch entityTypeFetch = getEntityTypeFetch();
+
+		final int pageSize = 1000;
+		for (int page = 0; entityTypeList.size() == page * pageSize; page++)
+		{
+			QueryImpl<EntityType> query = new QueryImpl<>();
+			query.setFetch(entityTypeFetch);
+			query.setPageSize(pageSize);
+			query.setOffset(page * pageSize);
+			dataService.findAll(ENTITY_TYPE_META_DATA, query, EntityType.class).forEach(entityTypeList::add);
+		}
+
 		return entityTypeList.stream();
 	}
 

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/system/SystemEntityTypeInitializer.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/system/SystemEntityTypeInitializer.java
@@ -83,7 +83,7 @@ public class SystemEntityTypeInitializer
 	{
 		if (systemEntityType.getPackage() == null)
 		{
-			if (metaDataService.isMetaEntityType(systemEntityType))
+			if (MetaDataService.isMetaEntityType(systemEntityType))
 			{
 				systemEntityType.setPackage(metaPackage);
 			}

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/system/SystemEntityTypePersister.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/system/SystemEntityTypePersister.java
@@ -67,13 +67,11 @@ public class SystemEntityTypePersister
 
 	private void persistMetadataMetadata()
 	{
-		MetaDataService metadataService = dataService.getMeta();
-
 		RepositoryCollection metadataRepoCollection = dataService.getMeta().getDefaultBackend();
 
 		// collect meta entity meta
 		List<EntityType> metaEntityTypeList = systemEntityTypeRegistry.getSystemEntityTypes()
-																	  .filter(metadataService::isMetaEntityType)
+																	  .filter(MetaDataService::isMetaEntityType)
 																	  .collect(toList());
 		List<EntityType> resolvedEntityTypeList = entityTypeDependencyResolver.resolve(metaEntityTypeList);
 

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/MetaDataServiceImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/MetaDataServiceImplTest.java
@@ -1064,7 +1064,7 @@ public class MetaDataServiceImplTest
 	public void isMetaEntityType(String entityTypeId, boolean isMeta)
 	{
 		EntityType entityType = when(mock(EntityType.class).getId()).thenReturn(entityTypeId).getMock();
-		assertEquals(metaDataServiceImpl.isMetaEntityType(entityType), isMeta);
+		assertEquals(MetaDataService.isMetaEntityType(entityType), isMeta);
 	}
 
 	@Test


### PR DESCRIPTION
The fix is two-fold: 
* Make sure metadata tables are always cached
* Make sure MetaDataService.getEntityTypes retrieves the data in a cacheable way

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
