### PR TITLE
 Handle MethodArgumentNotValidException by putting the localized error messages from BindingResult in the ErrorResponse

### DIFF
--- a/molgenis-data-i18n/src/main/java/org/molgenis/data/i18n/LocalizationConfig.java
+++ b/molgenis-data-i18n/src/main/java/org/molgenis/data/i18n/LocalizationConfig.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.ResourceBundleMessageSource;
 
 import java.util.Locale;
 
@@ -45,6 +46,9 @@ public class LocalizationConfig
 	{
 		LocalizationMessageSource localizationMessageSource = new LocalizationMessageSource(messageFormatFactory,
 				localizationRepository(), () -> new Locale(appSettings.getLanguageCode()));
+		ResourceBundleMessageSource resourceBundleMessageSource = new ResourceBundleMessageSource();
+		resourceBundleMessageSource.addBasenames("org.hibernate.validator.ValidationMessages");
+		localizationMessageSource.setParentMessageSource(resourceBundleMessageSource);
 		MessageSourceHolder.setMessageSource(localizationMessageSource);
 		return localizationMessageSource;
 	}

--- a/molgenis-i18n/src/main/java/org/molgenis/i18n/LocalizationMessageSource.java
+++ b/molgenis-i18n/src/main/java/org/molgenis/i18n/LocalizationMessageSource.java
@@ -61,7 +61,12 @@ public class LocalizationMessageSource extends AbstractMessageSource
 	@Override
 	public MessageFormat resolveCode(String code, Locale locale)
 	{
-		return createMessageFormat(resolveCodeWithoutArguments(code, locale), locale);
+		String resolved = resolveCodeWithoutArguments(code, locale);
+		if (resolved == null)
+		{
+			return null;
+		}
+		return createMessageFormat(resolved, locale);
 	}
 
 	@Override

--- a/molgenis-web/pom.xml
+++ b/molgenis-web/pom.xml
@@ -89,6 +89,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <!-- Remove exclusions when https://issues.apache.org/jira/browse/MNG-5600 has been resolved -->

--- a/molgenis-web/src/main/java/org/molgenis/web/WebL10nConfig.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/WebL10nConfig.java
@@ -1,0 +1,15 @@
+package org.molgenis.web;
+
+import org.molgenis.i18n.PropertiesMessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebL10nConfig
+{
+	@Bean
+	PropertiesMessageSource webMessageSource()
+	{
+		return new PropertiesMessageSource("web");
+	}
+}

--- a/molgenis-web/src/main/java/org/molgenis/web/exception/ExceptionHandlerUtils.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/exception/ExceptionHandlerUtils.java
@@ -1,10 +1,19 @@
 package org.molgenis.web.exception;
 
+import org.molgenis.i18n.MessageSourceHolder;
 import org.molgenis.web.ErrorMessageResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.web.util.matcher.ELRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,7 +22,11 @@ import org.springframework.web.servlet.ModelAndView;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+
+import static com.google.common.collect.Lists.newArrayList;
 
 class ExceptionHandlerUtils
 {
@@ -27,6 +40,8 @@ class ExceptionHandlerUtils
 	private static final RequestMatcher requestMatcher = new ELRequestMatcher(
 			"hasHeader('X-Requested-With','XMLHttpRequest')");
 	public static final String OPTIONS = "OPTIONS";
+
+	private static final Logger LOG = LoggerFactory.getLogger(ExceptionHandlerUtils.class);
 
 	private ExceptionHandlerUtils()
 	{
@@ -58,7 +73,8 @@ class ExceptionHandlerUtils
 	private static Object handleException(Exception e, boolean isHtmlRequest, HttpStatus httpStatus, String errorCode,
 			String environment)
 	{
-		ErrorMessageResponse errorMessageResponse = ErrorMessageResponse.create(e.getLocalizedMessage(), errorCode);
+		LOG.info("", e);
+		ErrorMessageResponse errorMessageResponse = createErrorMessageResponse(e, errorCode);
 		if (isHtmlRequest)
 		{
 			Map<String, Object> model = new HashMap<>();
@@ -74,6 +90,42 @@ class ExceptionHandlerUtils
 		{
 			return new ResponseEntity<>(errorMessageResponse, httpStatus);
 		}
+	}
+
+	private static ErrorMessageResponse createErrorMessageResponse(Exception e, String errorCode)
+	{
+		if (e instanceof BindingResult)
+		{
+			return getErrorMessageResponse((BindingResult) e);
+		}
+		else if (e instanceof MethodArgumentNotValidException)
+		{
+			return getErrorMessageResponse(((MethodArgumentNotValidException) e).getBindingResult());
+		}
+		else
+		{
+			return new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage(e.getLocalizedMessage(), errorCode));
+		}
+	}
+
+	private static ErrorMessageResponse getErrorMessageResponse(BindingResult bindingResult)
+	{
+		List<ErrorMessageResponse.ErrorMessage> errorMessages = newArrayList();
+		Locale locale = LocaleContextHolder.getLocale();
+		MessageSource messageSource = MessageSourceHolder.getMessageSource();
+		for (ObjectError objectError : bindingResult.getGlobalErrors())
+		{
+			String message = messageSource.getMessage("org.molgenis.web.exception.ObjectError",
+					new Object[] { objectError.getObjectName(), objectError }, locale);
+			errorMessages.add(new ErrorMessageResponse.ErrorMessage(message, objectError.getCode()));
+		}
+		for (FieldError fieldError : bindingResult.getFieldErrors())
+		{
+			String message = messageSource.getMessage("org.molgenis.web.exception.FieldError",
+					new Object[] { fieldError.getField(), fieldError.getObjectName(), fieldError }, locale);
+			errorMessages.add(new ErrorMessageResponse.ErrorMessage(message, fieldError.getCode()));
+		}
+		return new ErrorMessageResponse(errorMessages);
 	}
 
 	private static boolean isHtmlRequest(HandlerMethod handlerMethod)

--- a/molgenis-web/src/main/resources/l10n/web_en.properties
+++ b/molgenis-web/src/main/resources/l10n/web_en.properties
@@ -1,0 +1,2 @@
+org.molgenis.web.exception.ObjectError=''{0}'' {1}
+org.molgenis.web.exception.FieldError=Field ''{0}'' of ''{1}'' {2}

--- a/molgenis-web/src/test/java/org/molgenis/web/exception/SpringExceptionHandlerTest.java
+++ b/molgenis-web/src/test/java/org/molgenis/web/exception/SpringExceptionHandlerTest.java
@@ -1,14 +1,22 @@
 package org.molgenis.web.exception;
 
+import com.google.common.collect.ImmutableList;
+import org.mockito.Mock;
+import org.molgenis.i18n.MessageSourceHolder;
+import org.molgenis.i18n.properties.AllPropertiesMessageSource;
 import org.molgenis.test.AbstractMockitoTest;
 import org.molgenis.web.ErrorMessageResponse;
 import org.springframework.beans.ConversionNotSupportedException;
 import org.springframework.beans.TypeMismatchException;
-import org.springframework.http.HttpStatus;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
 import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
 import org.springframework.web.HttpMediaTypeNotAcceptableException;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -20,233 +28,242 @@ import org.springframework.web.context.request.async.AsyncRequestTimeoutExceptio
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.servlet.http.HttpServletRequest;
 
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.springframework.http.HttpStatus.*;
 import static org.testng.Assert.assertEquals;
 
 public class SpringExceptionHandlerTest extends AbstractMockitoTest
 {
 	private SpringExceptionHandler handler;
+	private ObjectError globalError;
+	private FieldError fieldError;
+	@Mock
+	private HandlerMethod handlerMethod;
+	@Mock
+	private HttpServletRequest httpServletRequest;
+	@Mock
+	private NoHandlerFoundException noHandlerFoundException;
+	@Mock
+	private AsyncRequestTimeoutException asyncRequestTimeoutException;
+	@Mock
+	private BindException bindException;
+	@Mock
+	private MissingServletRequestPartException missingServletRequestPartException;
+	@Mock
+	private MethodArgumentNotValidException methodArgumentNotValidException;
+	@Mock
+	private BindingResult bindingResult;
+	@Mock
+	private HttpMediaTypeNotAcceptableException httpMediaTypeNotAcceptableException;
+	@Mock
+	private HttpMessageNotWritableException httpMessageNotWritableException;
+	@Mock
+	private HttpMessageNotReadableException httpMessageNotReadableException;
+	@Mock
+	private TypeMismatchException typeMismatchException;
+	@Mock
+	private HttpMediaTypeNotSupportedException httpMediaTypeNotSupportedException;
+	@Mock
+	private ServletRequestBindingException servletRequestBindingException;
+	@Mock
+	private ConversionNotSupportedException conversionNotSupportedException;
+	@Mock
+	private MissingServletRequestParameterException missingServletRequestParameterException;
+	@Mock
+	private MissingPathVariableException missingPathVariableException;
+
+	@BeforeClass
+	public void beforeClass()
+	{
+		AllPropertiesMessageSource molgenisLocalizationMessages = new AllPropertiesMessageSource();
+		molgenisLocalizationMessages.addMolgenisNamespaces("web");
+		ResourceBundleMessageSource hibernateValidationMessages = new ResourceBundleMessageSource();
+		hibernateValidationMessages.addBasenames("org.hibernate.validator.ValidationMessages");
+		molgenisLocalizationMessages.setParentMessageSource(hibernateValidationMessages);
+		MessageSourceHolder.setMessageSource(molgenisLocalizationMessages);
+
+		globalError = new ObjectError("entityCollectionRequestV2", new String[] { "TwoFieldsSet" }, new Object[] { 1 },
+				"must have two fields set");
+		fieldError = new FieldError("entityCollectionRequestV2", "num", -10, false,
+				new String[] { "Min.entityCollectionRequestV2.num", "Min.num", "Min.int", "Min" }, new Object[] {
+				new DefaultMessageSourceResolvable(new String[] { "entityCollectionRequestV2.num", "num" }, null,
+						"num"), 0 }, "must be greater than or equal to 0");
+	}
 
 	@BeforeMethod
 	public void setUp()
 	{
 		handler = new SpringExceptionHandler();
-
 	}
 
 	@Test
 	public void testNoHandlerFoundException()
 	{
-		HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
-
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.NOT_FOUND);
-		NoHandlerFoundException exception = mock(NoHandlerFoundException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
+		when(noHandlerFoundException.getLocalizedMessage()).thenReturn("localized message");
 		when(httpServletRequest.getMethod()).thenReturn("OPTIONS");
-		assertEquals(handler.handleSpringException(exception, httpServletRequest), expected);
+		assertEquals(handler.handleSpringException(noHandlerFoundException, httpServletRequest), new ResponseEntity<>(
+				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")), NOT_FOUND));
 	}
 
 	@Test
 	public void AsyncRequestTimeoutException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
-
-		ResponseEntity expected = new ResponseEntity(
+		when(asyncRequestTimeoutException.getLocalizedMessage()).thenReturn("localized message");
+		assertEquals(handler.handleSpringException(asyncRequestTimeoutException, handlerMethod), new ResponseEntity<>(
 				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.SERVICE_UNAVAILABLE);
-		AsyncRequestTimeoutException exception = mock(AsyncRequestTimeoutException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+				SERVICE_UNAVAILABLE));
 	}
 
 	@Test
 	public void testBindException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(bindException.getGlobalErrors()).thenReturn(ImmutableList.of(globalError));
+		when(bindException.getFieldErrors()).thenReturn(ImmutableList.of(fieldError));
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		BindException exception = mock(BindException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(bindException, handlerMethod), new ResponseEntity<>(
+				new ErrorMessageResponse(ImmutableList.of(
+						new ErrorMessageResponse.ErrorMessage("'entityCollectionRequestV2' must have two fields set",
+								"TwoFieldsSet"), new ErrorMessageResponse.ErrorMessage(
+								"Field 'num' of 'entityCollectionRequestV2' must be greater than or equal to 0",
+								"Min"))), BAD_REQUEST));
 	}
 
 	@Test
 	public void testMissingServletRequestPartException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(missingServletRequestPartException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		MissingServletRequestPartException exception = mock(MissingServletRequestPartException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(missingServletRequestPartException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						BAD_REQUEST));
 	}
 
 	@Test
 	public void testMethodArgumentNotValidException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(methodArgumentNotValidException.getBindingResult()).thenReturn(bindingResult);
+		when(bindingResult.getGlobalErrors()).thenReturn(ImmutableList.of(globalError));
+		when(bindingResult.getFieldErrors()).thenReturn(ImmutableList.of(fieldError));
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		MethodArgumentNotValidException exception = mock(MethodArgumentNotValidException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(methodArgumentNotValidException, handlerMethod),
+				new ResponseEntity<>(new ErrorMessageResponse(ImmutableList.of(
+						new ErrorMessageResponse.ErrorMessage("'entityCollectionRequestV2' must have two fields set",
+								"TwoFieldsSet"), new ErrorMessageResponse.ErrorMessage(
+								"Field 'num' of 'entityCollectionRequestV2' must be greater than or equal to 0",
+								"Min"))), BAD_REQUEST));
 	}
 
 	@Test
 	public void testHttpMessageNotWritableException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(httpMessageNotWritableException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.INTERNAL_SERVER_ERROR);
-		HttpMessageNotWritableException exception = mock(HttpMessageNotWritableException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(httpMessageNotWritableException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						INTERNAL_SERVER_ERROR));
 	}
 
 	@Test
 	public void testHttpMessageNotReadableException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(httpMessageNotReadableException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		HttpMessageNotReadableException exception = mock(HttpMessageNotReadableException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(httpMessageNotReadableException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						BAD_REQUEST));
 	}
 
 	@Test
 	public void testTypeMismatchException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(typeMismatchException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		TypeMismatchException exception = mock(TypeMismatchException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(typeMismatchException, handlerMethod), new ResponseEntity<>(
+				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")), BAD_REQUEST));
 	}
 
 	@Test
 	public void testConversionNotSupportedException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(conversionNotSupportedException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.INTERNAL_SERVER_ERROR);
-		ConversionNotSupportedException exception = mock(ConversionNotSupportedException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(conversionNotSupportedException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						INTERNAL_SERVER_ERROR));
 	}
 
 	@Test
 	public void testServletRequestBindingException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(servletRequestBindingException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		ServletRequestBindingException exception = mock(ServletRequestBindingException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(servletRequestBindingException, handlerMethod), new ResponseEntity<>(
+				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")), BAD_REQUEST));
 	}
 
 	@Test
 	public void testMissingServletRequestParameterExceptionn()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(missingServletRequestParameterException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.BAD_REQUEST);
-		MissingServletRequestParameterException exception = mock(MissingServletRequestParameterException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(missingServletRequestParameterException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						BAD_REQUEST));
 	}
 
 	@Test
 	public void testMissingPathVariableException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(missingPathVariableException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
+		assertEquals(handler.handleSpringException(missingPathVariableException, handlerMethod), new ResponseEntity<>(
 				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.INTERNAL_SERVER_ERROR);
-		MissingPathVariableException exception = mock(MissingPathVariableException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+				INTERNAL_SERVER_ERROR));
 	}
 
 	@Test
 	public void testHttpMediaTypeNotAcceptableException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(httpMediaTypeNotAcceptableException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.NOT_ACCEPTABLE);
-		HttpMediaTypeNotAcceptableException exception = mock(HttpMediaTypeNotAcceptableException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(httpMediaTypeNotAcceptableException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						NOT_ACCEPTABLE));
 	}
 
 	@Test
 	public void testHttpMediaTypeNotSupportedException()
 	{
-		HandlerMethod handlerMethod = mock(HandlerMethod.class);
 		when(handlerMethod.hasMethodAnnotation(ResponseBody.class)).thenReturn(true);
+		when(httpMediaTypeNotSupportedException.getLocalizedMessage()).thenReturn("localized message");
 
-		ResponseEntity expected = new ResponseEntity(
-				new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
-				HttpStatus.UNSUPPORTED_MEDIA_TYPE);
-		HttpMediaTypeNotSupportedException exception = mock(HttpMediaTypeNotSupportedException.class);
-		when(exception.getLocalizedMessage()).thenReturn("localized message");
-
-		assertEquals(handler.handleSpringException(exception, handlerMethod), expected);
+		assertEquals(handler.handleSpringException(httpMediaTypeNotSupportedException, handlerMethod),
+				new ResponseEntity<>(
+						new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+						UNSUPPORTED_MEDIA_TYPE));
 	}
 }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [nvt] User documentation updated
- [nvt] (If you have changed REST API interface) view-swagger.ftl updated
- [nvt] Test plan template updated
- [x] Clean commits
