### PR TITLE
Api tests/fix file not found due to space in path

### DIFF
--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
@@ -10,11 +10,11 @@ import org.molgenis.auth.GroupMetaData;
 import org.slf4j.Logger;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
+import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -46,7 +46,7 @@ public class RestTestUtils
 	public static final String X_MOLGENIS_TOKEN = "x-molgenis-token";
 
 	// Admin credentials
-	public static final String DEFAULT_HOST = "http://localhost:8080";
+	public static final String DEFAULT_HOST = "https://molgenis01.gcc.rug.nl"; //"http://localhost:8080";
 	public static final String DEFAULT_ADMIN_NAME = "admin";
 	public static final String DEFAULT_ADMIN_PW = "admin";
 
@@ -215,10 +215,10 @@ public class RestTestUtils
 		try
 		{
 			jsonObject = (JSONObject) new JSONParser(JSONParser.MODE_JSON_SIMPLE).parse(
-					new FileReader(Resources.getResource(RestTestUtils.class, fileName).getFile()));
+					new InputStreamReader(RestTestUtils.class.getResourceAsStream(fileName), Charset.forName("UTF-8")));
 
 		}
-		catch (ParseException | FileNotFoundException e)
+		catch (ParseException e)
 		{
 			LOG.error("Unable to readJsonFile(" + fileName + ")");
 			LOG.error(e.getMessage());

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
@@ -46,7 +46,7 @@ public class RestTestUtils
 	public static final String X_MOLGENIS_TOKEN = "x-molgenis-token";
 
 	// Admin credentials
-	public static final String DEFAULT_HOST = "https://molgenis01.gcc.rug.nl"; //"http://localhost:8080";
+	public static final String DEFAULT_HOST = "http://localhost:8080";
 	public static final String DEFAULT_ADMIN_NAME = "admin";
 	public static final String DEFAULT_ADMIN_PW = "admin";
 


### PR DESCRIPTION
Change the way test sets a loaded to allow for space in path name

needs to be testen on jenkins machine

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
