### PR TITLE
Fix #6461 Javascript package versions used in the build should be rep…

### DIFF
--- a/molgenis-core-ui/pom.xml
+++ b/molgenis-core-ui/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>0.0.27</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>install node and npm</id>
@@ -129,7 +129,7 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>0.0.27</version>
+                        <version>${frontend-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>webpack production build</id>

--- a/molgenis-metadata-manager/pom.xml
+++ b/molgenis-metadata-manager/pom.xml
@@ -40,6 +40,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-metadata-manager/pom.xml
+++ b/molgenis-metadata-manager/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <workingDirectory>src/main/frontend</workingDirectory>
                 </configuration>

--- a/molgenis-navigator/pom.xml
+++ b/molgenis-navigator/pom.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <workingDirectory>src/main/frontend</workingDirectory>
                 </configuration>

--- a/molgenis-navigator/pom.xml
+++ b/molgenis-navigator/pom.xml
@@ -39,6 +39,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-one-click-importer/pom.xml
+++ b/molgenis-one-click-importer/pom.xml
@@ -40,6 +40,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-one-click-importer/pom.xml
+++ b/molgenis-one-click-importer/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <workingDirectory>src/main/frontend</workingDirectory>
                 </configuration>

--- a/molgenis-searchall/pom.xml
+++ b/molgenis-searchall/pom.xml
@@ -40,6 +40,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-searchall/pom.xml
+++ b/molgenis-searchall/pom.xml
@@ -17,7 +17,7 @@
             <plugin>
                 <groupId>com.github.eirslett</groupId>
                 <artifactId>frontend-maven-plugin</artifactId>
-                <version>1.4</version>
+                <version>${frontend-maven-plugin.version}</version>
                 <configuration>
                     <workingDirectory>src/main/frontend</workingDirectory>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -59,9 +59,9 @@
         <postgres.version>9.4.1211</postgres.version>
         <sonar.jacoco.itReportPath>${project.basedir}/../target/jacoco-it.exec</sonar.jacoco.itReportPath>
         <mockito.version>2.7.22</mockito.version>
+        <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
         <node.version>v6.11.0</node.version>
-        <!-- Update to 1.x when https://github.com/eirslett/frontend-maven-plugin/issues/647 is fixed -->
-        <yarn.version>v0.27.5</yarn.version>
+        <yarn.version>v1.1.0</yarn.version>
     </properties>
 
     <distributionManagement>


### PR DESCRIPTION
Fix #6461 Javascript package versions used in the build should be reproducible

- Update yarn to release version 1.1
- Update maven frontend plugin to 1.6 ( includes yarn fix)
- Move configuration of frontend plugin version to central pom and use variable in sub-poms
- Add frozen lock file option to yarn install to insure lock file does not get updated by accident
- Issue in backlog to [update dev guidelines](http://wiki.gcc.rug.nl/ticket/5366#ticket)
- Describe use of yarn within molgenis in [document](https://docs.google.com/document/d/1bMQaXfIoub3rd0eU_rJ1jF90RAx9vdZOHl9izo34K5M)

#### Checklist
- [x] Review [document](https://docs.google.com/document/d/1bMQaXfIoub3rd0eU_rJ1jF90RAx9vdZOHl9izo34K5M)
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
