### PR TITLE
Upgrade Elasticsearch 5.4.1 to 5.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <jsr305.version>3.0.1</jsr305.version>
         <findbugs.annotations.version>3.0.1</findbugs.annotations.version>
         <sonatype.id>sonatype-nexus-staging</sonatype.id>
-        <elasticsearch.version>5.4.1</elasticsearch.version>
+        <elasticsearch.version>5.5.1</elasticsearch.version>
         <postgres.version>9.4.1211</postgres.version>
         <mockito.version>2.7.22</mockito.version>
     </properties>


### PR DESCRIPTION
Reason for the update is that our VMs that are running a standalone Elasticsearch automatically updated to 5.5.1.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
