### PR TITLE
[Feature] Add submitDate timestamp when questionnaire is submitted

### DIFF
--- a/docs/user_documentation/guide-questionnaire.md
+++ b/docs/user_documentation/guide-questionnaire.md
@@ -27,6 +27,10 @@ questionnaires.
 The cool feature in the questionnaire module is that you can show certain questions based on the answer given on other questions.
 You do this by using the __Javascript Magma syntax__ to create an expression inside the visible column (See driverslicence in the simple questionnaire example).
 
+## Questionnaire timestamp on submit
+MOLGENIS will automatically add a submit date for you when you submit a questionnaire. So keep in mind that you do not have to manually
+add a question relating to submit dates.
+
 # Using Questionnaire data
 You can access the questionnaire results through the data explorer.
 Go to the data explorer and look for the (in our case) Simple Questionnaire table.

--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Questionnaire.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Questionnaire.js
@@ -128,14 +128,21 @@ var Questionnaire = React.createClass({
             var attrName = arr[i].name;
             var attr = this.state.entity.allAttributes[attrName];
 
-            //Set value of attribute with visibleExpression that is not visible to null
-            if (attr.visibleExpression && evalScript(attr.visibleExpression, values) === false) {
-                arr[i].value = null;
-            }
-
             //Set status to SUBMITTED
             if (attrName === 'status') {
                 arr[i].value = 'SUBMITTED';
+            }
+
+            if (attrName === 'submitDate') {
+              // Generate submit timestamp
+              var currentTime = moment().toISOString();
+              arr[i].value = currentTime
+            }
+
+            // Set value of attribute with visibleExpression that is not visible to null
+            // Ignore the submitDate attribute. This should never be set to null
+            if (attr.visibleExpression && evalScript(attr.visibleExpression, values) === false && attrName !== 'submitDate') {
+                arr[i].value = null;
             }
         }
     },

--- a/molgenis-questionnaires/src/main/java/org/molgenis/questionnaires/QuestionnaireMetaData.java
+++ b/molgenis-questionnaires/src/main/java/org/molgenis/questionnaires/QuestionnaireMetaData.java
@@ -8,9 +8,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
+import static org.molgenis.data.meta.AttributeType.DATE_TIME;
 import static org.molgenis.data.meta.AttributeType.ENUM;
 import static org.molgenis.data.meta.model.Package.PACKAGE_SEPARATOR;
 import static org.molgenis.data.system.model.RootSystemPackage.PACKAGE_SYSTEM;
+import static org.molgenis.questionnaires.QuestionnaireStatus.SUBMITTED;
 
 /**
  * Base EntityType for 'questionnaire' entities
@@ -22,6 +24,7 @@ public class QuestionnaireMetaData extends SystemEntityType
 	public static final String QUESTIONNAIRE = PACKAGE_SYSTEM + PACKAGE_SEPARATOR + SIMPLE_NAME;
 
 	public static final String ATTR_STATUS = "status";
+	public static final String SUBMIT_DATE = "submitDate";
 
 	private final OwnedEntityType ownedEntityType;
 
@@ -43,6 +46,15 @@ public class QuestionnaireMetaData extends SystemEntityType
 		{
 			enumOptions.add(questionnaireStatus.toString());
 		}
+
 		addAttribute(ATTR_STATUS).setDataType(ENUM).setEnumOptions(enumOptions).setVisible(false).setNillable(false);
+
+		// Attribute turns required and visible when questionnaire is submitted
+		addAttribute(SUBMIT_DATE).setDataType(DATE_TIME)
+								 .setLabel("Submit date")
+								 .setNullableExpression(
+										 "$('" + ATTR_STATUS + "').value() !== '" + SUBMITTED.toString() + "'")
+								 .setVisibleExpression(
+										 "$('" + ATTR_STATUS + "').value() === '" + SUBMITTED.toString() + "'");
 	}
 }


### PR DESCRIPTION
## Implementation
- A questionnaire always gets a 'submitDate' attribute
- This attribute becomes visible when the questionnaire status === SUBMITTED
- This attribute becomes required when the questionnaire status === SUBMITTED
- The value is inserted when the questionnaire status is set to SUBMITTED

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes

#### Screenshots
##### In the dataexplorer
![screen shot 2018-01-23 at 17 05 26](https://user-images.githubusercontent.com/3625016/35286239-bb47f090-005f-11e8-853a-0bc9ff77636b.png)


##### In the submitted questionnaire form
![screen shot 2018-01-23 at 17 05 52](https://user-images.githubusercontent.com/3625016/35286247-bec919ec-005f-11e8-8539-357fd6cc93e0.png)



