### PR TITLE
Fix #6766 Can't import file other than .xlsx in one-click importer in Safari

### DIFF
--- a/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
+++ b/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
@@ -11,7 +11,7 @@
               class="form-control"
               ref="fileInput"
               type="file"
-              accept=".csv, .zip, .xls, .xlsx, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+              accept=".csv, .zip, .xls, .xlsx, text/csv, application/zip, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
               @change="importFile"/>
             <div class="supported-types">
               <span class="text-muted"><em>{{ 'file-types' | i18n }}: XLSX, XLS, CSV</em></span>


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
