### PR TITLE
[GF] Add code coverage reports for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,3 +32,4 @@ notifications:
       secure: blnxfapt6aAdRDjNvy2Ykp3yPxhRqo0srfz9MI2obKGXFOO2ee+AF0TNosmz9aZG0J3u4e3YI+z9BvjcNMvTzzPCjiLiC3MSbtB9w0SHwhg6q7s1ehVoYKqB22++8S6GEYy5FgBpBLQ+jXEnwiglHfKLowJjvQS8s2NBMhAwEqY=
 after_success:
   - .travis/sonar.sh
+  - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Uploads Java+JavaScript coverage report of successful Travis CI builds to codecov.io

(The right place to start since that's where we build our pull requests, but same method can be used to upload from Jenkins if we wish, the upload is not dependent on CI details)

Dashboard will be visible on https://codecov.io/gh/molgenis/molgenis , for a sneak peek see https://codecov.io/gh/fdlk/molgenis/branch/master

Uses coverage measure of `(fully covered) / (not covered + partially covered + fully covered)`

Will also add a report comment to pull requests (which I'd suggest the reviewer use as input for the "Code unit/integration/system tested" checkmark in our checklist)
And give them a yay check or a nay cross, I'm using default configuration for now cause I wouldn't know what's wrong with it (yet).

(Current build gets a nay cross cause no coverage is available for the master just yet.)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits