### PR TITLE
Fix #6588 Delete attribute using metadata manager fails

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerAttributeEditForm.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerAttributeEditForm.vue
@@ -274,7 +274,7 @@
     name: 'metadata-manager-attribute-edit-form',
     methods: {
       deleteAttribute (selectedAttribute) {
-        this.$swal(getConfirmBeforeDeletingProperties(selectedAttribute.label)).then(() => {
+        this.$swal(getConfirmBeforeDeletingProperties(selectedAttribute.label, this.$t)).then(() => {
           this.$store.commit(DELETE_SELECTED_ATTRIBUTE, selectedAttribute.id)
         }).catch(this.$swal.noop)
       },


### PR DESCRIPTION
Fix #6588 Using the Metadata manager to remove an attribute via the tree results in an error #6855

Add translation param to method call.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
