### PR TITLE
Fix #6709 After using search in the navigator the 'home' button stops working

### DIFF
--- a/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
+++ b/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
@@ -28,9 +28,9 @@
       <div class="col input-group">
         <ol class="breadcrumb">
           <li class="breadcrumb-item">
-            <router-link to="/">
+            <a :href="homeUrl" v-on:click="reset">
               <i class="fa fa-home" aria-hidden="true"></i>
-            </router-link>
+            </a>
           </li>
           <li class="breadcrumb-item" v-for="package in path">
             <a v-if="isLast(path, package)">{{package.label}}</a>
@@ -79,7 +79,7 @@
   import _ from 'lodash'
   import { QUERY_PACKAGES, QUERY_ENTITIES, RESET_STATE, GET_STATE_FOR_PACKAGE, GET_ENTITY_PACKAGES } from '../store/actions'
   import { SET_QUERY, SET_ERROR, RESET_PATH, SET_PACKAGES } from '../store/mutations'
-  import { Package } from '../store/state'
+  import { Package, INITIAL_STATE } from '../store/state'
   import { mapState } from 'vuex'
 
   export default {
@@ -98,7 +98,8 @@
             'class': 'hidden-sm-down'
           }
         },
-        filter: null
+        filter: null,
+        homeUrl: INITIAL_STATE.baseUrl
       }
     },
     methods: {
@@ -119,6 +120,10 @@
       isLast: function (list: Array<Package>, item: Package) {
         const tail = list[list.length - 1]
         return !!tail && !!item && tail.id === item.id
+      },
+      reset: function () {
+        this.$store.commit(SET_QUERY, undefined)
+        this.$store.dispatch(RESET_STATE)
       }
     },
     computed: {

--- a/molgenis-navigator/src/main/frontend/test/unit/specs/components/Navigator.spec.js
+++ b/molgenis-navigator/src/main/frontend/test/unit/specs/components/Navigator.spec.js
@@ -73,4 +73,17 @@ describe('Navigator', () => {
       expect(Navigator.methods.isLast(list, item1)).to.equal(false)
     })
   })
+
+  describe('reset', () => {
+    it('should clear the query and dispatch a call to reset the state', () => {
+      Navigator.methods.$store = {
+        dispatch: sinon.spy(),
+        commit: sinon.spy()
+      }
+
+      Navigator.methods.reset('foobar')
+      Navigator.methods.$store.commit.should.have.been.calledWith('__SET_QUERY__', undefined)
+      Navigator.methods.$store.dispatch.should.have.been.calledWith('__RESET_STATE__')
+    })
+  })
 })


### PR DESCRIPTION
Reset state when clicking on the home breadcrumb, even when state is already set to home ( when showing search result)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [ ] Test plan template updated
- [x] Clean commits
