### PR TITLE
Fix #6571 If 2fa is not enabled I get an empty security tab

### DIFF
--- a/molgenis-security/src/main/resources/templates/view-useraccount.ftl
+++ b/molgenis-security/src/main/resources/templates/view-useraccount.ftl
@@ -3,6 +3,7 @@
 
 <@header/>
 <div class="container">
+<#if two_factor_authentication_app_option != "DISABLED">
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
             <ul class="nav nav-tabs" role="tablist">
@@ -15,6 +16,7 @@
             </ul>
         </div>
     </div>
+</#if>
 
     <div class="tab-content">
         <div role="tabpanel" class="tab-pane active" id="account">


### PR DESCRIPTION
... in the account plugin

Hides all the tabs if 2fa is disabled.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
