### PR TITLE
Fix #6618, Fix #6737 Search queries with spaces do not get sent to negotiator, When I combine search term with filter, list of matching biobanks only matches filter in negotiator

### DIFF
--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-directory.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-directory.js
@@ -27,7 +27,7 @@ $.when($,
         var rsql = molgenis.dataexplorer.getRSQL()
         var humanReadable = ''
         if (rsql && googleSearch) {
-            uri = uri + rsql + ';*=q=' + googleSearch
+            uri = uri + rsql + ';*=q=' + encodeURIComponent(googleSearch)
             humanReadable = 'Free text search contains ' + googleSearch + ' and ' + molgenis.rsql.getHumanReadable(rsql)
         }
         else if (rsql) {
@@ -35,7 +35,7 @@ $.when($,
             humanReadable = molgenis.rsql.getHumanReadable(rsql)
         }
         else if (googleSearch) {
-            uri = uri + '*=q=' + googleSearch
+            uri = uri + '*=q=' + encodeURIComponent(googleSearch)
             humanReadable = 'Free text search contains ' + googleSearch
         }
         var collections = []

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-directory.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-directory.js
@@ -27,7 +27,7 @@ $.when($,
         var rsql = molgenis.dataexplorer.getRSQL()
         var humanReadable = ''
         if (rsql && googleSearch) {
-            uri = uri + rsql + '&*=q=' + googleSearch
+            uri = uri + rsql + ';*=q=' + googleSearch
             humanReadable = 'Free text search contains ' + googleSearch + ' and ' + molgenis.rsql.getHumanReadable(rsql)
         }
         else if (rsql) {


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [ ] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [x] Clean commits
