### PR TITLE
Fix #6689: RSQL complex ref filter is incorrectly applied and shown in Data Explorer

### DIFF
--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-filter-rsql.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-filter-rsql.js
@@ -128,8 +128,12 @@
 
             var complexFilterElement = new molgenis.dataexplorer.filter.ComplexFilterElement(attribute)
             complexFilterElement.simpleFilter = simpleFilter
-            complexFilterElement.operator = lines[index + 1]
-
+            //every complex filter element gets an operator to state how it relates to the previous one
+            //so the operator for the first complexfilterelement is not meaningfull since there is no previous element
+            //so if the index is 0 we can skip adding the operator
+            if (index != 0) {
+                complexFilterElement.operator = lines[index - 1]
+            }
             complexFilter.addComplexFilterElement(complexFilterElement)
         }
         return complexFilter


### PR DESCRIPTION


#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
