### PR TITLE
Fix #6695 Search All breaks when there are Entity Types not in a package

### DIFF
--- a/molgenis-navigator/src/main/frontend/src/store/actions.js
+++ b/molgenis-navigator/src/main/frontend/src/store/actions.js
@@ -3,7 +3,7 @@ import type { Package, Entity } from '../flow.types'
 import { INITIAL_STATE } from './state'
 // $FlowFixMe
 import api from '@molgenis/molgenis-api-client'
-import { RESET_PATH, SET_ENTITIES, SET_ERROR, SET_PACKAGES, SET_PATH } from './mutations'
+import { RESET_PATH, SET_ENTITIES, SET_ERROR, SET_PACKAGES, SET_PATH, SET_QUERY } from './mutations'
 
 export const QUERY_PACKAGES = '__QUERY_PACKAGES__'
 export const QUERY_ENTITIES = '__QUERY_ENTITIES__'
@@ -181,7 +181,15 @@ export default {
       // At the moment each entity is stored in either a single package, or no package at all
       if (response.items.length > 0) {
         const entityType = response.items[0]
-        dispatch(GET_STATE_FOR_PACKAGE, entityType['package'].id)
+        const _package = entityType['package']
+        if (_package) {
+          dispatch(GET_STATE_FOR_PACKAGE, _package.id)
+        } else {
+          // In case entity is not in package fallback to searching for entity name.
+          const entityLabel = entityType.label
+          commit(SET_QUERY, entityLabel)
+          dispatch(QUERY_ENTITIES, entityLabel)
+        }
       } else {
         dispatch(RESET_STATE)
       }

--- a/molgenis-navigator/src/main/frontend/test/unit/specs/store/actions.spec.js
+++ b/molgenis-navigator/src/main/frontend/test/unit/specs/store/actions.spec.js
@@ -1,7 +1,7 @@
 import api from '@molgenis/molgenis-api-client'
 import td from 'testdouble'
-import actions, { GET_ENTITIES_IN_PACKAGE, GET_STATE_FOR_PACKAGE, RESET_STATE } from 'src/store/actions'
-import { RESET_PATH, SET_ENTITIES, SET_ERROR, SET_PACKAGES, SET_PATH } from 'src/store/mutations'
+import actions, { GET_ENTITIES_IN_PACKAGE, GET_STATE_FOR_PACKAGE, RESET_STATE, QUERY_ENTITIES } from 'src/store/actions'
+import { RESET_PATH, SET_ENTITIES, SET_ERROR, SET_PACKAGES, SET_PATH, SET_QUERY } from 'src/store/mutations'
 import utils from '@molgenis/molgenis-vue-test-utils'
 
 describe('actions', () => {
@@ -473,6 +473,35 @@ describe('actions', () => {
         payload: entityId,
         expectedActions: [
           {type: RESET_STATE}
+        ]
+      }
+
+      utils.testAction(actions.__GET_ENTITY_PACKAGES__, options, done)
+    })
+
+    it('should fallback to searching if the lookup entity is not in a package', done => {
+      const entityId = 'my-entity-id'
+      const entity = {
+        'id': entityId,
+        'label': 'my entity in a package'
+      }
+
+      const response = {
+        items: [entity]
+      }
+
+      const get = td.function('api.get')
+
+      td.when(get('/api/v2/sys_md_EntityType?num=1000&&q=isAbstract==false;id==' + entityId)).thenResolve(response)
+      td.replace(api, 'get', get)
+
+      const options = {
+        payload: entityId,
+        expectedMutations: [
+          {type: SET_QUERY, payload: entity.label}
+        ],
+        expectedActions: [
+          {type: QUERY_ENTITIES, payload: entity.label}
         ]
       }
 

--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/model/EntityTypeResult.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/model/EntityTypeResult.java
@@ -4,6 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import org.molgenis.gson.AutoGson;
 
+import javax.annotation.Nullable;
 import java.util.List;
 
 @AutoValue
@@ -12,6 +13,7 @@ public abstract class EntityTypeResult implements Described
 {
 	public abstract String getId();
 
+	@Nullable
 	public abstract String getPackageId();
 
 	public abstract boolean isLabelMatch();

--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/service/SearchAllService.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/service/SearchAllService.java
@@ -35,37 +35,40 @@ public class SearchAllService
 		this.languageService = requireNonNull(languageService);
 	}
 
-	public Result searchAll(String searchterm)
+	public Result searchAll(final String searchTerm)
 	{
 		final String lang = languageService.getCurrentUserLanguageCode();
 		return Result.builder()
 					 .setEntityTypes(dataService.findAll(ENTITY_TYPE_META_DATA, EntityType.class)
 												.filter(not(EntityUtils::isSystemEntity))
-												.map(entityType -> toEntityTypeResult(searchterm, entityType, lang))
+												.map(entityType -> toEntityTypeResult(searchTerm, entityType, lang))
 												.filter(EntityTypeResult::isMatch)
 												.collect(toList()))
 					 .setPackages(dataService.findAll(PACKAGE, Package.class)
 											 .filter(not(EntityUtils::isSystemPackage))
 											 .map(PackageResult::create)
 											 .filter(packageResult -> packageResult.isLabelOrDescriptionMatch(
-													 searchterm))
+													 searchTerm))
 											 .collect(toList()))
 					 .build();
 	}
 
-	private EntityTypeResult toEntityTypeResult(String searchterm, EntityType entityType, String lang)
+	private EntityTypeResult toEntityTypeResult(final String searchTerm, final EntityType entityType, final String lang)
 	{
-		return EntityTypeResult.builder()
-							   .setId(entityType.getId())
-							   .setLabel(entityType.getLabel(lang))
-							   .setDescription(entityType.getDescription(lang))
-							   .setPackageId(entityType.getPackage().getId())
-							   .setLabelMatch(containsIgnoreCase(entityType.getLabel(lang), searchterm))
-							   .setDescriptionMatch(containsIgnoreCase(entityType.getDescription(lang), searchterm))
-							   .setAttributes(matchingAttributes(searchterm, entityType.getAllAttributes(), lang))
-							   .setNrOfMatchingEntities(
-									   dataService.count(entityType.getId(), new QueryImpl<>().search(searchterm)))
-							   .build();
+		EntityTypeResult.Builder builder = EntityTypeResult.builder().setId(entityType.getId())
+				.setLabel(entityType.getLabel(lang)).setDescription(entityType.getDescription(lang));
+
+		if (entityType.getPackage() != null)
+		{
+			builder.setPackageId(entityType.getPackage().getId());
+		}
+
+		builder.setLabelMatch(containsIgnoreCase(entityType.getLabel(lang), searchTerm))
+				.setDescriptionMatch(containsIgnoreCase(entityType.getDescription(lang), searchTerm))
+				.setAttributes(matchingAttributes(searchTerm, entityType.getAllAttributes(), lang))
+				.setNrOfMatchingEntities(dataService.count(entityType.getId(), new QueryImpl<>().search(searchTerm)));
+
+		return builder.build();
 	}
 
 	private List<AttributeResult> matchingAttributes(String searchterm, Iterable<Attribute> allAttributes, String lang)

--- a/molgenis-searchall/src/test/java/org/molgenis/searchall/controller/SearchAllServiceTest.java
+++ b/molgenis-searchall/src/test/java/org/molgenis/searchall/controller/SearchAllServiceTest.java
@@ -27,8 +27,8 @@ import static org.testng.Assert.assertEquals;
 
 public class SearchAllServiceTest
 {
-	DataService dataService;
-	SearchAllService searchAllService;
+	private DataService dataService;
+	private SearchAllService searchAllService;
 	private EntityType entity1;
 	private EntityType entity2;
 	private EntityType entity3;
@@ -137,7 +137,7 @@ public class SearchAllServiceTest
 		when(entity4.getId()).thenReturn("entity id 4");
 		when(entity4.getDescription("en")).thenReturn("entity test description 4");
 		when(entity4.getAllAttributes()).thenReturn(singletonList(attr4));
-		when(entity4.getPackage()).thenReturn(pack3);
+		when(entity4.getPackage()).thenReturn(null);
 	}
 
 	@Test
@@ -179,7 +179,7 @@ public class SearchAllServiceTest
 															 .setId("entity id 4")
 															 .setLabel("entity nr 4")
 															 .setDescription("entity test description 4")
-															 .setPackageId("package id 3")
+															 .setPackageId(null)
 															 .setLabelMatch(false)
 															 .setDescriptionMatch(true)
 															 .setAttributes(Collections.emptyList())


### PR DESCRIPTION
Fix #6695 Search All breaks when there are Entity Types not in a package

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated (N.A.)
- [x] (If you have changed REST API interface) view-swagger.ftl updated (N.A.)
- [x] Test plan template updated (N.A. since it is unit tested)
- [x] Clean commits
