### PR TITLE
Fix #6687 When downloading the content as xlsx of a large table (66.…

### DIFF
--- a/docs/user_documentation/guide-explore.md
+++ b/docs/user_documentation/guide-explore.md
@@ -311,7 +311,8 @@ System packages, system entities and system attributes are available in MOLGENIS
 
 # Download  
 
-At the bottom right of each table, there is a download button. This button allows you to save the data to a CSV or XLSX file. Depending on the purpose of the download, identifiers or labels can be used as column headers. Probably the data is safest inside molgenis!
+At the bottom right of each table, there is a download button. This button allows you to save the data to a CSV or XLSX file. The XLSX download is limited to 500000 values to prevent performance issues. 
+Depending on the purpose of the download, identifiers or labels can be used as column headers.
 Another button, next to the download button, will allow you to send your data to a [galaxy](https://galaxyproject.org/ "Galaxy") server.
 
 ![Dataexplorer download](../images/dataexplorer/download_export.png?raw=true, "dataexplorer/download_export")

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -1,5 +1,6 @@
 package org.molgenis.dataexplorer.controller;
 
+import com.google.common.collect.Iterables;
 import com.google.gson.Gson;
 import freemarker.core.ParseException;
 import org.apache.commons.lang3.StringUtils;
@@ -75,6 +76,7 @@ public class DataExplorerController extends PluginController
 	public static final String MOD_ENTITIESREPORT = "entitiesreport";
 	public static final String MOD_DATA = "data";
 	public static final String NAVIGATOR = "navigator";
+	private static final Long MAX_EXCEL_CELLS = 500000L;
 
 	@Autowired
 	private DataExplorerSettings dataExplorerSettings;
@@ -363,6 +365,16 @@ public class DataExplorerController extends PluginController
 				download.writeToCsv(dataRequest, outputStream, ',');
 				break;
 			case DOWNLOAD_TYPE_XLSX:
+
+				if (getNumberOfCellsForEntityType(dataRequest.getEntityName(), dataRequest.getQuery())
+						>= MAX_EXCEL_CELLS)
+				{
+					response.sendError(500, String.format(
+							"Total number of cells for this download exceeds the maximum of %s for .xlsx downloads, please use .csv instead",
+							MAX_EXCEL_CELLS));
+					break;
+				}
+
 				response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
 				response.addHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
 
@@ -370,6 +382,13 @@ public class DataExplorerController extends PluginController
 				download.writeToExcel(dataRequest, outputStream);
 				break;
 		}
+	}
+
+	private Long getNumberOfCellsForEntityType(String entityId, Query query)
+	{
+		long rows = dataService.count(entityId, query);
+		long columns = Iterables.size(dataService.getMeta().getEntityTypeById(entityId).getAllAttributes());
+		return rows * columns;
 	}
 
 	public String getDownloadFilename(String entityTypeId, LocalDateTime localDateTime, DownloadType downloadType)

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -372,14 +372,15 @@ public class DataExplorerController extends PluginController
 					response.sendError(500, String.format(
 							"Total number of cells for this download exceeds the maximum of %s for .xlsx downloads, please use .csv instead",
 							MAX_EXCEL_CELLS));
-					break;
 				}
+				else
+				{
+					response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
+					response.addHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
 
-				response.setContentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
-				response.addHeader("Content-Disposition", "attachment; filename=\"" + fileName + "\"");
-
-				outputStream = response.getOutputStream();
-				download.writeToExcel(dataRequest, outputStream);
+					outputStream = response.getOutputStream();
+					download.writeToExcel(dataRequest, outputStream);
+				}
 				break;
 		}
 	}


### PR DESCRIPTION
…000 rows) the complete site goes down for some time

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
