### PR TITLE
Fix #6286: Job's view page refreshing interferes with ability to use the system

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/jobs/JobsController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/jobs/JobsController.java
@@ -79,7 +79,7 @@ public class JobsController extends MolgenisPluginController
 	{
 		final List<Entity> jobs = new ArrayList<>();
 
-		Instant weekAgo = Instant.now().minus(7, ChronoUnit.DAYS);
+		Instant weekAgo = Instant.now().minus(7, ChronoUnit.DAYS).truncatedTo(ChronoUnit.DAYS);
 		User currentUser = userAccountService.getCurrentUser();
 
 		dataService.getMeta()

--- a/molgenis-core-ui/src/main/javascript/modules/react-components/jobs/JobsContainer.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/jobs/JobsContainer.js
@@ -35,7 +35,7 @@ var JobsContainer = React.createClass({
     },
     componentDidMount: function () {
         this.retrieveJobs();
-        this.setInterval(this.retrieveJobs, this.props.interval || 1000);
+        this.setInterval(this.retrieveJobs, this.props.interval || 10000);
         this._notificationSystem = this.refs.notificationSystem;
     },
     render: function () {


### PR DESCRIPTION
Depends on #6372, merge that first!

This fix is also two-fold:
* Don't update the week-ago threshold every millisecond, so that results can be cached
* Retrieve job information once every 10 seconds, should be quick enough and prevents spamming the server to death

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
