### PR TITLE
Fix #6677 When adding a header logo above the menu bar parts of plugins are not clickable

### DIFF
--- a/molgenis-core-ui/src/main/resources/css/molgenis.css
+++ b/molgenis-core-ui/src/main/resources/css/molgenis.css
@@ -22,7 +22,7 @@
 }
 
 body>.container-fluid {
-	padding-top: 55px !important;
+	padding-top: 55px;
 	margin-bottom: 3em;
 }
 

--- a/molgenis-core-ui/src/main/resources/js/menu/app.js
+++ b/molgenis-core-ui/src/main/resources/js/menu/app.js
@@ -77,14 +77,14 @@ webpackJsonp([1], {
     e.exports = {
       render: function () {
         var e = this, t = e.$createElement, n = e._self._c || t
-        return n('div', {staticClass: 'fixed-top'}, [e.topLogo ? [n('div', {attrs: {id: 'TopLogo'}}, [n('a', {attrs: {href: '/'}}, [n('img', {
+        return n('div', {staticClass: 'fixed-top'}, [e.topLogo ? [n('div', {attrs: {id: 'Intro'}}, [n('a', {attrs: {href: '/'}}, [n('img', {
           attrs: {
             src: e.topLogo,
             alt: '',
             border: '0',
             height: '150'
           }
-        })])])] : e._e(), e._v(' '), n('nav', {staticClass: 'navbar navbar-toggleable-md navbar-light bg-faded'}, [n('button', {
+        })])])] : e._e(), e._v(' '), n('nav', {staticClass: 'navbar navbar-toggleable-md navbar-light bg-faded navbar-fixed-top'}, [n('button', {
           staticClass: 'navbar-toggler navbar-toggler-right',
           attrs: {
             type: 'button',


### PR DESCRIPTION
Content of the webpage was below the image in the bootstrap4 menu. You could see this when scrolling. This was introduced when this new menu was created. The toplogo got a different id in the bootstrap4 menu than we were used to in the bootstrap3 menu. This caused the css styling of the top logo not to be reached while the css was put in the header. 

Then we still had the problem with the navbar disapearing. 
It was fixed-top so I looked at the classes in the menu of the bootstrap3 menu and I found there: navbar-fixed-top, but still the styling was not correct and I found out part of the problem was introduced here: https://github.com/molgenis/molgenis/pull/6658
I fixed that by removing the !important in the body>.container-fluid. I retested the fixed issue in the PR and I cannot reproduce it, but maybe something for the reviewer to recheck. 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Clean commits
