### PR TITLE
FIx/6465 Clean up flow config.

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/.flowconfig
+++ b/molgenis-metadata-manager/src/main/frontend/.flowconfig
@@ -1,11 +1,7 @@
 [ignore]
-.*/node_modules/config-chain/test/broken.json
-.*/node_modules/vue/.*
-.*/node_modules/vue-router/.*
-*.vue
+.*/node_modules/**/.*
 
 [include]
-./src/.*
 
 [libs]
 

--- a/molgenis-metadata-manager/src/main/frontend/package.json
+++ b/molgenis-metadata-manager/src/main/frontend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --ext .js,.vue src test/unit/specs"
   },
   "dependencies": {
-    "@molgenis/molgenis-api-client": "^1.2.5",
+    "@molgenis/molgenis-api-client": "^2.0.2",
     "@molgenis/molgenis-i18n-js": "^0.0.5",
     "@molgenis/molgenis-vue-test-utils": "^1.0.0",
     "flow": "^0.2.3",

--- a/molgenis-metadata-manager/src/main/frontend/src/store/actions.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/actions.js
@@ -1,4 +1,5 @@
 // @flow
+// $FlowFixMe
 import api from '@molgenis/molgenis-api-client'
 
 import {

--- a/molgenis-metadata-manager/src/main/frontend/yarn.lock
+++ b/molgenis-metadata-manager/src/main/frontend/yarn.lock
@@ -2,11 +2,12 @@
 # yarn lockfile v1
 
 
-"@molgenis/molgenis-api-client@^1.2.5":
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-1.2.5.tgz#d6972b710eca9b09eac191c2ac1612ff35cec40f"
+"@molgenis/molgenis-api-client@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.0.2.tgz#78e898f9abae24863b0995d79226827e2741ae75"
   dependencies:
     babel-runtime "^6.11.6"
+    form-data "^2.3.1"
     isomorphic-fetch "^2.2.1"
     lodash "^4.17.4"
 
@@ -2515,6 +2516,14 @@ foreach@^2.0.5:
 forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
+
+form-data@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.1.tgz#6fb94fbd71885306d73d15cc497fe4cc4ecd44bf"
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.5"
+    mime-types "^2.1.12"
 
 form-data@~2.1.1:
   version "2.1.4"

--- a/molgenis-navigator/src/main/frontend/.flowconfig
+++ b/molgenis-navigator/src/main/frontend/.flowconfig
@@ -2,9 +2,7 @@
 .*/node_modules/**/.*
 
 [include]
-./src/.*
 
 [libs]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/molgenis-one-click-importer/src/main/frontend/.flowconfig
+++ b/molgenis-one-click-importer/src/main/frontend/.flowconfig
@@ -1,12 +1,7 @@
 [ignore]
-.*/node_modules/config-chain/test/broken.json
-.*/node_modules/vue/.*
-.*/node_modules/vue-router/.*
-*.vue
-.*/node_modules/@molgenis/**/.*
+.*/node_modules/**/.*
 
 [include]
-./src/.*
 
 [libs]
 

--- a/molgenis-searchall/src/main/frontend/.flowconfig
+++ b/molgenis-searchall/src/main/frontend/.flowconfig
@@ -2,9 +2,7 @@
 .*/node_modules/**/.*
 
 [include]
-./src/.*
 
 [libs]
 
 [options]
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe


### PR DESCRIPTION
Do not scan node_module folders
Bump molgenis-api version (non flow version) for Meta-data-editor plugin
Remove unneeded flow config ( default behaviour)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
