### PR TITLE
Fix #6752 One-click importer cannot import decimal data

### DIFF
--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/service/impl/OneClickImporterServiceImpl.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/service/impl/OneClickImporterServiceImpl.java
@@ -1,5 +1,6 @@
 package org.molgenis.oneclickimporter.service.impl;
 
+import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.poi.ss.usermodel.Cell;
 import org.apache.poi.ss.usermodel.CellType;
 import org.apache.poi.ss.usermodel.Row;
@@ -9,7 +10,6 @@ import org.molgenis.data.MolgenisDataException;
 import org.molgenis.data.meta.AttributeType;
 import org.molgenis.oneclickimporter.model.Column;
 import org.molgenis.oneclickimporter.model.DataCollection;
-import org.molgenis.oneclickimporter.service.CsvService;
 import org.molgenis.oneclickimporter.service.OneClickImporterService;
 import org.springframework.stereotype.Component;
 
@@ -22,7 +22,6 @@ import static com.google.common.base.Strings.isNullOrEmpty;
 import static com.google.common.collect.Lists.newArrayList;
 import static com.google.common.collect.Lists.newLinkedList;
 import static java.lang.Boolean.parseBoolean;
-import static java.lang.Integer.parseInt;
 import static java.time.ZoneOffset.UTC;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 import static org.apache.commons.lang3.math.NumberUtils.isNumber;
@@ -33,13 +32,6 @@ import static org.apache.poi.util.LocaleUtil.setUserTimeZone;
 @Component
 public class OneClickImporterServiceImpl implements OneClickImporterService
 {
-	private final CsvService csvService;
-
-	public OneClickImporterServiceImpl(CsvService csvService)
-	{
-		this.csvService = Objects.requireNonNull(csvService);
-	}
-
 	@Override
 	public List<DataCollection> buildDataCollectionsFromExcel(List<Sheet> sheets)
 	{
@@ -183,7 +175,7 @@ public class OneClickImporterServiceImpl implements OneClickImporterService
 
 		if (isNumber(part))
 		{
-			return parseInt(part);
+			return NumberUtils.createNumber(part);
 		}
 
 		return part;

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/OneClickImporterServiceTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/OneClickImporterServiceTest.java
@@ -26,15 +26,13 @@ import static org.testng.Assert.*;
 
 public class OneClickImporterServiceTest
 {
-	@Mock
-	private CsvService csvService;
 	private OneClickImporterService oneClickImporterService;
 
 	@BeforeClass
 	public void beforeClass()
 	{
 		initMocks(this);
-		oneClickImporterService = new OneClickImporterServiceImpl(csvService);
+		oneClickImporterService = new OneClickImporterServiceImpl();
 	}
 
 	@Test
@@ -131,7 +129,7 @@ public class OneClickImporterServiceTest
 	public void testBuildDataCollectionWithSimpleValidCsvFile() throws IOException, URISyntaxException
 	{
 
-		oneClickImporterService = new OneClickImporterServiceImpl(csvService);
+		oneClickImporterService = new OneClickImporterServiceImpl();
 
 		List<String[]> lines = loadLinesFromFile(OneClickImporterServiceTest.class, "/simple-valid.csv");
 		DataCollection actual = oneClickImporterService.buildDataCollectionFromCsv("simple-valid", lines);
@@ -147,7 +145,7 @@ public class OneClickImporterServiceTest
 	@Test
 	public void testBuildDataCollectionWithComplexValidCsvFile() throws IOException, URISyntaxException
 	{
-		oneClickImporterService = new OneClickImporterServiceImpl(csvService);
+		oneClickImporterService = new OneClickImporterServiceImpl();
 
 		List<String[]> lines = loadLinesFromFile(OneClickImporterServiceTest.class, "/complex-valid.csv");
 		DataCollection actual = oneClickImporterService.buildDataCollectionFromCsv("complex-valid", lines);
@@ -162,7 +160,7 @@ public class OneClickImporterServiceTest
 						"Mariska Slofstra", "Tommy de Boer", "Connor Stroomberg", "Piet Klaassen", null));
 		Column c4 = Column.create("UMCG employee", 3,
 				newArrayList(true, true, true, true, true, true, true, true, false, false));
-		Column c5 = Column.create("Age", 4, newArrayList(26, null, null, null, null, 22, 27, null, 53, 32));
+		Column c5 = Column.create("Age", 4, newArrayList(26.4f, null, null, null, null, 22, 27, null, 53, 0.123f));
 
 		DataCollection expected = DataCollection.create("complex-valid", newArrayList(c1, c2, c3, c4, c5));
 		assertEquals(actual, expected);

--- a/molgenis-one-click-importer/src/test/resources/complex-valid.csv
+++ b/molgenis-one-click-importer/src/test/resources/complex-valid.csv
@@ -1,5 +1,5 @@
 first name,last name,full name,UMCG employee,Age
-Mark,de Haan,Mark de Haan,TRUE,26
+Mark,de Haan,Mark de Haan,TRUE,26.4
 Fleur,Kelpin,Fleur Kelpin,TRUE,
 Dennis,Hendriksen,Dennis Hendriksen,TRUE,
 Bart,Charbon,Bart Charbon,TRUE,
@@ -8,4 +8,4 @@ Mariska,Slofstra,Mariska Slofstra,TRUE,22
 Tommy,de Boer,Tommy de Boer,TRUE,27
 Connor,Stroomberg,Connor Stroomberg,TRUE,
 Piet,Klaassen,Piet Klaassen,FALSE,53
-Jan,,,FALSE,32
+Jan,,,FALSE,0.123


### PR DESCRIPTION
Parse String as number if string is a number, (used to be parsed as integer)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- (n.a.) User documentation updated
- (n.a.) (If you have changed REST API interface) view-swagger.ftl updated
- (n.a.) Test plan template updated
- [x] Clean commits
