### PR TITLE
Fix #6755 Metadata editor is very slow causing saving to be clicked twice giving error message the second time twice giving error message the second time

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerContainer.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerContainer.vue
@@ -6,20 +6,28 @@
         <hr>
       </div>
     </div>
-
-    <div class="row">
+    <div v-if="loading" class="row">
       <div class="col">
-        <div v-if="editorEntityType && editorEntityType.id !== ''">
-          <metadata-manager-entity-edit-form ></metadata-manager-entity-edit-form>
-          <hr>
+        <div class="row">
+          <spinner></spinner>
         </div>
-        <h4 v-else class="text-muted text-center">{{ 'no-entity-type-selected-text' | i18n }}</h4>
       </div>
     </div>
-
-    <div class="row">
-      <div class="col">
-        <metadata-manager-attribute-edit-form v-if="editorEntityType && editorEntityType.id !== ''"></metadata-manager-attribute-edit-form>
+    <div v-else>
+      <div class="row">
+        <div class="col">
+          <div v-if="editorEntityType && editorEntityType.id !== ''">
+            <metadata-manager-entity-edit-form></metadata-manager-entity-edit-form>
+            <hr>
+          </div>
+          <h4 v-else class="text-muted text-center">{{ 'no-entity-type-selected-text' | i18n }}</h4>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col">
+          <metadata-manager-attribute-edit-form
+            v-if="editorEntityType && editorEntityType.id !== ''"></metadata-manager-attribute-edit-form>
+        </div>
       </div>
     </div>
   </div>
@@ -29,6 +37,7 @@
   import MetadataManagerHeader from './MetadataManagerHeader'
   import MetadataManagerEntityEditForm from './MetadataManagerEntityEditForm'
   import MetadataManagerAttributeEditForm from './MetadataManagerAttributeEditForm'
+  import Spinner from './generic-components/Spinner'
 
   import { SET_SELECTED_ENTITY_TYPE_ID, SET_SELECTED_ATTRIBUTE_ID } from '../store/mutations'
   import { GET_ENTITY_TYPES, GET_PACKAGES, GET_ATTRIBUTE_TYPES, GET_EDITOR_ENTITY_TYPE } from '../store/actions'
@@ -37,7 +46,7 @@
   export default {
     name: 'metadata-manager',
     computed: {
-      ...mapState(['alert', 'editorEntityType']),
+      ...mapState(['alert', 'editorEntityType', 'loading']),
       ...mapGetters({
         selectedEntityType: 'getSelectedEntityType',
         selectedAttribute: 'getSelectedAttribute'
@@ -89,7 +98,8 @@
     components: {
       MetadataManagerHeader,
       MetadataManagerEntityEditForm,
-      MetadataManagerAttributeEditForm
+      MetadataManagerAttributeEditForm,
+      Spinner
     }
   }
 </script>

--- a/molgenis-metadata-manager/src/main/frontend/src/components/generic-components/Spinner.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/components/generic-components/Spinner.vue
@@ -1,0 +1,3 @@
+<template>
+  <i class="fa fa-spinner fa-spin fa-3x"></i>
+</template>

--- a/molgenis-metadata-manager/src/main/frontend/src/flow.types.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/flow.types.js
@@ -17,7 +17,8 @@ export type State = {
   selectedEntityTypeId: ?string,
   selectedAttributeId: ?string,
   editorEntityType: EditorEntityType,
-  initialEditorEntityType: ?EditorEntityType
+  initialEditorEntityType: ?EditorEntityType,
+  loading: number
 }
 
 export type Alert = {

--- a/molgenis-metadata-manager/src/main/frontend/src/store/actions.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/actions.js
@@ -81,7 +81,6 @@ export const toAttribute = (attribute: Object): EditorAttribute => {
 const withSpinner = (commit, promise) => {
   commit(SET_LOADING, true)
   promise.catch(error => {
-    console.log(error)
     commit(CREATE_ALERT, {type: 'error', message: error})
   }).then(() => commit(SET_LOADING, false), 1000)
 }

--- a/molgenis-metadata-manager/src/main/frontend/src/store/mutations.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/mutations.js
@@ -22,6 +22,8 @@ export const SET_SELECTED_ATTRIBUTE_ID: string = '__SET_SELECTED_ATTRIBUTE_ID__'
 export const DELETE_SELECTED_ATTRIBUTE: string = '__DELETE_SELECTED_ATTRIBUTE__'
 
 export const CREATE_ALERT: string = '__CREATE_ALERT__'
+export const SET_LOADING = '__SET_LOADING__'
+
 const SYS_PACKAGE_ID = 'sys'
 
 /**
@@ -161,5 +163,8 @@ export default {
    */
   [CREATE_ALERT] (state: State, alert: Alert) {
     state.alert = alert
+  },
+  [SET_LOADING] (state: State, loading: boolean) {
+    state.loading = loading ? state.loading + 1 : state.loading - 1
   }
 }

--- a/molgenis-metadata-manager/src/main/frontend/src/store/state.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/state.js
@@ -23,7 +23,8 @@ const state: State = {
     'attributes': [],
     'referringAttributes': [],
     'lookupAttributes': []
-  }
+  },
+  loading: 0
 }
 
 export default state

--- a/molgenis-metadata-manager/src/main/frontend/test/unit/specs/actions.spec.js
+++ b/molgenis-metadata-manager/src/main/frontend/test/unit/specs/actions.spec.js
@@ -11,7 +11,8 @@ import {
   SET_PACKAGES,
   SET_SELECTED_ATTRIBUTE_ID,
   SET_SELECTED_ENTITY_TYPE_ID,
-  UPDATE_EDITOR_ENTITY_TYPE
+  UPDATE_EDITOR_ENTITY_TYPE,
+  SET_LOADING
 } from 'store/mutations'
 
 import actions, { toAttribute, toEntityType } from 'store/actions'
@@ -40,6 +41,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: SET_PACKAGES, payload: response}
         ]
       }
@@ -54,6 +56,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -79,6 +82,7 @@ describe('actions', () => {
       const options = {
         state: {route: {params: {}}},
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: SET_ENTITY_TYPES, payload: response.items}
         ]
       }
@@ -93,6 +97,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -113,6 +118,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: SET_ATTRIBUTE_TYPES, payload: ['string', 'int', 'xref']}
         ]
       }
@@ -127,6 +133,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -155,6 +162,7 @@ describe('actions', () => {
       const options = {
         payload: entityTypeId,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: SET_EDITOR_ENTITY_TYPE, payload: payload}
         ]
       }
@@ -170,6 +178,7 @@ describe('actions', () => {
       const options = {
         payload: entityTypeId,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -196,6 +205,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: SET_EDITOR_ENTITY_TYPE, payload: payload}
         ]
       }
@@ -210,6 +220,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -241,6 +252,7 @@ describe('actions', () => {
         payload: '1',
         state: state,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: SET_ENTITY_TYPES, payload: [{id: '2'}]},
           {type: SET_SELECTED_ENTITY_TYPE_ID, payload: null},
           {type: SET_SELECTED_ATTRIBUTE_ID, payload: null},
@@ -261,6 +273,7 @@ describe('actions', () => {
         payload: '1',
         state: state,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -295,6 +308,7 @@ describe('actions', () => {
       const options = {
         state: state,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {
             type: UPDATE_EDITOR_ENTITY_TYPE,
             payload: {key: 'attributes', value: [...state.editorEntityType.attributes, attribute]}
@@ -313,6 +327,7 @@ describe('actions', () => {
 
       const options = {
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }
@@ -344,6 +359,7 @@ describe('actions', () => {
       const options = {
         state: state,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: payload}
         ]
       }
@@ -364,6 +380,7 @@ describe('actions', () => {
       const options = {
         state: state,
         expectedMutations: [
+          {type: SET_LOADING, payload: true},
           {type: CREATE_ALERT, payload: alertPayload}
         ]
       }

--- a/molgenis-metadata-manager/src/main/frontend/test/unit/specs/mutations.spec.js
+++ b/molgenis-metadata-manager/src/main/frontend/test/unit/specs/mutations.spec.js
@@ -395,4 +395,28 @@ describe('mutations', () => {
       expect(state.editorEntityType.attributes).to.deep.equal(expected)
     })
   })
+
+  describe('Testing mutation SET_LOADING', () => {
+    it('should set loading to true', () => {
+      const state = {
+        loading: 0
+      }
+
+      const expected = 1
+
+      mutations.__SET_LOADING__(state, true)
+      expect(state.loading).to.equal(expected)
+    })
+
+    it('should set loading to false', () => {
+      const state = {
+        loading: 1
+      }
+
+      const expected = 0
+
+      mutations.__SET_LOADING__(state, false)
+      expect(state.loading).to.equal(expected)
+    })
+  })
 })


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
