### PR TITLE
Styling; remove double container padding.

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/src/App.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/App.vue
@@ -6,14 +6,6 @@
 
 <style>
 
-  .temp-header {
-    background-color: #000000;
-  }
-
-  .temp-header a {
-    color: #ffffff;
-  }
-
   .app-container {
     padding-top: 40px
   }

--- a/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
+++ b/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
@@ -1,6 +1,6 @@
 // @flow
 <template>
-  <div class="container">
+  <div>
 
     <div v-if="error != undefined" class="alert alert-danger" role="alert">
       <button @click="error=null" type="button" class="close"><span aria-hidden="true">&times;</span></button>

--- a/molgenis-one-click-importer/src/main/frontend/src/App.vue
+++ b/molgenis-one-click-importer/src/main/frontend/src/App.vue
@@ -4,17 +4,6 @@
       </div>
 </template>
 
-<style>
-  .temp-header {
-    background-color: #000000;
-    margin-bottom: 20px;
-  }
-
-  .temp-header  a {
-      color: #ffffff;
-  }
-</style>
-
 <script>
   import OneClickImporter from './components/OneClickImporter'
   export default {


### PR DESCRIPTION
Remove container class from component, this should no longer be use on the plugin template as each plugin is wrapped using the molgenis-header that already puts the plugin into a container.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Clean commits
