### PR TITLE
Add a skip-js-compile profile to maven

### DIFF
--- a/molgenis-core-ui/pom.xml
+++ b/molgenis-core-ui/pom.xml
@@ -25,6 +25,7 @@
                             <goal>install-node-and-npm</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <nodeVersion>v5.12.0</nodeVersion>
                             <npmVersion>3.8.6</npmVersion>
                         </configuration>
@@ -35,6 +36,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>prune</arguments>
                         </configuration>
                     </execution>
@@ -43,6 +45,9 @@
                         <goals>
                             <goal>npm</goal>
                         </goals>
+                        <configuration>
+                            <skip>${skip.js}</skip>
+                        </configuration>
                     </execution>
                     <execution>
                         <id>update package.json version</id>
@@ -50,6 +55,7 @@
                             <goal>gulp</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>update-version</arguments>
                         </configuration>
                     </execution>
@@ -60,6 +66,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>test</arguments>
                         </configuration>
                     </execution>
@@ -118,6 +125,38 @@
     </build>
 
     <profiles>
+        <profile>
+            <id>skip-js-compile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>classes/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>classes/js</exclude>
+                                        <exclude>classes/css</exclude>
+                                        <exclude>classes/index.html</exclude>
+                                    </excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <properties>
+                <webpack.production>true</webpack.production>
+            </properties>
+        </profile>
+
         <profile>
             <id>production</id>
             <properties>

--- a/molgenis-metadata-manager/pom.xml
+++ b/molgenis-metadata-manager/pom.xml
@@ -12,6 +12,37 @@
     <artifactId>molgenis-metadata-manager</artifactId>
     <name>metadata-manager</name>
 
+    <profiles>
+        <profile>
+            <id>skip-js-compile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>classes/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>classes/js</exclude>
+                                        <exclude>classes/css</exclude>
+                                        <exclude>classes/index.html</exclude>
+                                    </excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -29,6 +60,7 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <nodeVersion>${node.version}</nodeVersion>
                             <yarnVersion>${yarn.version}</yarnVersion>
                         </configuration>
@@ -40,6 +72,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -51,6 +84,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>run build</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -62,6 +96,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>test</arguments>
                             <!-- Do not stop the build on JS test failure -->
                             <failOnError>true</failOnError>

--- a/molgenis-navigator/pom.xml
+++ b/molgenis-navigator/pom.xml
@@ -8,9 +8,40 @@
         <version>5.3.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>molgenis-navigator</artifactId>
     <name>navigator</name>
+
+    <profiles>
+        <profile>
+            <id>skip-js-compile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>classes/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>classes/js</exclude>
+                                        <exclude>classes/css</exclude>
+                                        <exclude>classes/index.html</exclude>
+                                    </excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -28,6 +59,7 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <nodeVersion>${node.version}</nodeVersion>
                             <yarnVersion>${yarn.version}</yarnVersion>
                         </configuration>
@@ -39,6 +71,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -50,6 +83,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>run build</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -61,6 +95,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>test</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -91,7 +126,6 @@
             <artifactId>molgenis-core-ui</artifactId>
             <version>${project.version}</version>
         </dependency>
-
         <dependency>
             <groupId>org.molgenis</groupId>
             <artifactId>molgenis-test</artifactId>

--- a/molgenis-one-click-importer/pom.xml
+++ b/molgenis-one-click-importer/pom.xml
@@ -12,6 +12,37 @@
     <artifactId>molgenis-one-click-importer</artifactId>
     <name>one-click-importer</name>
 
+    <profiles>
+        <profile>
+            <id>skip-js-compile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>classes/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>classes/js</exclude>
+                                        <exclude>classes/css</exclude>
+                                        <exclude>classes/index.html</exclude>
+                                    </excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -29,6 +60,7 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <nodeVersion>${node.version}</nodeVersion>
                             <yarnVersion>${yarn.version}</yarnVersion>
                         </configuration>
@@ -40,6 +72,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -51,6 +84,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>run build</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -62,6 +96,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>test</arguments>
                             <!-- Do not stop the build on JS test failure -->
                             <failOnError>true</failOnError>

--- a/molgenis-searchall/pom.xml
+++ b/molgenis-searchall/pom.xml
@@ -12,6 +12,37 @@
     <artifactId>molgenis-searchall</artifactId>
     <name>searchall</name>
 
+    <profiles>
+        <profile>
+            <id>skip-js-compile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <configuration>
+                            <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                            <filesets>
+                                <fileset>
+                                    <directory>target</directory>
+                                    <includes>
+                                        <include>classes/*</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>classes/js</exclude>
+                                        <exclude>classes/css</exclude>
+                                        <exclude>classes/index.html</exclude>
+                                    </excludes>
+                                </fileset>
+                            </filesets>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -29,6 +60,7 @@
                         </goals>
                         <phase>initialize</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <nodeVersion>${node.version}</nodeVersion>
                             <yarnVersion>${yarn.version}</yarnVersion>
                         </configuration>
@@ -40,6 +72,7 @@
                             <goal>yarn</goal>
                         </goals>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>--frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -51,6 +84,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>run build</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
@@ -62,6 +96,7 @@
                         </goals>
                         <phase>test</phase>
                         <configuration>
+                            <skip>${skip.js}</skip>
                             <arguments>test</arguments>
                             <!-- Do not stop the build on JS test failure -->
                             <failOnError>true</failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,7 @@
 
         <!-- plugin versions -->
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+        <skip.js>false</skip.js>
 
         <!-- dependency versions -->
         <slf4j.version>1.7.25</slf4j.version><!-- must match version in logback-parent pom -->
@@ -177,6 +178,12 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>skip-js-compile</id>
+            <properties>
+                <skip.js>true</skip.js>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
If you run a clean install with `-P skip-js-compile`, All the modules containing the maven-frontend-plugin will not execute their yarn / npm install commands

Impact: Running a build with the new profile and no tests **reduced** build time from **3m45s** to **1m14s** on my local machine


#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
