### PR TITLE
Fix #6724 Search all broken with abstract entities in database.

### DIFF
--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/service/SearchAllService.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/service/SearchAllService.java
@@ -41,6 +41,7 @@ public class SearchAllService
 		return Result.builder()
 					 .setEntityTypes(dataService.findAll(ENTITY_TYPE_META_DATA, EntityType.class)
 												.filter(not(EntityUtils::isSystemEntity))
+							 					.filter(not(EntityType::isAbstract))
 												.map(entityType -> toEntityTypeResult(searchTerm, entityType, lang))
 												.filter(EntityTypeResult::isMatch)
 												.collect(toList()))

--- a/molgenis-searchall/src/test/java/org/molgenis/searchall/controller/SearchAllServiceTest.java
+++ b/molgenis-searchall/src/test/java/org/molgenis/searchall/controller/SearchAllServiceTest.java
@@ -33,6 +33,7 @@ public class SearchAllServiceTest
 	private EntityType entity2;
 	private EntityType entity3;
 	private EntityType entity4;
+	private EntityType abstractEntity;
 
 	private Package pack1;
 	private Package pack2;
@@ -138,6 +139,14 @@ public class SearchAllServiceTest
 		when(entity4.getDescription("en")).thenReturn("entity test description 4");
 		when(entity4.getAllAttributes()).thenReturn(singletonList(attr4));
 		when(entity4.getPackage()).thenReturn(null);
+
+		abstractEntity = mock(EntityType.class);
+		when(abstractEntity.getLabel("en")).thenReturn("abstract");
+		when(abstractEntity.getId()).thenReturn("abstract");
+		when(abstractEntity.getDescription("en")).thenReturn("abstract");
+		when(abstractEntity.getAllAttributes()).thenReturn(singletonList(attr1));
+		when(abstractEntity.isAbstract()).thenReturn(true);
+		when(abstractEntity.getPackage()).thenReturn(pack1);
 	}
 
 	@Test
@@ -146,7 +155,7 @@ public class SearchAllServiceTest
 		when(dataService.findAll(PackageMetadata.PACKAGE, Package.class)).thenReturn(
 				Stream.of(pack1, pack2, pack3, pack_sys));
 		when(dataService.findAll(EntityTypeMetadata.ENTITY_TYPE_META_DATA, EntityType.class)).thenReturn(
-				Stream.of(entity1, entity2, entity3, entity4));
+				Stream.of(entity1, entity2, entity3, entity4, abstractEntity));
 		when(dataService.count("entity id 1", new QueryImpl<>().search("test"))).thenReturn(2L);
 		when(dataService.count("entity id 3", new QueryImpl<>().search("test"))).thenReturn(6L);
 		when(dataService.count("entity id 4", new QueryImpl<>().search("test"))).thenReturn(11L);


### PR DESCRIPTION
Getting the repository of a abstract entity results in a null pointer.
To fix this abstract entities are filtered from the search result.

It might be better if MetaDataService.getRepository(id) did not return null in case of a abstract repository.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
