### PR TITLE
Fix #6576: Default opencpu port number is 80, which conflicts with http protocol

### DIFF
--- a/molgenis-r/src/main/java/org/molgenis/r/OpenCpuSettingsImpl.java
+++ b/molgenis-r/src/main/java/org/molgenis/r/OpenCpuSettingsImpl.java
@@ -28,7 +28,7 @@ public class OpenCpuSettingsImpl extends DefaultSettingsEntity implements OpenCp
 		private String defaultScheme;
 		@Value("${opencpu.uri.host:localhost}")
 		private String defaultHost;
-		@Value("${opencpu.uri.port:80}")
+		@Value("${opencpu.uri.port:8004}")
 		private String defaultPort;
 		@Value("${opencpu.uri.path:/ocpu/}")
 		private String defaultRootPath;
@@ -62,7 +62,7 @@ public class OpenCpuSettingsImpl extends DefaultSettingsEntity implements OpenCp
 							  .setDefaultValue(defaultPort)
 							  .setNillable(false)
 							  .setLabel("URI port")
-							  .setDescription("Open CPU URI port (e.g. 80).");
+							  .setDescription("Open CPU URI port (e.g. 8004).");
 			addAttribute(ROOT_PATH).setDataType(STRING)
 								   .setDefaultValue(defaultRootPath)
 								   .setNillable(false)


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
