### PR TITLE
Use max-height instead of height to stop blowing up smaller images

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/menu/app.js
+++ b/molgenis-core-ui/src/main/resources/js/menu/app.js
@@ -97,7 +97,7 @@ webpackJsonp([1], {
         }, [n('span', {staticClass: 'navbar-toggler-icon'})]), e._v(' '), e.navBarLogo ? n('a', {
           staticClass: 'navbar-brand',
           attrs: {href: '/menu/main/' + e.menu.items[0].href}
-        }, [n('img', {attrs: {src: e.navBarLogo, height: '30'}})]) : n('a', {
+        }, [n('img', {attrs: {src: e.navBarLogo, style:"max-height: 30px"}})]) : n('a', {
           staticClass: 'navbar-brand',
           attrs: {href: '#'}
         }), e._v(' '), n('div', {


### PR DESCRIPTION
When using the default molgenis logo ( 24px height) the image is blown up ( this does not look nice), this can be fixed by using max-height instead of height. this way images smaller then 30 px( this was set as height) will not be blown up.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
