### PR TITLE
Add template for testing public data upload.

### DIFF
--- a/molgenis-api-tests/README.md
+++ b/molgenis-api-tests/README.md
@@ -6,7 +6,7 @@ Collection of integration tests to run against a live server. Tests use a java h
 
 ##### Maven properties:
 
-`REST_TEST_HOST=[url_of_live_molgenis_to_test_agains]` // defaults http://localhost:8080  
+`REST_TEST_HOST=[url_of_live_molgenis_to_test_against]` // default http://localhost:8080  
 `REST_TEST_ADMIN_NAME=[name_of_admin_user]` // user name of user that acts as 'admin' user, this user is used to for test setup and teardown  
 `REST_TEST_ADMIN_PW=[password_for_admin_users]`
 
@@ -31,3 +31,9 @@ All of the above mentioned maven properties + the following environment variable
 
 set environment variables   
 `mvn test -Dtest=ImportPublicDataIT -DREST_TEST_ADMIN_NAME="[admin_name]" -DREST_TEST_ADMIN_PW="[admin_pw]"` 
+
+##### Running on a CI-server
+
+We run separate builds for each individual customer. To add a job for a new customer please check the existing builds. You can copy a job and update the configuration.
+
+Check CI-jobs: [![Import public data job](https://molgenis50.gcc.rug.nl/jenkins/buildStatus/icon?job=Nightly%20live%20API%20Tests)]()

--- a/molgenis-api-tests/README.md
+++ b/molgenis-api-tests/README.md
@@ -1,0 +1,33 @@
+# Molgenis API Test
+
+[![Build Status](https://molgenis50.gcc.rug.nl/jenkins/buildStatus/icon?job=Nightly%20live%20API%20Tests)](http://www.molgenis.org/jenkins/job/Nightly%20live%20API%20Tests/)
+
+Collection of integration tests to run against a live server. Tests use a java http client to test the molgenis API.
+
+##### Maven properties:
+
+`REST_TEST_HOST=[url_of_live_molgenis_to_test_agains]` // defaults http://localhost:8080  
+`REST_TEST_ADMIN_NAME=[name_of_admin_user]` // user name of user that acts as 'admin' user, this user is used to for test setup and teardown  
+`REST_TEST_ADMIN_PW=[password_for_admin_users]`
+
+##### Running on local machine:
+
+`mvn test -Dtest=[RestControllerIT,...comma-separated-list-of-test-classes] -DREST_TEST_ADMIN_NAME="[admin_name]" -DREST_TEST_ADMIN_PW="[admin_pw]"` 
+
+
+### Public data upload test
+
+The class `ImportPublicDataIT` is used as a template for running tests that upload public customer data to live molgenis server. 
+
+##### Properties and environment variables:
+
+All of the above mentioned maven properties + the following environment variables  
+`molgenis.test.upload.folder`  // path to folder to load data files from  
+`molgenis.test.upload.file`  // file to use in test  
+`molgenis.test.upload.package.to.remove`  // package to delete after test ( success or failure )  
+`molgenis.test.upload.check.url`  // url to test via GET for testing successful upload  
+
+##### Running on local machine:
+
+set environment variables   
+`mvn test -Dtest=ImportPublicDataIT -DREST_TEST_ADMIN_NAME="[admin_name]" -DREST_TEST_ADMIN_PW="[admin_pw]"` 

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/importpublicdata/ImportPublicDataIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/importpublicdata/ImportPublicDataIT.java
@@ -1,0 +1,83 @@
+package org.molgenis.api.tests.importpublicdata;
+
+import com.google.common.base.Strings;
+import io.restassured.RestAssured;
+import org.junit.Assert;
+import org.molgenis.api.tests.utils.RestTestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+
+import static io.restassured.RestAssured.given;
+import static org.molgenis.api.tests.utils.RestTestUtils.*;
+
+public class ImportPublicDataIT
+{
+	private static final Logger LOG = LoggerFactory.getLogger(ImportPublicDataIT.class);
+
+	private String adminToken;
+	private String testUrl;
+	private String uploadTopLevelPackage;
+
+	@BeforeClass
+	public void beforeClass()
+	{
+		LOG.info("Read environment variables");
+		String envHost = System.getProperty("REST_TEST_HOST");
+		RestAssured.baseURI = Strings.isNullOrEmpty(envHost) ? RestTestUtils.DEFAULT_HOST : envHost;
+		LOG.info("baseURI: " + RestAssured.baseURI);
+
+		String envAdminName = System.getProperty("REST_TEST_ADMIN_NAME");
+		String adminUserName = Strings.isNullOrEmpty(envAdminName) ? RestTestUtils.DEFAULT_ADMIN_NAME : envAdminName;
+		LOG.info("adminUserName: " + adminUserName);
+
+		String envAdminPW = System.getProperty("REST_TEST_ADMIN_PW");
+		String adminPassword = Strings.isNullOrEmpty(envHost) ? RestTestUtils.DEFAULT_ADMIN_PW : envAdminPW;
+
+		adminToken = login(adminUserName, adminPassword);
+
+		LOG.info("Importing Test data");
+
+		String uploadFolder = getExpectedEnvVariable("molgenis.test.upload.folder");
+		String uploadFile = getExpectedEnvVariable("molgenis.test.upload.file");
+		uploadTopLevelPackage = getExpectedEnvVariable("molgenis.test.upload.package.to.remove");
+		testUrl = getExpectedEnvVariable("molgenis.test.upload.check.url");
+		RestTestUtils.uploadEMX(adminToken, uploadFolder, uploadFile);
+
+		LOG.info("Importing Done");
+	}
+
+	private String getExpectedEnvVariable(String envName)
+	{
+		String envVariable = System.getenv(envName);
+		Assert.assertFalse( "Expected enviroment variable '" + envName + "' not found.",
+				Strings.isNullOrEmpty(envVariable));
+		LOG.info("Test upload " + envName + ": " + envVariable);
+		return envVariable;
+	}
+
+	@Test
+	public void testDataWasUploaded()
+	{
+		given().log()
+			   .all()
+			   .header(X_MOLGENIS_TOKEN, adminToken)
+			   .contentType("text/plain")
+			   .when()
+			   .get(testUrl)
+			   .then()
+			   .log()
+			   .all()
+			   .statusCode(200);
+	}
+
+	@AfterClass(alwaysRun = true)
+	public void afterClass()
+	{
+		RestTestUtils.removePackages(adminToken, Collections.singletonList(uploadTopLevelPackage));
+	}
+}

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
@@ -138,17 +138,29 @@ public class RestTestUtils
 	 */
 	public static void uploadEMX(String adminToken, String fileName)
 	{
-		URL resourceUrl = Resources.getResource(RestTestUtils.class, fileName);
-		File file = null;
-		try
-		{
-			file = new File(new URI(resourceUrl.toString()).getPath());
-		}
-		catch (URISyntaxException e)
-		{
-			LOG.error(e.getMessage());
-		}
+		File file = getResourceFile(fileName);
 
+		uploadEMXFile(adminToken, file);
+	}
+
+	/**
+	 * Import emx file using add/update.
+	 * <p>
+	 * Importing is done async in the backend, but this methods waits for importing to be done.
+	 *
+	 * @param adminToken to use for login
+	 * @param pathToFileFolder
+	 * @param fileName name of the file to upload
+	 */
+	public static void uploadEMX(String adminToken, String pathToFileFolder, String fileName)
+	{
+		File file = new File(pathToFileFolder + File.separator + fileName);
+
+		uploadEMXFile(adminToken, file);
+	}
+
+	private static void uploadEMXFile(String adminToken, File file)
+	{
 		String importJobURLString = given().multiPart(file)
 										   .param("file")
 										   .param("action", "ADD_UPDATE_EXISTING")
@@ -168,15 +180,7 @@ public class RestTestUtils
 		LOG.info("Import completed");
 	}
 
-	/**
-	 * Import emx file using add/update.
-	 * <p>
-	 * Importing is done async in the backend, but this methods waits for importing to be done.
-	 *
-	 * @param adminToken to use for login
-	 * @param fileName   the file to upload
-	 */
-	public static void uploadVCF(String adminToken, String fileName, String entityName)
+	private static File getResourceFile(String fileName)
 	{
 		URL resourceUrl = Resources.getResource(RestTestUtils.class, fileName);
 		File file = null;
@@ -188,6 +192,20 @@ public class RestTestUtils
 		{
 			LOG.error(e.getMessage());
 		}
+		return file;
+	}
+
+	/**
+	 * Import emx file using add/update.
+	 * <p>
+	 * Importing is done async in the backend, but this methods waits for importing to be done.
+	 *
+	 * @param adminToken to use for login
+	 * @param fileName   the file to upload
+	 */
+	public static void uploadVCF(String adminToken, String fileName, String entityName)
+	{
+		File file = getResourceFile(fileName);
 
 		String importJobURLString = given().multiPart(file)
 										   .param("file")


### PR DESCRIPTION
Add template for testing public data upload.
+
Refactor test utils to import a file using absolute path.

Template can be use by jenkins job to upload a emx file from the jenkins server to the test server, check upload succes and cleanup after test.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
