### PR TITLE
Fix #6745 Data explorer filter roundtrip doesn't work with =in= operator

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/transformer.js
+++ b/molgenis-core-ui/src/main/javascript/modules/rest-client/rsql/transformer.js
@@ -130,12 +130,18 @@ function toText(constraint) {
 }
 
 function toSimpleRef(labels, constraint) {
+    const addLabel = value => ({'label': labels[value], value})
+
+    let values
+    if( constraint.comparison === '=in=' ) {
+        values = constraint.arguments
+    } else {
+      values = (constraint.operands || [constraint]).map(o => o.arguments)
+    }
+
     return {
-        'type': 'SIMPLE_REF',
-        'values': (constraint.operands || [constraint]).map(o => {
-            const value = o.arguments
-            return {'label': labels[value], value}
-        })
+      'type': 'SIMPLE_REF',
+      values : values.map(addLabel)
     }
 }
 

--- a/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
+++ b/molgenis-core-ui/src/test/javascript/modules/rest-client/rsql/transformerTest.js
@@ -238,6 +238,17 @@ test("Test transformModelPart XREF two values", assert => {
     assert.end();
 })
 
+test("Test transformModelPart XREF two values with IN comparison", assert => {
+  const actual = transformModelPart("XREF", {"ref1": "label1", "ref2": "label2"},
+    parser.parse("xxref=in=(ref1,ref2)"))
+  const expected = {
+    'type': 'SIMPLE_REF',
+    'values': [{'label': 'label1', 'value': 'ref1'}, {'label': 'label2', 'value': 'ref2'}]
+  }
+  assert.deepEqual(actual, expected);
+  assert.end();
+})
+
 test("Test toComplexLine one value selected", assert => {
     const actual = toComplexLine({"ref1": "label1"}, parser.parse("xmref==ref1"))
     const expected = {'operator': undefined, 'values': [{'label': 'label1', 'value': 'ref1'}]}


### PR DESCRIPTION
Handle 'IN' query as special case when parsing arguments

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- (n.a.) User documentation updated
- (n.a.) (If you have changed REST API interface) view-swagger.ftl updated
- (n.a.) Test plan template updated
- [x] Clean commits
