### PR TITLE
Fix #6691 File filter does not display add-on OR button on multiselect

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/jquery.molgenis.xrefmrefsearch.js
+++ b/molgenis-core-ui/src/main/resources/js/jquery.molgenis.xrefmrefsearch.js
@@ -296,7 +296,7 @@
                 $container.addClass("select2-bootstrap-prepend");
                 $container.prepend($dropdown);
             }
-            else if (attribute.fieldType === 'XREF') {
+            else if (attribute.fieldType === 'FILE' || attribute.fieldType === 'XREF') {
                 $operatorInput.val('OR');
                 $container.append($('<div class="input-group-addon dropdown-toggle-container"><button class="btn btn-default" type="button" disabled>OR</button></div>'));
                 $container.append($operatorInput);


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested (N.A.)
- [x] User documentation updated (N.A.)
- [x] (If you have changed REST API interface) view-swagger.ftl updated (N.A.)
- [x] Test plan template updated (N.A.)
- [x] Clean commits
