### PR TITLE
Clean up auto import styling

### DIFF
--- a/molgenis-one-click-importer/src/main/frontend/src/App.vue
+++ b/molgenis-one-click-importer/src/main/frontend/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-      <div id="molgenis-one-click-importer">
+      <div id="molgenis-one-click-importer" class="pt-3">
         <one-click-importer></one-click-importer>
       </div>
 </template>

--- a/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
+++ b/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
@@ -3,26 +3,27 @@
 
     <div class="row">
       <div class="col-md-12">
-        <form id="upload-form" v-on:submit.prevent class="form-inline">
+        <form id="upload-form" v-on:submit.prevent class="form">
           <div class="form-group">
+            <label for="file-input">{{ 'import-input-label' | i18n }}</label>
             <input
               id="file-input"
+              class="form-control"
               ref="fileInput"
               type="file"
               accept=".csv, .zip, .xls, .xlsx, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
               @change="importFile"/>
+            <div class="supported-types">
+              <span class="text-muted"><em>{{ 'file-types' | i18n }}: XLSX, XLS, CSV</em></span>
+            </div>
           </div>
         </form>
-        <div class="supported-types">
-          <span class="text-muted"><em>{{ 'file-types' | i18n }}: XLSX, XLS, CSV</em></span>
-        </div>
-        <br/>
       </div>
     </div>
 
     <div class="row">
       <div class="col">
-        <h5>{{ 'import-list-header' | i18n }}</h5>
+        <strong>{{ 'import-list-header' | i18n }}</strong>
         <ul class="imports-list list-unstyled">
 
           <!-- Running job -->

--- a/molgenis-one-click-importer/src/main/resources/l10n/one-click-importer_en.properties
+++ b/molgenis-one-click-importer/src/main/resources/l10n/one-click-importer_en.properties
@@ -1,3 +1,4 @@
+import-input-label=Select a file to import
 file-types=Supported file types
 import-list-header=Imports
 error-message-prefix=Import failed

--- a/molgenis-one-click-importer/src/main/resources/l10n/one-click-importer_nl.properties
+++ b/molgenis-one-click-importer/src/main/resources/l10n/one-click-importer_nl.properties
@@ -1,3 +1,4 @@
+import-input-label=Selecteer een bestand om te importeren
 file-types=Ondersteunde bestandstypen
 import-list-header=Geïmporteerde bestanden
 error-message-prefix=Fout tijdens het importeren


### PR DESCRIPTION
As plugins now have a configurable header, the default header was removed form the one click importer.

If the default header however is empty the styling seems strange ( no space between nav-bar and plugin items).

A 'default' padding is added to the plugin div.
+
Add label for input and cleanup styling a bit.

(cherry picked from commit 16fe2b3)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
