### PR TITLE
Fix #6747 When typing " in navigator I get error: {}

### DIFF
--- a/molgenis-navigator/src/main/frontend/src/store/actions.js
+++ b/molgenis-navigator/src/main/frontend/src/store/actions.js
@@ -120,16 +120,15 @@ export default {
       try {
         validateQuery(query)
         uri = getPackageQuery(query)
+        api.get(uri).then(response => {
+          commit(SET_PACKAGES, filterNonVisiblePackages(response.items))
+        }, error => {
+          commit(SET_ERROR, error)
+        })
       } catch (error) {
         commit(SET_ERROR, error.message)
       }
     }
-
-    api.get(uri).then(response => {
-      commit(SET_PACKAGES, filterNonVisiblePackages(response.items))
-    }, error => {
-      commit(SET_ERROR, error)
-    })
   },
   [QUERY_ENTITIES] ({commit}: { commit: Function }, query: string) {
     if (query) {

--- a/molgenis-navigator/src/main/frontend/test/unit/specs/store/actions.spec.js
+++ b/molgenis-navigator/src/main/frontend/test/unit/specs/store/actions.spec.js
@@ -18,10 +18,11 @@ describe('actions', () => {
       }
 
       const get = td.function('api.get')
-      td.when(get('/api/v2/sys_md_Package?sort=label&num=1000')).thenResolve(response)
+      td.when(get('/api/v2/sys_md_Package?sort=label&num=1000&q=id=q="test",description=q="test",label=q="test"')).thenResolve(response)
       td.replace(api, 'get', get)
 
       const options = {
+        payload: 'test',
         expectedMutations: [
           {type: SET_PACKAGES, payload: [package1, package2]}
         ]
@@ -54,11 +55,6 @@ describe('actions', () => {
 
     it('should fail creating the URI and call the SET_ERROR mutation', done => {
       const error = 'Double quotes not are allowed in queries, please use single quotes.'
-
-      const get = td.function('api.get')
-      td.when(get('/undefined')).thenResolve('ignore')
-      td.replace(api, 'get', get)
-
       const options = {
         payload: '"wrong query"',
         expectedMutations: [
@@ -71,12 +67,14 @@ describe('actions', () => {
 
     it('should fail the get and call the SET_ERROR mutation', done => {
       const error = 'failed to get'
+      const query = 'foobar'
 
       const get = td.function('api.get')
-      td.when(get('/api/v2/sys_md_Package?sort=label&num=1000')).thenReject(error)
+      td.when(get('/api/v2/sys_md_Package?sort=label&num=1000&q=id=q="' + encodeURIComponent(query) + '",description=q="' + encodeURIComponent(query) + '",label=q="' + encodeURIComponent(query) + '"')).thenReject(error)
       td.replace(api, 'get', get)
 
       const options = {
+        payload: query,
         expectedMutations: [
           {type: SET_ERROR, payload: error}
         ]


### PR DESCRIPTION
Fix #6747 When typing " in navigator I get error: {}

When the query in identified as invalid, no call to the backend should be made.
The user is shown an error explaining the query is invalid.

bug fix; move api inside of try + update test.

Would be good to fix this in backend someday or write a more complete validator as part of the api-client

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
