### PR TITLE
Fix #6822 Attribute.newInstance doesn't copy validation expression

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/Attribute.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/Attribute.java
@@ -110,6 +110,7 @@ public class Attribute extends StaticEntity
 		}
 
 		attrMetaCopy.setTags(Lists.newArrayList(attrMeta.getTags())); // do not deep-copy
+		attrMetaCopy.setValidationExpression(attrMeta.getValidationExpression());
 		attrMetaCopy.setVisibleExpression(attrMeta.getVisibleExpression());
 		attrMetaCopy.setDefaultValue(attrMeta.getDefaultValue());
 		return attrMetaCopy;

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/AttributeTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/AttributeTest.java
@@ -122,7 +122,9 @@ public class AttributeTest
 
 		Attribute attribute = mock(Attribute.class);
 		when(attribute.isVisible()).thenReturn(true);
+		when(attribute.getValidationExpression()).thenReturn("expression");
 		Attribute attributeCopy = Attribute.newInstance(attribute, SHALLOW_COPY_ATTRS, attributeFactory);
 		verify(attributeCopy).setVisible(true);
+		verify(attributeCopy).setValidationExpression("expression");
 	}
 }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
