### PR TITLE
Fix #7157 Rest request handler fail to recognise json response

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/package.json
+++ b/molgenis-metadata-manager/src/main/frontend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --ext .js,.vue src test/unit/specs"
   },
   "dependencies": {
-    "@molgenis/molgenis-api-client": "^2.1.0",
+    "@molgenis/molgenis-api-client": "^2.1.3",
     "@molgenis/molgenis-i18n-js": "^0.0.5",
     "@molgenis/molgenis-vue-test-utils": "^1.0.0",
     "flow": "^0.2.3",

--- a/molgenis-metadata-manager/src/main/frontend/yarn.lock
+++ b/molgenis-metadata-manager/src/main/frontend/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@molgenis/molgenis-api-client@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.0.tgz#66cdcca5c4a2e0b413be7aef27cd5559ffdcb2e2"
+"@molgenis/molgenis-api-client@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.3.tgz#9332bae3e343c78c58582687bf1c1b157e4c396f"
   dependencies:
     babel-runtime "^6.11.6"
     form-data "^2.3.1"

--- a/molgenis-navigator/src/main/frontend/package.json
+++ b/molgenis-navigator/src/main/frontend/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "eslint --ext .js,.vue src test/unit/specs"
   },
   "dependencies": {
-    "@molgenis/molgenis-api-client": "^2.1.0",
+    "@molgenis/molgenis-api-client": "^2.1.3",
     "@molgenis/molgenis-i18n-js": "^0.0.5",
     "@molgenis/molgenis-vue-test-utils": "^1.0.0",
     "bootstrap-vue": "^1.4.1",

--- a/molgenis-navigator/src/main/frontend/yarn.lock
+++ b/molgenis-navigator/src/main/frontend/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@molgenis/molgenis-api-client@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.0.tgz#66cdcca5c4a2e0b413be7aef27cd5559ffdcb2e2"
+"@molgenis/molgenis-api-client@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.3.tgz#9332bae3e343c78c58582687bf1c1b157e4c396f"
   dependencies:
     babel-runtime "^6.11.6"
     form-data "^2.3.1"

--- a/molgenis-one-click-importer/src/main/frontend/package.json
+++ b/molgenis-one-click-importer/src/main/frontend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --ext .js,.vue src test/unit/specs"
   },
   "dependencies": {
-    "@molgenis/molgenis-api-client": "^2.1.0",
+    "@molgenis/molgenis-api-client": "^2.1.3",
     "@molgenis/molgenis-i18n-js": "^0.0.5",
     "@molgenis/molgenis-vue-test-utils": "^1.0.0",
     "font-awesome": "^4.7.0",

--- a/molgenis-one-click-importer/src/main/frontend/yarn.lock
+++ b/molgenis-one-click-importer/src/main/frontend/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@molgenis/molgenis-api-client@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.0.tgz#66cdcca5c4a2e0b413be7aef27cd5559ffdcb2e2"
+"@molgenis/molgenis-api-client@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.3.tgz#9332bae3e343c78c58582687bf1c1b157e4c396f"
   dependencies:
     babel-runtime "^6.11.6"
     form-data "^2.3.1"

--- a/molgenis-searchall/src/main/frontend/package.json
+++ b/molgenis-searchall/src/main/frontend/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --fix --ext .js,.vue src test/unit/specs"
   },
   "dependencies": {
-    "@molgenis/molgenis-api-client": "^2.1.0",
+    "@molgenis/molgenis-api-client": "^2.1.3",
     "@molgenis/molgenis-i18n-js": "^0.0.5",
     "@molgenis/molgenis-vue-test-utils": "^1.0.0",
     "flow": "^0.2.3",

--- a/molgenis-searchall/src/main/frontend/yarn.lock
+++ b/molgenis-searchall/src/main/frontend/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@molgenis/molgenis-api-client@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.0.tgz#66cdcca5c4a2e0b413be7aef27cd5559ffdcb2e2"
+"@molgenis/molgenis-api-client@^2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@molgenis/molgenis-api-client/-/molgenis-api-client-2.1.3.tgz#9332bae3e343c78c58582687bf1c1b157e4c396f"
   dependencies:
     babel-runtime "^6.11.6"
     form-data "^2.3.1"
@@ -3021,9 +3021,13 @@ i18next@^7.1.3:
   version "7.2.3"
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-7.2.3.tgz#a6c220ac1c8240ff1078aa9bc997fd449e052dc7"
 
-iconv-lite@0.4.15, iconv-lite@~0.4.13:
+iconv-lite@0.4.15:
   version "0.4.15"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.15.tgz#fe265a218ac6a57cfe854927e9d04c19825eddeb"
+
+iconv-lite@~0.4.13:
+  version "0.4.19"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
 
 icss-replace-symbols@^1.1.0:
   version "1.1.0"
@@ -4046,8 +4050,8 @@ no-case@^2.2.0:
     lower-case "^1.1.1"
 
 node-fetch@^1.0.1:
-  version "1.7.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.2.tgz#c54e9aac57e432875233525f3c891c4159ffefd7"
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"


### PR DESCRIPTION
Fix #7157 Rest request handler fail to recognise json response update api client, updated client accepts all valid forms of content-type header value in response to denote a json response as defined in https://tools.ietf.org/html/rfc7231#section-3.1.1.5

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
