### PR TITLE
Fix #6705 After searching for something in the navigator, the system packages (which are not in the root) are shown

### DIFF
--- a/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
+++ b/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
@@ -17,7 +17,7 @@
                   type="button">{{ 'search-button' | i18n }}</button>
         </span>
         <span class="input-group-btn">
-          <button @click="clearQuery()" class="btn btn-secondary" :disabled="!query"
+          <button @click="reset()" class="btn btn-secondary" :disabled="!query"
                   type="button">{{ 'clear-button' | i18n }}</button>
         </span>
       </div>
@@ -108,10 +108,6 @@
         this.$store.dispatch(QUERY_PACKAGES, this.$store.state.query)
         this.$store.dispatch(QUERY_ENTITIES, this.$store.state.query)
       }, 200),
-      clearQuery: function () {
-        this.$store.commit(SET_QUERY, undefined)
-        this.$store.dispatch(QUERY_PACKAGES)
-      },
       selectPackage: function (packageId: string) {
         this.$store.commit(SET_QUERY, undefined)
         this.$store.dispatch(GET_STATE_FOR_PACKAGE, packageId)

--- a/molgenis-navigator/src/main/frontend/test/unit/specs/components/Navigator.spec.js
+++ b/molgenis-navigator/src/main/frontend/test/unit/specs/components/Navigator.spec.js
@@ -25,19 +25,6 @@ describe('Navigator', () => {
     })
   })
 
-  describe('clearQuery', () => {
-    it('should clear the query and dispatch a call to fetch all packages', () => {
-      Navigator.methods.$store = {
-        dispatch: sinon.spy(),
-        commit: sinon.spy()
-      }
-
-      Navigator.methods.clearQuery('foobar')
-      Navigator.methods.$store.commit.should.have.been.calledWith('__SET_QUERY__', undefined)
-      Navigator.methods.$store.dispatch.should.have.been.calledWith('__QUERY_PACKAGES__')
-    })
-  })
-
   describe('selectPackage', () => {
     Navigator.methods.$store = {
       state: {},


### PR DESCRIPTION
Update clear behaviour to clear the query and reset the interface

(cherry picked from commit d6ecc28)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
