### PR TITLE
Revert "Fix #6677 When adding a header logo above the menu bar parts of plugins are not clickable"

### DIFF
--- a/molgenis-core-ui/src/main/resources/css/molgenis.css
+++ b/molgenis-core-ui/src/main/resources/css/molgenis.css
@@ -22,7 +22,7 @@
 }
 
 body>.container-fluid {
-	padding-top: 55px;
+	padding-top: 55px !important;
 	margin-bottom: 3em;
 }
 

--- a/molgenis-core-ui/src/main/resources/js/menu/app.js
+++ b/molgenis-core-ui/src/main/resources/js/menu/app.js
@@ -77,14 +77,14 @@ webpackJsonp([1], {
     e.exports = {
       render: function () {
         var e = this, t = e.$createElement, n = e._self._c || t
-        return n('div', {staticClass: 'fixed-top'}, [e.topLogo ? [n('div', {attrs: {id: 'Intro'}}, [n('a', {attrs: {href: '/'}}, [n('img', {
+        return n('div', {staticClass: 'fixed-top'}, [e.topLogo ? [n('div', {attrs: {id: 'TopLogo'}}, [n('a', {attrs: {href: '/'}}, [n('img', {
           attrs: {
             src: e.topLogo,
             alt: '',
             border: '0',
             height: '150'
           }
-        })])])] : e._e(), e._v(' '), n('nav', {staticClass: 'navbar navbar-toggleable-md navbar-light bg-faded navbar-fixed-top'}, [n('button', {
+        })])])] : e._e(), e._v(' '), n('nav', {staticClass: 'navbar navbar-toggleable-md navbar-light bg-faded'}, [n('button', {
           staticClass: 'navbar-toggler navbar-toggler-right',
           attrs: {
             type: 'button',


### PR DESCRIPTION
Reverts molgenis/molgenis#6700

this is no fix since it reintroduces https://github.com/molgenis/molgenis/issues/6525

the "Also the top logo height is not added to the padding, causing the menu to overlap the plugin when a toplogo is configured in the application settings"