### PR TITLE
Fix #6858: Wrong version number in molgenis-swagger pom.xml dependency

### DIFF
--- a/molgenis-swagger/pom.xml
+++ b/molgenis-swagger/pom.xml
@@ -19,6 +19,11 @@
             <artifactId>molgenis-web</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.molgenis</groupId>
+            <artifactId>molgenis-data-i18n</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- third party dependencies -->
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -74,11 +79,6 @@
                 </exclusion>
             </exclusions>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.molgenis</groupId>
-            <artifactId>molgenis-data-i18n</artifactId>
-            <version>5.2.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
