### PR TITLE
Fix #6917 I cannot see a date in my catalina out logs

### DIFF
--- a/molgenis-app/src/main/resources/logback.xml
+++ b/molgenis-app/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
 	<appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
 		<encoder>
-			<pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+			<pattern>%d{yyyy-MM-dd_HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
 		</encoder>
 	</appender>
     <appender name="jobExecutionLogAppender" class="org.molgenis.data.jobs.model.JobExecutionLogAppender"/>


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
