### PR TITLE
Fix #6982 Translate date and dateTime values back into moments before form submission

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Questionnaire.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Questionnaire.js
@@ -7,6 +7,7 @@ import FormFactory from "./Form";
 import Spinner from "./Spinner";
 import Button from "./Button";
 import _ from "underscore";
+import moment from "moment";
 
 var div = React.DOM.div;
 
@@ -109,6 +110,12 @@ var Questionnaire = React.createClass({
                         break;
                     case 'COMPOUND':
                         //nothing, no value
+                        break;
+                    case 'DATE':
+                        values[attr.name] = moment(value, 'YYYY-MM-DD', true);
+                        break;
+                    case 'DATE_TIME':
+                        values[attr.name] = moment(value, moment.ISO_8601, true);
                         break;
                     default:
                         values[attr.name] = value;


### PR DESCRIPTION
This fixes the bug whereby the age function would fail due to the difference between now() and a 'string  would result in a NaN. This would result in the values being set to null on the form and then the validation would fail in the backend.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
