### PR TITLE
Fix #6923 When altering static content, spans without text are destroyed

### DIFF
--- a/molgenis-core-ui/src/main/resources/templates/view-staticcontent-edit.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/view-staticcontent-edit.ftl
@@ -33,5 +33,8 @@
 
 <script>
     CKEDITOR.replace('elm1');
+    CKEDITOR.dtd.$removeEmpty['i'] = false;
+    CKEDITOR.dtd.$removeEmpty['span'] = false;
+    CKEDITOR.dtd.$removeEmpty['button'] = false;
 </script>
 <@footer/>


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
