### PR TITLE
Fix #7095: Travis build times out

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ cache:
     - '$HOME/.m2/repository'
     - '$HOME/.sonar/cache'
     - '$HOME/Library/Caches/Yarn'
+env:
+  - MAVEN_TESTS="./mvnw verify --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -DskipITs"
+  # Travis aborts a job if it doesn't write to console for more than 10 minutes, use travis_wait to prevent this
+  - MAVEN_TESTS="travis_wait 40 ./mvnw verify --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password -DskipUTs"
 services:
   - postgresql
 addons:
@@ -18,13 +22,11 @@ before_install:
   # Use wrapper script to install fixed maven version
   - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
 install:
-  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -T4
+  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:
-  # Travis aborts a job if it doesn't write to console for more than 10 minutes, use travis_wait to prevent this
-  # Travis provides us with a travis user and travis database
-  - travis_wait 50 ./mvnw verify --batch-mode --quiet -T4 -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password
+  - $MAVEN_TESTS
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,13 @@ before_install:
   # Use wrapper script to install fixed maven version
   - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
 install:
-  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V -T4
 before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:
   # Travis aborts a job if it doesn't write to console for more than 10 minutes, use travis_wait to prevent this
   # Travis provides us with a travis user and travis database
-  - travis_wait 40 ./mvnw verify --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password
+  - travis_wait 50 ./mvnw verify --batch-mode --quiet -T4 -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password
 notifications:
   slack:
     rooms:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   # Use wrapper script to install fixed maven version
   - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
 install:
-  - ./mvnw install -DskipTests -Dmaven.javadoc.skip=true -B -V
+  - ./mvnw install -DskipTests -Dmaven.javadoc.skip=true -B -V -T4
 before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
   # Use wrapper script to install fixed maven version
   - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
 install:
-  - ./mvnw install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+  - ./mvnw install -DskipTests -Dmaven.javadoc.skip=true -B -V
 before_script:
   - sudo sysctl -w vm.max_map_count=262144
 script:

--- a/molgenis-api-tests/pom.xml
+++ b/molgenis-api-tests/pom.xml
@@ -30,6 +30,9 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>sql-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>create postgres integration database</id>
@@ -63,6 +66,9 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>reserve-network-port</id>
@@ -77,6 +83,9 @@
                     <plugin>
                         <groupId>com.github.alexcojocaru</groupId>
                         <artifactId>elasticsearch-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>start-elasticsearch</id>
@@ -117,6 +126,9 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
+                <configuration>
+                    <skip>${skipITs}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>reserve-mail-network-ports</id>
@@ -137,6 +149,7 @@
                         <goals><goal>reserve-network-port</goal></goals>
                         <phase>process-resources</phase>
                         <configuration>
+                            <skip>${skipITs}</skip>
                             <portNames>
                                 <portName>cargo.rmi.port</portName>
                                 <portName>cargo.servlet.port</portName>
@@ -151,6 +164,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>2.2</version>
+                <configuration>
+                    <skip>${skipITs}</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <id>unpack</id>
@@ -175,6 +191,7 @@
                 <groupId>org.codehaus.cargo</groupId>
                 <artifactId>cargo-maven2-plugin</artifactId>
                 <configuration>
+                    <skip>${skipITs}</skip>
                     <container>
                         <containerId>tomcat7x</containerId>
                         <zipUrlInstaller>

--- a/molgenis-metadata-manager/pom.xml
+++ b/molgenis-metadata-manager/pom.xml
@@ -74,7 +74,7 @@
                         </goals>
                         <configuration>
                             <skip>${skip.js}</skip>
-                            <arguments>--frozen-lockfile</arguments>
+                            <arguments>--mutex network --frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-navigator/pom.xml
+++ b/molgenis-navigator/pom.xml
@@ -73,7 +73,7 @@
                         </goals>
                         <configuration>
                             <skip>${skip.js}</skip>
-                            <arguments>--frozen-lockfile</arguments>
+                            <arguments>--mutex network --frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-one-click-importer/pom.xml
+++ b/molgenis-one-click-importer/pom.xml
@@ -76,7 +76,7 @@
                         </goals>
                         <configuration>
                             <skip>${skip.js}</skip>
-                            <arguments>--frozen-lockfile</arguments>
+                            <arguments>--mutex network --frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/molgenis-platform-integration-tests/pom.xml
+++ b/molgenis-platform-integration-tests/pom.xml
@@ -29,6 +29,9 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>sql-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>create postgres integration database</id>
@@ -76,6 +79,9 @@
                     <plugin>
                         <groupId>com.github.alexcojocaru</groupId>
                         <artifactId>elasticsearch-maven-plugin</artifactId>
+                        <configuration>
+                            <skip>${skipITs}</skip>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>start-elasticsearch</id>
@@ -106,6 +112,7 @@
                             <goal>unpack-dependencies</goal>
                         </goals>
                         <configuration>
+                            <skip>${skipITs}</skip>
                             <includeGroupIds>${project.groupId}</includeGroupIds>
                             <includeArtifactIds>molgenis-data-elasticsearch</includeArtifactIds>
                             <excludeTransitive>true</excludeTransitive>

--- a/molgenis-searchall/pom.xml
+++ b/molgenis-searchall/pom.xml
@@ -74,7 +74,7 @@
                         </goals>
                         <configuration>
                             <skip>${skip.js}</skip>
-                            <arguments>--frozen-lockfile</arguments>
+                            <arguments>--mutex network --frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,12 @@
 
         <!-- plugin versions -->
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
+
+        <!-- skip stuff -->
         <skip.js>false</skip.js>
+        <skipTests>false</skipTests>
+        <skipITs>${skipTests}</skipITs>
+        <skipUTs>${skipTests}</skipUTs>
 
         <!-- dependency versions -->
         <slf4j.version>1.7.25</slf4j.version><!-- must match version in logback-parent pom -->
@@ -305,6 +310,7 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.19.1</version>
                     <configuration>
+                        <skip>${skipUTs}</skip>
                         <argLine>${argLine}</argLine>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
Splits the build into two travis jobs, one for the unit tests and one for the integration tests.
During the build phase of both jobs, builds the artifacts in parallel.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
