### PR TITLE
Fix #6967 Molgenis does not run on mac os version 'high sierra'.

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/menumanager/MenuManagerServiceImpl.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/menumanager/MenuManagerServiceImpl.java
@@ -15,6 +15,7 @@ import org.molgenis.ui.menu.MenuItem;
 import org.molgenis.ui.menu.MenuItemType;
 import org.molgenis.ui.menu.MenuReaderService;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
+@Component
 public class MenuManagerServiceImpl implements MenuManagerService
 {
 	private final MenuReaderService menuReaderService;


### PR DESCRIPTION
Fix #6967 Molgenis does not run on mac os version 'high sierra'.

I suspect due to changes in the high sierra file system (faster) the 'AppDbSettings' is now called before the 'MenuManagerServiceImpl' is created, 'AppDbSettings' needs 'MenuManagerServiceImpl'.

Adding the @Component annotation makes it possible to wire 'MenuManagerServiceImpl' on 'AppDbSettings' instantiation.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
