### PR TITLE
Fix #6900 When uploading a questionnaire with a categorical mref with nillable expressions do not give clear errors

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Form.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Form.js
@@ -688,10 +688,13 @@ var Form = React.createClass({
      * @private
      */
     _isValueNotSet(fieldType, value) {
-        if(fieldType === 'CATEGORICAL_MREF' || fieldType === 'MREF') {
+        if(value === undefined) {
+            return true
+        }
+        else if(fieldType === 'CATEGORICAL_MREF' || fieldType === 'MREF') {
             return !value.items || value.items.length === 0
         } else {
-            return value === '' || value === undefined || value === null
+            return value === '' || value === null
         }
     },
     _resolveBoolExpression: function (expression, entityInstance) {

--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Form.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Form.js
@@ -672,14 +672,27 @@ var Form = React.createClass({
             if(attr.nullableExpression) {
               entityInstance[attr.name] = value;
               var isNillable = this._resolveBoolExpression(attr.nullableExpression, entityInstance)
-              var isValueNull = value === '' || value === undefined || value === null
-              if (!isNillable && isValueNull) {
+              if (!isNillable && this._isValueNotSet(type, value)) {
                 errorMessage = 'Field is required, please enter a value';
               }
             }
         }
 
         callback({valid: errorMessage === undefined, errorMessage: errorMessage});
+    },
+    /**
+     * Returns true if the field value has not been set, the definition of 'being set' depends on the type of field.
+     * @param {string} fieldType type of field, one of {DECIMAL. MREF, CATEGORICAL_MREF, ...}
+     * @param {*} value current field value
+     * @returns {boolean}
+     * @private
+     */
+    _isValueNotSet(fieldType, value) {
+        if(fieldType === 'CATEGORICAL_MREF' || fieldType === 'MREF') {
+            return !value.items || value.items.length === 0
+        } else {
+            return value === '' || value === undefined || value === null
+        }
     },
     _resolveBoolExpression: function (expression, entityInstance) {
         //TODO make evalScript work with entities


### PR DESCRIPTION
Split off 'is value set' question to separate function. The new function uses the fieldType in conjunction with the value to check if the field has been set or not.

n.b. maybe we should spilt of all the validate helper function used in Form.js to a separate js module so we can write unit test of the validation, independent of the React/html/form stuff.  

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
