### PR TITLE
Workaround for issue #6647 Remove 'show navigator link' setting 

### DIFF
--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/settings/DataExplorerSettings.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/settings/DataExplorerSettings.java
@@ -36,13 +36,11 @@ public class DataExplorerSettings extends DefaultSettingsEntity
 		public static final String GENERAL_ITEM_SELECT_PANEL = "item_select_panel";
 		public static final String GENERAL_LAUNCH_WIZARD = "launch_wizard";
 		public static final String GENERAL_HEADER_ABBREVIATE = "header_abbreviate";
-		public static final String GENERAL_SHOW_NAVIGATOR_LINK = "show_navigator_link";
 
 		private static final boolean DEFAULT_GENERAL_SEARCHBOX = true;
 		private static final boolean DEFAULT_GENERAL_ITEM_SELECT_PANEL = true;
 		private static final boolean DEFAULT_GENERAL_LAUNCH_WIZARD = false;
 		private static final int DEFAULT_GENERAL_HEADER_ABBREVIATE = 180;
-		private static final boolean DEFAULT_GENERAL_SHOW_NAVIGATOR_LINK = false;
 
 		public static final String MOD = "mods";
 		public static final String MOD_AGGREGATES = "mod_aggregates";
@@ -130,11 +128,6 @@ public class DataExplorerSettings extends DefaultSettingsEntity
 												   .setNillable(false)
 												   .setDefaultValue(String.valueOf(DEFAULT_GENERAL_HEADER_ABBREVIATE))
 												   .setLabel("Entity description abbreviation length");
-			addAttribute(GENERAL_SHOW_NAVIGATOR_LINK).setParent(generalAttr)
-												.setDataType(BOOL)
-												.setNillable(false) // Set to true because of lack of migration system.
-												.setDefaultValue(String.valueOf(DEFAULT_GENERAL_SHOW_NAVIGATOR_LINK))
-												.setLabel("Show link to navigator plugin");
 		}
 
 		private void addModulesSettings()
@@ -412,17 +405,6 @@ public class DataExplorerSettings extends DefaultSettingsEntity
 	public void setHeaderAbbreviate(int headerAbbreviate)
 	{
 		set(Meta.GENERAL_HEADER_ABBREVIATE, headerAbbreviate);
-	}
-
-	public boolean getShowNavigatorLink()
-	{
-		Boolean value = getBoolean(Meta.GENERAL_SHOW_NAVIGATOR_LINK);
-		return value != null ? value : false;
-	}
-
-	public void setShowNavigatorLink(boolean showNavigatorLink)
-	{
-		set(Meta.GENERAL_SHOW_NAVIGATOR_LINK, showNavigatorLink);
 	}
 
 	@Nullable

--- a/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer.ftl
+++ b/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer.ftl
@@ -87,7 +87,7 @@
                     </div>
                 </div>
             </div>
-            <#if navigatorBaseUrl?? && plugin_settings.show_navigator_link?? && plugin_settings.get("show_navigator_link") == true>
+            <#if navigatorBaseUrl??>
                 <div class="row">
                     <div class="col-md-12">
                         <div class="panel panel-primary">


### PR DESCRIPTION
Remove 'show navigator link' setting from DataExploreSettings and update the template to show the link by default.

https://docs.google.com/spreadsheets/d/17KTnwRdwwtTUBuqzUSXUSPFH1IfQB8YovbFptGrRkBU/edit#gid=0&range=44:44

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
