### PR TITLE
Fix #6967 Molgenis does not run on mac os version 'high sierra'.

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/MolgenisWebAppConfig.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/MolgenisWebAppConfig.java
@@ -23,8 +23,6 @@ import org.molgenis.ui.freemarker.MolgenisFreemarkerObjectWrapper;
 import org.molgenis.ui.menu.MenuMolgenisUi;
 import org.molgenis.ui.menu.MenuReaderService;
 import org.molgenis.ui.menu.MenuReaderServiceImpl;
-import org.molgenis.ui.menumanager.MenuManagerService;
-import org.molgenis.ui.menumanager.MenuManagerServiceImpl;
 import org.molgenis.ui.security.MolgenisUiPermissionDecorator;
 import org.molgenis.ui.style.StyleService;
 import org.molgenis.ui.style.ThemeFingerprintRegistry;
@@ -336,12 +334,6 @@ public abstract class MolgenisWebAppConfig extends WebMvcConfigurerAdapter
 	public MenuReaderService menuReaderService()
 	{
 		return new MenuReaderServiceImpl(appSettings);
-	}
-
-	@Bean
-	public MenuManagerService menuManagerService()
-	{
-		return new MenuManagerServiceImpl(menuReaderService(), appSettings, dataService);
 	}
 
 	@Bean

--- a/molgenis-core-ui/src/main/java/org/molgenis/ui/menumanager/MenuManagerServiceImpl.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/ui/menumanager/MenuManagerServiceImpl.java
@@ -15,6 +15,7 @@ import org.molgenis.ui.menu.MenuItem;
 import org.molgenis.ui.menu.MenuItemType;
 import org.molgenis.ui.menu.MenuReaderService;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.util.List;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 
+@Component
 public class MenuManagerServiceImpl implements MenuManagerService
 {
 	private final MenuReaderService menuReaderService;


### PR DESCRIPTION
Fix #6967 Molgenis does not run on mac os version 'high sierra'.

I suspect due to changes in the high sierra file system (faster) the 'AppDbSettings' is now called before the 'MenuManagerServiceImpl' is created, 'AppDbSettings' needs 'MenuManagerServiceImpl'.

Adding the @component annotation makes it possible to wire 'MenuManagerServiceImpl' on 'AppDbSettings' instantiation.

For cleanup purposes the initialisation of MenuManagerServiceImpl bean in the MolgenisWebappConfig is deleted.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
