### PR TITLE
Fix #6325 "Unknown table name" when deleting EntityType with references to it

### DIFF
--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlNameGenerator.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlNameGenerator.java
@@ -46,6 +46,11 @@ public class PostgreSqlNameGenerator
 		return quotedIdentifier ? getQuotedIdentifier(identifier) : identifier;
 	}
 
+	static String getJunctionTableName(EntityType entityType, Attribute attr)
+	{
+		return getJunctionTableName(entityType, attr, true);
+	}
+
 	/**
 	 * Returns the junction table name for the given attribute of the given entity
 	 *
@@ -53,12 +58,12 @@ public class PostgreSqlNameGenerator
 	 * @param attr       attribute
 	 * @return PostgreSQL junction table name
 	 */
-	static String getJunctionTableName(EntityType entityType, Attribute attr)
+	public static String getJunctionTableName(EntityType entityType, Attribute attr, boolean quotedIdentifier)
 	{
 		int nrAdditionalChars = 1;
 		String entityPart = generateId(entityType, (MAX_IDENTIFIER_BYTE_LENGTH - nrAdditionalChars) / 2);
 		String attrPart = generateId(attr, (MAX_IDENTIFIER_BYTE_LENGTH - nrAdditionalChars) / 2);
-		return getQuotedIdentifier(entityPart + '_' + attrPart);
+		return quotedIdentifier ? getQuotedIdentifier(entityPart + '_' + attrPart) : entityPart + '_' + attrPart;
 	}
 
 	/**

--- a/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/PostgreSqlNameGeneratorTest.java
+++ b/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/PostgreSqlNameGeneratorTest.java
@@ -54,25 +54,30 @@ public class PostgreSqlNameGeneratorTest
 	@DataProvider(name = "getJunctionTableNameProvider")
 	public static Iterator<Object[]> getJunctionTableNameProvider()
 	{
-		return newArrayList(new Object[] { "entity", "attr", "\"entity#6844280e_attr\"" },
-				new Object[] { "this$is-a_Very_very_very_very_very_very_very_long_s1mpl3_nam3", "attr",
+		return newArrayList(new Object[] { "entity", "attr", true, "\"entity#6844280e_attr\"" },
+				new Object[] { "this$is-a_Very_very_very_very_very_very_very_long_s1mpl3_nam3", "attr", true,
 						"\"thisisa_Very_very_very#d9b1efe8_attr\"" },
-				new Object[] { "entity", "this$is-a_Very_very_very_very_very_very_very_long_attr_nam3",
+				new Object[] { "entity", "this$is-a_Very_very_very_very_very_very_very_long_attr_nam3", true,
 						"\"entity#6844280e_thisisa_Very_very_very#69363cb7\"" },
 				new Object[] { "this$is-a_Very_very_very_very_very_very_very_long_s1mpl3_nam3",
-						"this$is-a_Very_very_very_very_very_very_very_long_attr_nam3",
-						"\"thisisa_Very_very_very#d9b1efe8_thisisa_Very_very_very#69363cb7\"" }).iterator();
+						"this$is-a_Very_very_very_very_very_very_very_long_attr_nam3", true,
+						"\"thisisa_Very_very_very#d9b1efe8_thisisa_Very_very_very#69363cb7\"" },
+				new Object[] { "this$is-a_Very_very_very_very_very_very_very_long_s1mpl3_nam3",
+						"this$is-a_Very_very_very_very_very_very_very_long_attr_nam3", false,
+						"thisisa_Very_very_very#d9b1efe8_thisisa_Very_very_very#69363cb7" }).iterator();
 	}
 
 	@Test(dataProvider = "getJunctionTableNameProvider")
-	public void testGetJunctionTableName(String entityTypeId, String attrName, String expectedJunctionTableName)
+	public void testGetJunctionTableName(String entityTypeId, String attrName, boolean quotedIdentifiers,
+			String expectedJunctionTableName)
 	{
 		EntityType entityType = mock(EntityType.class);
 		when(entityType.getId()).thenReturn(entityTypeId);
 		Attribute attr = mock(Attribute.class);
 		when(attr.getIdentifier()).thenReturn("9876543210-9876543210-9876543210");
 		when(attr.getName()).thenReturn(attrName);
-		assertEquals(PostgreSqlNameGenerator.getJunctionTableName(entityType, attr), expectedJunctionTableName);
+		assertEquals(PostgreSqlNameGenerator.getJunctionTableName(entityType, attr, quotedIdentifiers),
+				expectedJunctionTableName);
 	}
 
 	@DataProvider(name = "getJunctionTableIndexNameProvider")

--- a/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/identifier/EntityTypeRegistryImplTest.java
+++ b/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/identifier/EntityTypeRegistryImplTest.java
@@ -1,19 +1,22 @@
 package org.molgenis.data.postgresql.identifier;
 
 import com.google.common.collect.ImmutableMap;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.transaction.TransactionManager;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.transaction.TransactionManager.TRANSACTION_ID_RESOURCE_NAME;
 import static org.springframework.transaction.support.TransactionSynchronizationManager.bindResource;
 import static org.springframework.transaction.support.TransactionSynchronizationManager.unbindResource;
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.*;
 
 public class EntityTypeRegistryImplTest
 {
@@ -47,15 +50,46 @@ public class EntityTypeRegistryImplTest
 	}
 
 	@Test
-	public void testGetEntityTypeDescriptionJunctionTable() throws Exception
+	public void testUnregisterEntityType()
 	{
-		String entityTypeId = "entityTypeId";
-		EntityType entityType = mock(EntityType.class);
-		when(entityType.getAllAttributes()).thenReturn(emptyList());
-		when(entityType.getId()).thenReturn(entityTypeId);
+		EntityType entityType = prepareMockEntityTypeForRegistering();
+
 		entityTypeRegistryImpl.registerEntityType(entityType);
-		String tableName = "entityTypeId#c34894ba_mrefattr";
-		assertEquals(entityTypeRegistryImpl.getEntityTypeDescription(tableName),
-				EntityTypeDescription.create(entityTypeId, ImmutableMap.of()));
+
+		assertNotNull(entityTypeRegistryImpl.getEntityTypeDescription("org_molgenis_test_many_packages_deep#2409e1c6"));
+		assertNotNull(entityTypeRegistryImpl.getEntityTypeDescription(
+				"org_molgenis_test_many#2409e1c6_xref_attribute_with_a_long_name"));
+		assertNotNull(entityTypeRegistryImpl.getEntityTypeDescription("org_molgenis_test_many#2409e1c6_mref"));
+		assertNull(entityTypeRegistryImpl.getEntityTypeDescription("org_molgenis_test_many#2409e1c6_stringAttribute"));
+
+		entityTypeRegistryImpl.unregisterEntityType(entityType);
+
+		assertNull(entityTypeRegistryImpl.getEntityTypeDescription("org_molgenis_test_many_packages_deep#2409e1c6"));
+		assertNull(entityTypeRegistryImpl.getEntityTypeDescription(
+				"org_molgenis_test_many#2409e1c6_xref_attribute_with_a_long_name"));
+		assertNull(entityTypeRegistryImpl.getEntityTypeDescription("org_molgenis_test_many#2409e1c6_mref"));
+	}
+
+	private EntityType prepareMockEntityTypeForRegistering()
+	{
+		Attribute stringAttr = mock(Attribute.class);
+		when(stringAttr.getDataType()).thenReturn(AttributeType.STRING);
+		when(stringAttr.getName()).thenReturn("stringAttribute");
+
+		Attribute xrefAttr = mock(Attribute.class);
+		when(xrefAttr.getDataType()).thenReturn(AttributeType.XREF);
+		when(xrefAttr.getName()).thenReturn("xref_attribute_with_a_long_name");
+		when(xrefAttr.getIdentifier()).thenReturn("0");
+
+		Attribute mrefAttr = mock(Attribute.class);
+		when(mrefAttr.getDataType()).thenReturn(AttributeType.MREF);
+		when(mrefAttr.getName()).thenReturn("mref");
+		when(xrefAttr.getIdentifier()).thenReturn("1");
+
+		EntityType entityType = mock(EntityType.class);
+		when(entityType.getId()).thenReturn("org_molgenis_test_many_packages_deep");
+		when(entityType.getAllAttributes()).thenReturn(asList(stringAttr, xrefAttr, mrefAttr));
+
+		return entityType;
 	}
 }


### PR DESCRIPTION
Stores junction table names in the EntityTypeRegistry as well, so that the corresponding EntityType can be looked up even when the generated id is long and truncated. 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
