### PR TITLE
Use created and location header

### DIFF
--- a/molgenis-one-click-importer/pom.xml
+++ b/molgenis-one-click-importer/pom.xml
@@ -87,6 +87,12 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-data</artifactId>
             <version>${project.version}</version>
@@ -94,6 +100,11 @@
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-core-ui</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.molgenis</groupId>
+            <artifactId>molgenis-data-rest</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -117,6 +128,10 @@
                     <artifactId>stax-api</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
         </dependency>
     </dependencies>
 

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/controller/OneClickImporterController.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/controller/OneClickImporterController.java
@@ -2,6 +2,7 @@ package org.molgenis.oneclickimporter.controller;
 
 import org.apache.poi.openxml4j.exceptions.InvalidFormatException;
 import org.apache.poi.ss.usermodel.Sheet;
+import org.molgenis.data.MolgenisDataException;
 import org.molgenis.data.i18n.LanguageService;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.settings.AppSettings;
@@ -18,7 +19,9 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.File;
 import java.io.IOException;
 
@@ -70,7 +73,7 @@ public class OneClickImporterController extends MolgenisPluginController
 
 	@ResponseBody
 	@RequestMapping(value = "/upload", method = POST)
-	public String importFile(@RequestParam(value = "file") MultipartFile multipartFile)
+	public void importFile(HttpServletResponse response, @RequestParam(value = "file") MultipartFile multipartFile)
 			throws UnknownFileTypeException, IOException, InvalidFormatException
 	{
 		String filename = multipartFile.getOriginalFilename();
@@ -88,16 +91,20 @@ public class OneClickImporterController extends MolgenisPluginController
 		else
 		{
 			throw new UnknownFileTypeException(
-						"File with extention: " + fileExtension + " is not a valid one-click importer file");
+					String.format("File with extension: %s is not a valid one-click importer file", fileExtension));
 		}
 
 		EntityType dataTable = entityService.createEntity(dataCollection);
-		return dataTable.getId();
+
+		ServletUriComponentsBuilder builder = ServletUriComponentsBuilder.fromCurrentRequestUri();
+		response.setStatus(HttpServletResponse.SC_CREATED);
+		response.setHeader("Location", builder.build().toUriString() + dataTable.getId());
 	}
 
 	@ResponseBody
 	@ResponseStatus(BAD_REQUEST)
-	@ExceptionHandler({ UnknownFileTypeException.class, IOException.class, InvalidFormatException.class })
+	@ExceptionHandler({ UnknownFileTypeException.class, IOException.class, InvalidFormatException.class,
+			MolgenisDataException.class })
 	public ErrorMessageResponse handleUnknownEntityException(Exception e)
 	{
 		return new ErrorMessageResponse(singletonList(new ErrorMessageResponse.ErrorMessage(e.getMessage())));

--- a/molgenis-one-click-importer/src/test/java/org.molgenis.oneclickimporter/controller/OneClickImporterControllerTest.java
+++ b/molgenis-one-click-importer/src/test/java/org.molgenis.oneclickimporter/controller/OneClickImporterControllerTest.java
@@ -3,6 +3,7 @@ package org.molgenis.oneclickimporter.controller;
 import com.google.common.io.Resources;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.molgenis.data.i18n.LanguageService;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.settings.AppSettings;
@@ -29,8 +30,12 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 
+import static org.hamcrest.core.StringEndsWith.endsWith;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.fileUpload;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -110,8 +115,8 @@ public class OneClickImporterControllerTest
 		when(table.getId()).thenReturn(tableId);
 
 		mockMvc.perform(fileUpload(OneClickImporterController.URI + "/upload").file(multipartFile))
-				.andExpect(status().isOk())
-				.andExpect(content().string(tableId));
+				.andExpect(status().isCreated())
+				.andExpect(header().string("Location", endsWith(tableId)));
 
 		verify(oneClickImporterService).buildDataCollection("simple-valid", sheet);
 	}
@@ -133,11 +138,12 @@ public class OneClickImporterControllerTest
 		when(entityService.createEntity(dataCollection)).thenReturn(table);
 		when(table.getId()).thenReturn(tableId);
 
-		mockMvc.perform(fileUpload(OneClickImporterController.URI + "/upload").file(multipartFile))
-				.andExpect(status().isOk())
-				.andExpect(content().string(tableId));
 
-		verify(oneClickImporterService, times(1)).buildDataCollection("simple-valid", sheet);
+		mockMvc.perform(fileUpload(OneClickImporterController.URI + "/upload").file(multipartFile))
+				.andExpect(status().isCreated())
+				.andExpect(header().string("Location", endsWith(tableId)));
+
+		verify(oneClickImporterService, Mockito.times(1)).buildDataCollection("simple-valid", sheet);
 
 	}
 
@@ -152,7 +158,7 @@ public class OneClickImporterControllerTest
 		mockMvc.perform(fileUpload(OneClickImporterController.URI + "/upload").file(multipartFile))
 			   .andExpect(status().isBadRequest());
 
-		verifyZeroInteractions(oneClickImporterService);
+		Mockito.verifyZeroInteractions(oneClickImporterService);
 	}
 
 	private MockMultipartFile getTestMultipartFile(final String path, final String contentType)

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/OneClickImporterServiceTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/OneClickImporterServiceTest.java
@@ -110,6 +110,9 @@ public class OneClickImporterServiceTest
 
 		columnValues = Arrays.asList(1L, 2L, 3L);
 		assertEquals(AttributeType.LONG, oneClickImporterService.guessAttributeType(columnValues));
+
+		columnValues = Arrays.asList(1L, "abc", 3L);
+		assertEquals(AttributeType.STRING, oneClickImporterService.guessAttributeType(columnValues));
 	}
 
 	private Sheet loadTestFile(String fileName) throws IOException, InvalidFormatException, URISyntaxException


### PR DESCRIPTION
Set status code to created and set location header on dataTable import success

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
