### PR TITLE
[FEATURE] Add categorical options to V2 response metadata

### DIFF
--- a/docs/developer_documentation/ref-rest2.md
+++ b/docs/developer_documentation/ref-rest2.md
@@ -81,6 +81,67 @@ GET http://molgenis.mydomain.example/api/v2/<entity_name>?aggs=x==attr0;y==attr1
 GET http://molgenis.mydomain.example/api/v2/<entity_name>?aggs=x==attr0;y==attr1;distinct=attr2&q=attr4==val
 ```
 
+## Including categorical options
+
+For simple lookup lists, it might be a convenience to include the list in the initial API response.
+You can do this for CATEGORICAL, and CATEGORICAL_MREF attributes using `includeCategories`.
+
+Not including the query option will set it to the default `false`.
+
+Key | Type | Description
+--- | --- | ---
+*includeCategories* | boolean | Includes a list of categorical options in attribute metadata for CATEGORICAL and CATEGORICAL_MREF attributes
+
+## Example request - response
+**TableA**
+
+| id | category |
+|----|----------|
+| 1  | A        |
+
+**TableB**
+
+| id | label |
+|----|-------|
+| A  | A very awesome category |
+| B  | A very busy category |
+| C  | A very complex category |
+
+*Request*
+```
+GET http://molgenis.mydomain.example/api/v2/TableA?includeCategories=true
+```
+
+*Response*
+```json
+{
+  "meta": {
+    "attributes": [
+      {
+        "name": "id"
+      },
+      {
+        "name": "category",
+        "categoricalOptions": [
+          {
+            "id": "A",
+            "label": "A very awesome category"
+          },
+          {
+            "id": "B",
+            "label": "A very busy category"
+          },
+          {
+            "id": "C",
+            "label": "A very complex category"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 # Batch 
 
 When working with larger datasets the RESTv2 api provides batching via the 'entities' parameter:

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
@@ -154,7 +154,7 @@ public class RestControllerV2APIIT
 	}
 
 	@Test
-	public void testRetrieveEntityIncludingCategories()
+	public void testRetrieveEntityIncludingCategoriesTest()
 	{
 		ValidatableResponse response = given().log()
 											  .all()

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
@@ -154,6 +154,53 @@ public class RestControllerV2APIIT
 	}
 
 	@Test
+	public void testRetrieveEntityIncludingCategories()
+	{
+		ValidatableResponse response = given().log()
+											  .all()
+											  .header(X_MOLGENIS_TOKEN, testUserToken)
+											  .param("includeCategories", newArrayList("true"))
+											  .param("attrs", newArrayList("xcategorical_value"))
+											  .get(API_V2 + "V2_API_TypeTestAPIV2/1")
+											  .then()
+											  .log()
+											  .all();
+		response.statusCode(OKE);
+		response.body("_meta.attributes[0].categoricalOptions.id", Matchers.hasItems("ref1", "ref2","ref3"));
+	}
+
+	@Test
+	public void testRetrieveEntityExcludingCategoriesResultsInNoCategoricalOptions()
+	{
+		ValidatableResponse response = given().log()
+											  .all()
+											  .header(X_MOLGENIS_TOKEN, testUserToken)
+											  .param("includeCategories", newArrayList("false"))
+											  .param("attrs", newArrayList("xcategorical_value"))
+											  .get(API_V2 + "V2_API_TypeTestAPIV2/1")
+											  .then()
+											  .log()
+											  .all();
+		response.statusCode(OKE);
+		response.body("_meta.attributes[0].categoricalOptions", Matchers.nullValue());
+	}
+
+	@Test
+	public void testRetrieveEntityWithoutSettingCategoriesResultsInNoCategoricalOptions()
+	{
+		ValidatableResponse response = given().log()
+											  .all()
+											  .header(X_MOLGENIS_TOKEN, testUserToken)
+											  .param("attrs", newArrayList("xcategorical_value"))
+											  .get(API_V2 + "V2_API_TypeTestAPIV2/1")
+											  .then()
+											  .log()
+											  .all();
+		response.statusCode(OKE);
+		response.body("_meta.attributes[0].categoricalOptions", Matchers.nullValue());
+	}
+
+	@Test
 	public void testRetrieveEntityWithAttributeFilterPost()
 	{
 		ValidatableResponse response = given().log()

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
@@ -154,7 +154,7 @@ public class RestControllerV2APIIT
 	}
 
 	@Test
-	public void testRetrieveEntityIncludingCategoriesTest()
+	public void testRetrieveEntityIncludingCategories()
 	{
 		ValidatableResponse response = given().log()
 											  .all()

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeResponseV2.java
@@ -49,8 +49,7 @@ class AttributeResponseV2
 	 * Constructs AttributeResponseV2 using params
 	 *
 	 * @param fetch             set of lowercase attribute names to include in response
-	 * @param includeCategories if set to true fetches options list for CATEGORICAL and CATEGORICAL_MREF types,
-	 *                          if set to false references to the entities are returned
+	 * @param includeCategories if set to true includes options list for CATEGORICAL and CATEGORICAL_MREF types in the attribute metadata
 	 */
 	public AttributeResponseV2(final String entityParentName, EntityType entityType, Attribute attr, Fetch fetch,
 			UserPermissionEvaluator permissionService, DataService dataService, boolean includeCategories)
@@ -142,7 +141,7 @@ class AttributeResponseV2
 	}
 
 	/**
-	 * Default AttributeResponseV2 with @param isCategoricalGetEager set to false
+	 * Default AttributeResponseV2 with @param includeCategories set to false
 	 *
 	 * @param fetch set of lowercase attribute names to include in response
 	 */

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeResponseV2.java
@@ -1,7 +1,5 @@
 package org.molgenis.data.rest.v2;
 
-import com.google.common.collect.Iterables;
-import com.google.common.collect.Lists;
 import org.molgenis.core.ui.data.support.Href;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Fetch;
@@ -13,7 +11,9 @@ import org.molgenis.data.support.EntityTypeUtils;
 import org.molgenis.security.core.UserPermissionEvaluator;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.Streams.stream;
 import static org.molgenis.data.meta.AttributeType.COMPOUND;
 import static org.molgenis.i18n.LanguageService.getCurrentUserLanguageCode;
 
@@ -43,6 +43,7 @@ class AttributeResponseV2
 	private String nullableExpression;
 	private String visibleExpression;
 	private String validationExpression;
+	private List<CategoricalOptionV2> categoricalOptions;
 
 	/**
 	 * @param fetch set of lowercase attribute names to include in response
@@ -65,11 +66,21 @@ class AttributeResponseV2
 		if (refEntity != null)
 		{
 			this.refEntity = new EntityTypeResponseV2(refEntity, fetch, permissionService, dataService);
+
+			if (this.fieldType.equals(AttributeType.CATEGORICAL) || this.fieldType.equals(
+					AttributeType.CATEGORICAL_MREF))
+			{
+				this.categoricalOptions = dataService.findAll(refEntity.getId())
+													 .map(entity -> new CategoricalOptionV2(entity.getIdValue(),
+															 entity.getLabelValue()))
+													 .collect(Collectors.toList());
+			}
 		}
 		else
 		{
 			this.refEntity = null;
 		}
+
 		Attribute mappedByAttr = attr.getMappedBy();
 		this.mappedBy = mappedByAttr != null ? mappedByAttr.getName() : null;
 
@@ -78,34 +89,32 @@ class AttributeResponseV2
 		{
 			// filter attribute parts
 			attrParts = filterAttributes(fetch, attrParts);
-
-			// create attribute response
-			this.attributes = Lists.newArrayList(Iterables.transform(attrParts, attr1 ->
+			this.attributes = stream(attrParts).map(attrPart ->
 			{
 				Fetch subAttrFetch;
 				if (fetch != null)
 				{
-					if (attr1.getDataType() == AttributeType.COMPOUND)
+					if (attrPart.getDataType() == AttributeType.COMPOUND)
 					{
 						subAttrFetch = fetch;
 					}
 					else
 					{
-						subAttrFetch = fetch.getFetch(attr1);
+						subAttrFetch = fetch.getFetch(attrPart);
 					}
 				}
-				else if (EntityTypeUtils.isReferenceType(attr1))
+				else if (EntityTypeUtils.isReferenceType(attrPart))
 				{
-					subAttrFetch = AttributeFilterToFetchConverter.createDefaultAttributeFetch(attr1,
+					subAttrFetch = AttributeFilterToFetchConverter.createDefaultAttributeFetch(attrPart,
 							getCurrentUserLanguageCode());
 				}
 				else
 				{
 					subAttrFetch = null;
 				}
-				return new AttributeResponseV2(entityParentName, entityType, attr1, subAttrFetch, permissionService,
+				return new AttributeResponseV2(entityParentName, entityType, attrPart, subAttrFetch, permissionService,
 						dataService);
-			}));
+			}).collect(Collectors.toList());
 		}
 		else
 		{
@@ -131,7 +140,7 @@ class AttributeResponseV2
 	{
 		if (fetch != null)
 		{
-			return Iterables.filter(attrs, attr -> filterAttributeRec(fetch, attr));
+			return stream(attrs).filter(attr -> filterAttributeRec(fetch, attr)).collect(Collectors.toList());
 		}
 		else
 		{
@@ -301,5 +310,10 @@ class AttributeResponseV2
 	public String getValidationExpression()
 	{
 		return validationExpression;
+	}
+
+	public List<CategoricalOptionV2> getCategoricalOptions()
+	{
+		return categoricalOptions;
 	}
 }

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/AttributeResponseV2.java
@@ -46,10 +46,14 @@ class AttributeResponseV2
 	private List<CategoricalOptionV2> categoricalOptions;
 
 	/**
-	 * @param fetch set of lowercase attribute names to include in response
+	 * Constructs AttributeResponseV2 using params
+	 *
+	 * @param fetch             set of lowercase attribute names to include in response
+	 * @param includeCategories if set to true fetches options list for CATEGORICAL and CATEGORICAL_MREF types,
+	 *                          if set to false references to the entities are returned
 	 */
 	public AttributeResponseV2(final String entityParentName, EntityType entityType, Attribute attr, Fetch fetch,
-			UserPermissionEvaluator permissionService, DataService dataService)
+			UserPermissionEvaluator permissionService, DataService dataService, boolean includeCategories)
 	{
 		String attrName = attr.getName();
 		this.href = Href.concatMetaAttributeHref(RestControllerV2.BASE_URI, entityParentName, attrName);
@@ -65,10 +69,11 @@ class AttributeResponseV2
 		EntityType refEntity = attr.getRefEntity();
 		if (refEntity != null)
 		{
-			this.refEntity = new EntityTypeResponseV2(refEntity, fetch, permissionService, dataService);
+			this.refEntity = new EntityTypeResponseV2(refEntity, fetch, permissionService, dataService,
+					includeCategories);
 
-			if (this.fieldType.equals(AttributeType.CATEGORICAL) || this.fieldType.equals(
-					AttributeType.CATEGORICAL_MREF))
+			if (includeCategories && (this.fieldType.equals(AttributeType.CATEGORICAL) || this.fieldType.equals(
+					AttributeType.CATEGORICAL_MREF)))
 			{
 				this.categoricalOptions = dataService.findAll(refEntity.getId())
 													 .map(entity -> new CategoricalOptionV2(entity.getIdValue(),
@@ -134,6 +139,17 @@ class AttributeResponseV2
 		this.nullableExpression = attr.getNullableExpression();
 		this.visibleExpression = attr.getVisibleExpression();
 		this.validationExpression = attr.getValidationExpression();
+	}
+
+	/**
+	 * Default AttributeResponseV2 with @param isCategoricalGetEager set to false
+	 *
+	 * @param fetch set of lowercase attribute names to include in response
+	 */
+	public AttributeResponseV2(final String entityParentName, EntityType entityType, Attribute attr, Fetch fetch,
+			UserPermissionEvaluator permissionService, DataService dataService)
+	{
+		this(entityParentName, entityType, attr, fetch, permissionService, dataService, false);
 	}
 
 	public static Iterable<Attribute> filterAttributes(Fetch fetch, Iterable<Attribute> attrs)

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/CategoricalOptionV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/CategoricalOptionV2.java
@@ -1,0 +1,23 @@
+package org.molgenis.data.rest.v2;
+
+public class CategoricalOptionV2
+{
+	private Object id;
+	private Object label;
+
+	public CategoricalOptionV2(Object id, Object label)
+	{
+		this.id = id;
+		this.label = label;
+	}
+
+	public Object getId()
+	{
+		return id;
+	}
+
+	public Object getLabel()
+	{
+		return label;
+	}
+}

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityCollectionResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityCollectionResponseV2.java
@@ -37,10 +37,11 @@ class EntityCollectionResponseV2
 	public EntityCollectionResponseV2(EntityPager entityPager, List<Map<String, Object>> items, Fetch fetch,
 			String href, EntityType meta, UserPermissionEvaluator permissionService, DataService dataService,
 			String prevHref,
-			String nextHref)
+			String nextHref,
+			boolean includeCategories)
 	{
 		this.href = href;
-		this.meta = new EntityTypeResponseV2(meta, fetch, permissionService, dataService);
+		this.meta = new EntityTypeResponseV2(meta, fetch, permissionService, dataService, includeCategories);
 		this.start = entityPager.getStart();
 		this.num = entityPager.getNum();
 		this.total = entityPager.getTotal();

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityTypeResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityTypeResponseV2.java
@@ -14,7 +14,9 @@ import org.molgenis.data.support.EntityTypeUtils;
 import org.molgenis.security.core.UserPermissionEvaluator;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static com.google.common.collect.Streams.stream;
 import static org.molgenis.data.meta.AttributeType.COMPOUND;
 import static org.molgenis.data.rest.v2.AttributeResponseV2.filterAttributes;
 import static org.molgenis.data.rest.v2.RestControllerV2.BASE_URI;
@@ -60,12 +62,12 @@ class EntityTypeResponseV2
 		// filter attribute parts
 		Iterable<Attribute> filteredAttrs = filterAttributes(fetch, meta.getAttributes());
 
-		this.attributes = Lists.newArrayList(Iterables.transform(filteredAttrs, attr ->
+		this.attributes = stream(filteredAttrs).map(attr ->
 		{
-			Fetch subAttrFetch;
+			Fetch subAttrFetch = null;
 			if (fetch != null)
 			{
-				if (attr.getDataType() == COMPOUND)
+				if (attr.getDataType().equals(COMPOUND))
 				{
 					subAttrFetch = fetch;
 				}
@@ -78,12 +80,8 @@ class EntityTypeResponseV2
 			{
 				subAttrFetch = AttributeFilterToFetchConverter.createDefaultAttributeFetch(attr, languageCode);
 			}
-			else
-			{
-				subAttrFetch = null;
-			}
 			return new AttributeResponseV2(name, meta, attr, subAttrFetch, permissionService, dataService);
-		}));
+		}).collect(Collectors.toList());
 
 		languageCode = getCurrentUserLanguageCode();
 

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityTypeResponseV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/EntityTypeResponseV2.java
@@ -40,16 +40,17 @@ class EntityTypeResponseV2
 	private final Boolean writable;
 	private String languageCode;
 
-	public EntityTypeResponseV2(EntityType meta, UserPermissionEvaluator permissionService, DataService dataService)
+	public EntityTypeResponseV2(EntityType meta, UserPermissionEvaluator permissionService, DataService dataService,
+			boolean includeCategories)
 	{
-		this(meta, null, permissionService, dataService);
+		this(meta, null, permissionService, dataService, includeCategories);
 	}
 
 	/**
 	 * @param fetch set of lowercase attribute names to include in response
 	 */
 	public EntityTypeResponseV2(EntityType meta, Fetch fetch, UserPermissionEvaluator permissionService,
-			DataService dataService)
+			DataService dataService, boolean includeCategories)
 	{
 		String name = meta.getId();
 		this.href = Href.concatMetaEntityHrefV2(BASE_URI, name);
@@ -80,7 +81,7 @@ class EntityTypeResponseV2
 			{
 				subAttrFetch = AttributeFilterToFetchConverter.createDefaultAttributeFetch(attr, languageCode);
 			}
-			return new AttributeResponseV2(name, meta, attr, subAttrFetch, permissionService, dataService);
+			return new AttributeResponseV2(name, meta, attr, subAttrFetch, permissionService, dataService, includeCategories);
 		}).collect(Collectors.toList());
 
 		languageCode = getCurrentUserLanguageCode();

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
@@ -638,7 +638,7 @@ public class RestControllerV2
 	}
 
 	private EntityCollectionResponseV2 createEntityCollectionResponse(String entityTypeId,
-			EntityCollectionRequestV2 request, HttpServletRequest httpRequest, boolean includeLookup)
+			EntityCollectionRequestV2 request, HttpServletRequest httpRequest, boolean includeCategories)
 	{
 		EntityType meta = dataService.getEntityType(entityTypeId);
 
@@ -709,7 +709,7 @@ public class RestControllerV2
 			}
 
 			return new EntityCollectionResponseV2(pager, entities, fetch, BASE_URI + '/' + entityTypeId, meta,
-					permissionService, dataService, prevHref, nextHref, includeLookup);
+					permissionService, dataService, prevHref, nextHref, includeCategories);
 		}
 	}
 
@@ -733,20 +733,20 @@ public class RestControllerV2
 		return createEntityResponse(entity, fetch, includeMetaData, false);
 	}
 
-	private Map<String, Object> createEntityResponse(Entity entity, Fetch fetch, boolean includeMetaData, boolean includeLookup)
+	private Map<String, Object> createEntityResponse(Entity entity, Fetch fetch, boolean includeMetaData, boolean includeCategories)
 	{
 		Map<String, Object> responseData = new LinkedHashMap<>();
 		if (includeMetaData)
 		{
-			createEntityTypeResponse(entity.getEntityType(), fetch, responseData, includeLookup);
+			createEntityTypeResponse(entity.getEntityType(), fetch, responseData, includeCategories);
 		}
 		createEntityValuesResponse(entity, fetch, responseData);
 		return responseData;
 	}
 
-	private void createEntityTypeResponse(EntityType entityType, Fetch fetch, Map<String, Object> responseData, boolean includeLookup)
+	private void createEntityTypeResponse(EntityType entityType, Fetch fetch, Map<String, Object> responseData, boolean includeCategories)
 	{
-		responseData.put("_meta", new EntityTypeResponseV2(entityType, fetch, permissionService, dataService, includeLookup));
+		responseData.put("_meta", new EntityTypeResponseV2(entityType, fetch, permissionService, dataService, includeCategories));
 	}
 
 	private void createEntityValuesResponse(Entity entity, Fetch fetch, Map<String, Object> responseData)

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/v2/RestControllerV2.java
@@ -159,9 +159,10 @@ public class RestControllerV2
 	@GetMapping("/{entityTypeId}/{id:.+}")
 	public Map<String, Object> retrieveEntity(@PathVariable("entityTypeId") String entityTypeId,
 			@PathVariable("id") String untypedId,
-			@RequestParam(value = "attrs", required = false) AttributeFilter attributeFilter)
+			@RequestParam(value = "attrs", required = false) AttributeFilter attributeFilter,
+			@RequestParam(value = "includeCategories", defaultValue = "false") boolean includeCategories)
 	{
-		return getEntityResponse(entityTypeId, untypedId, attributeFilter);
+		return getEntityResponse(entityTypeId, untypedId, attributeFilter, includeCategories);
 	}
 
 	/**
@@ -170,13 +171,14 @@ public class RestControllerV2
 	@PostMapping(value = "/{entityTypeId}/{id:.+}", params = "_method=GET")
 	public Map<String, Object> retrieveEntityPost(@PathVariable("entityTypeId") String entityTypeId,
 			@PathVariable("id") String untypedId,
-			@RequestParam(value = "attrs", required = false) AttributeFilter attributeFilter)
+			@RequestParam(value = "attrs", required = false) AttributeFilter attributeFilter,
+			@RequestParam(value = "includeCategories", defaultValue = "false") boolean includeCategories)
 	{
-		return getEntityResponse(entityTypeId, untypedId, attributeFilter);
+		return getEntityResponse(entityTypeId, untypedId, attributeFilter, includeCategories);
 	}
 
 	private Map<String, Object> getEntityResponse(String entityTypeId, String untypedId,
-			AttributeFilter attributeFilter)
+			AttributeFilter attributeFilter, boolean includeCategories)
 	{
 		EntityType entityType = dataService.getEntityType(entityTypeId);
 		Object id = getTypedValue(untypedId, entityType.getIdAttribute());
@@ -190,7 +192,7 @@ public class RestControllerV2
 			throw new UnknownEntityException(entityTypeId + " [" + untypedId + "] not found");
 		}
 
-		return createEntityResponse(entity, fetch, true);
+		return createEntityResponse(entity, fetch, true, includeCategories);
 	}
 
 	@Transactional
@@ -235,16 +237,18 @@ public class RestControllerV2
 	 */
 	@GetMapping("/{entityTypeId}")
 	public EntityCollectionResponseV2 retrieveEntityCollection(@PathVariable("entityTypeId") String entityTypeId,
-			@Valid EntityCollectionRequestV2 request, HttpServletRequest httpRequest)
+			@Valid EntityCollectionRequestV2 request, HttpServletRequest httpRequest,
+			@RequestParam(value = "includeCategories", defaultValue = "false") boolean includeCategories)
 	{
-		return createEntityCollectionResponse(entityTypeId, request, httpRequest);
+		return createEntityCollectionResponse(entityTypeId, request, httpRequest, includeCategories);
 	}
 
 	@PostMapping(value = "/{entityTypeId}", params = "_method=GET")
 	public EntityCollectionResponseV2 retrieveEntityCollectionPost(@PathVariable("entityTypeId") String entityTypeId,
-			@Valid EntityCollectionRequestV2 request, HttpServletRequest httpRequest)
+			@Valid EntityCollectionRequestV2 request, HttpServletRequest httpRequest,
+			@RequestParam(value = "includeCategories", defaultValue = "false") boolean includeCategories)
 	{
-		return createEntityCollectionResponse(entityTypeId, request, httpRequest);
+		return createEntityCollectionResponse(entityTypeId, request, httpRequest, includeCategories);
 	}
 
 	/**
@@ -634,7 +638,7 @@ public class RestControllerV2
 	}
 
 	private EntityCollectionResponseV2 createEntityCollectionResponse(String entityTypeId,
-			EntityCollectionRequestV2 request, HttpServletRequest httpRequest)
+			EntityCollectionRequestV2 request, HttpServletRequest httpRequest, boolean includeLookup)
 	{
 		EntityType meta = dataService.getEntityType(entityTypeId);
 
@@ -705,7 +709,7 @@ public class RestControllerV2
 			}
 
 			return new EntityCollectionResponseV2(pager, entities, fetch, BASE_URI + '/' + entityTypeId, meta,
-					permissionService, dataService, prevHref, nextHref);
+					permissionService, dataService, prevHref, nextHref, includeLookup);
 		}
 	}
 
@@ -726,18 +730,23 @@ public class RestControllerV2
 
 	private Map<String, Object> createEntityResponse(Entity entity, Fetch fetch, boolean includeMetaData)
 	{
+		return createEntityResponse(entity, fetch, includeMetaData, false);
+	}
+
+	private Map<String, Object> createEntityResponse(Entity entity, Fetch fetch, boolean includeMetaData, boolean includeLookup)
+	{
 		Map<String, Object> responseData = new LinkedHashMap<>();
 		if (includeMetaData)
 		{
-			createEntityTypeResponse(entity.getEntityType(), fetch, responseData);
+			createEntityTypeResponse(entity.getEntityType(), fetch, responseData, includeLookup);
 		}
 		createEntityValuesResponse(entity, fetch, responseData);
 		return responseData;
 	}
 
-	private void createEntityTypeResponse(EntityType entityType, Fetch fetch, Map<String, Object> responseData)
+	private void createEntityTypeResponse(EntityType entityType, Fetch fetch, Map<String, Object> responseData, boolean includeLookup)
 	{
-		responseData.put("_meta", new EntityTypeResponseV2(entityType, fetch, permissionService, dataService));
+		responseData.put("_meta", new EntityTypeResponseV2(entityType, fetch, permissionService, dataService, includeLookup));
 	}
 
 	private void createEntityValuesResponse(Entity entity, Fetch fetch, Map<String, Object> responseData)

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/RestControllerV2Test.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/v2/RestControllerV2Test.java
@@ -96,8 +96,10 @@ public class RestControllerV2Test extends AbstractMolgenisSpringTest
 	private static final String REF_ENTITY1_LABEL = "label1";
 	private static final String REF_REF_ENTITY_ID = "refRef0";
 	private static final String HREF_ENTITY_COLLECTION = BASE_URI + '/' + ENTITY_NAME;
+	private static final String HREF_ENTITY_COLLECTION_INCLUDE_CATEGORIES_IS_TRUE = BASE_URI + '/' + ENTITY_NAME + "?includeCategories=true";
 	private static final String HREF_COPY_ENTITY = BASE_URI + "/copy/" + ENTITY_NAME;
 	private static final String HREF_ENTITY_ID = HREF_ENTITY_COLLECTION + '/' + ENTITY_ID;
+	private static final String HREF_ENTITY_ID_INCLUDE_CATEGORIES_IS_TRUE = HREF_ENTITY_COLLECTION + '/' + ENTITY_ID + "?includeCategories=true";
 	private static final String FIRST_ERROR_MESSAGE = "$.errors[0].message";
 	private static final String FIRST_ERROR_CODE = "$.errors[0].code";
 
@@ -449,10 +451,21 @@ public class RestControllerV2Test extends AbstractMolgenisSpringTest
 	@Test
 	public void retrieveResource() throws Exception
 	{
+		String expectedContent = readFile(getClass().getResourceAsStream("resourceResponse.json"));
 		mockMvc.perform(get(HREF_ENTITY_ID))
 			   .andExpect(status().isOk())
 			   .andExpect(content().contentType(APPLICATION_JSON_UTF8))
-			   .andExpect(content().json(readFile(getClass().getResourceAsStream("resourceResponse.json"))));
+			   .andExpect(content().json(expectedContent));
+	}
+
+	@Test
+	public void retrieveResourceIncludingCategories() throws Exception
+	{
+		String expectedContent = readFile(getClass().getResourceAsStream("resourceResponseIncludingCategories.json"));
+		mockMvc.perform(get(HREF_ENTITY_ID_INCLUDE_CATEGORIES_IS_TRUE))
+			   .andExpect(status().isOk())
+			   .andExpect(content().contentType(APPLICATION_JSON_UTF8))
+			   .andExpect(content().json(expectedContent));
 	}
 
 	@Test
@@ -520,22 +533,26 @@ public class RestControllerV2Test extends AbstractMolgenisSpringTest
 	@Test
 	public void retrieveResourcePartialResponseSubSubAttributes() throws Exception
 	{
+
+		String expectedContent = readFile(
+				getClass().getResourceAsStream("resourcePartialSubSubAttributesResponse.json"));
 		mockMvc.perform(get(HREF_ENTITY_ID).param("attrs",
 				attrXrefName + '(' + REF_ATTR_ID_NAME + ',' + REF_ATTR_REF_NAME + '(' + REF_REF_ATTR_VALUE_NAME + ')'
 						+ ')'))
 			   .andExpect(status().isOk())
 			   .andExpect(content().contentType(APPLICATION_JSON_UTF8))
-			   .andExpect(content().json(
-					   readFile(getClass().getResourceAsStream("resourcePartialSubSubAttributesResponse.json"))));
+			   .andExpect(content().json(expectedContent));
 	}
 
 	@Test
 	public void retrieveResourceCollection() throws Exception
 	{
-		mockMvc.perform(get(HREF_ENTITY_COLLECTION))
+		String expectedContent = readFile(
+				getClass().getResourceAsStream("resourceCollectionResponse.json"));
+		mockMvc.perform(get(HREF_ENTITY_COLLECTION_INCLUDE_CATEGORIES_IS_TRUE))
 			   .andExpect(status().isOk())
 			   .andExpect(content().contentType(APPLICATION_JSON_UTF8))
-			   .andExpect(content().json(readFile(getClass().getResourceAsStream("resourceCollectionResponse.json"))));
+			   .andExpect(content().json(expectedContent));
 	}
 
 	@Test

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceCollectionResponse.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceCollectionResponse.json
@@ -98,17 +98,7 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false,
-        "categoricalOptions": [
-          {
-            "id": "ref0",
-            "label": "label0"
-          },
-          {
-            "id": "ref1",
-            "label": "label1"
-          }
-        ]
+        "isAggregatable": false
       },
       {
         "href": "/api/v2/entity/meta/categorical_mref",
@@ -171,17 +161,7 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false,
-        "categoricalOptions": [
-          {
-            "id": "ref0",
-            "label": "label0"
-          },
-          {
-            "id": "ref1",
-            "label": "label1"
-          }
-        ]
+        "isAggregatable": false
       },
       {
         "href": "/api/v2/entity/meta/compound",
@@ -673,17 +653,7 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false,
-        "categoricalOptions": [
-          {
-            "id": "ref0",
-            "label": "label0"
-          },
-          {
-            "id": "ref1",
-            "label": "label1"
-          }
-        ]
+        "isAggregatable": false
       },
       {
         "href": "/api/v2/entity/meta/categorical_mrefOptional",
@@ -746,17 +716,7 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false,
-        "categoricalOptions": [
-          {
-            "id": "ref0",
-            "label": "label0"
-          },
-          {
-            "id": "ref1",
-            "label": "label1"
-          }
-        ]
+        "isAggregatable": false
       },
       {
         "href": "/api/v2/entity/meta/dateOptional",

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceCollectionResponse.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceCollectionResponse.json
@@ -59,14 +59,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -82,7 +98,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mref",
@@ -106,14 +132,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -129,7 +171,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/compound",
@@ -393,14 +445,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -488,14 +556,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -550,14 +634,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -573,7 +673,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mrefOptional",
@@ -597,14 +707,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -620,7 +746,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/dateOptional",
@@ -788,14 +924,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -883,14 +1035,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -936,8 +1104,8 @@
           "id": "ref0"
         },
         {
-          "_href": "/api/v2/refEntity/ref0",
-          "id": "ref0"
+          "_href": "/api/v2/refEntity/ref1",
+          "id": "ref1"
         }
       ],
       "compound_attr0": "compoundAttr0Str",
@@ -957,8 +1125,8 @@
           "id": "ref0"
         },
         {
-          "_href": "/api/v2/refEntity/ref0",
-          "id": "ref0"
+          "_href": "/api/v2/refEntity/ref1",
+          "id": "ref1"
         }
       ],
       "script": "print \"Hello world\"",

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceCollectionResponseIncludingCategories.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceCollectionResponseIncludingCategories.json
@@ -1,5 +1,6 @@
 {
-  "_meta": {
+  "href": "/api/v2/entity",
+  "meta": {
     "href": "/api/v2/entity",
     "hrefCollection": "/api/v2/entity",
     "name": "entity",
@@ -97,7 +98,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mref",
@@ -160,7 +171,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/compound",
@@ -652,7 +673,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mrefOptional",
@@ -715,7 +746,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/dateOptional",
@@ -1045,51 +1086,58 @@
     "writable": false,
     "languageCode": "en"
   },
-  "_href": "/api/v2/entity/0",
-  "id": "0",
-  "bool": true,
-  "categorical": {
-    "_href": "/api/v2/refEntity/ref0",
-    "id": "ref0"
-  },
-  "categorical_mref": [
+  "start": 0,
+  "num": 100,
+  "total": 2,
+  "items": [
     {
-      "_href": "/api/v2/refEntity/ref0",
-      "id": "ref0"
-    },
-    {
-      "_href": "/api/v2/refEntity/ref1",
-      "id": "ref1"
+      "_href": "/api/v2/entity/0",
+      "id": "0",
+      "bool": true,
+      "categorical": {
+        "_href": "/api/v2/refEntity/ref0",
+        "id": "ref0"
+      },
+      "categorical_mref": [
+        {
+          "_href": "/api/v2/refEntity/ref0",
+          "id": "ref0"
+        },
+        {
+          "_href": "/api/v2/refEntity/ref1",
+          "id": "ref1"
+        }
+      ],
+      "compound_attr0": "compoundAttr0Str",
+      "compound_attrcompound_attr0": "compoundAttrCompoundAttr0Str",
+      "date": "2015-05-22",
+      "date_time": "2015-05-22T06:12:13Z",
+      "decimal": 3.14,
+      "email": "my@mail.com",
+      "enum": "enum0",
+      "html": "<h1>html</h1>",
+      "hyperlink": "http://www.molgenis.org/",
+      "int": 123,
+      "long": 9223372036854775807,
+      "mref": [
+        {
+          "_href": "/api/v2/refEntity/ref0",
+          "id": "ref0"
+        },
+        {
+          "_href": "/api/v2/refEntity/ref1",
+          "id": "ref1"
+        }
+      ],
+      "script": "print \"Hello world\"",
+      "string": "str",
+      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam consectetur auctor lectus sed tincidunt. Fusce sodales quis mauris non aliquam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Integer maximus imperdiet velit quis vehicula. Mauris pulvinar amet.",
+      "xref": {
+        "_href": "/api/v2/refEntity/ref0",
+        "id": "ref0"
+      },
+      "categorical_mrefOptional": [],
+      "mrefOptional": []
     }
-  ],
-  "compound_attr0": "compoundAttr0Str",
-  "compound_attrcompound_attr0": "compoundAttrCompoundAttr0Str",
-  "date": "2015-05-22",
-  "date_time": "2015-05-22T06:12:13Z",
-  "decimal": 3.14,
-  "email": "my@mail.com",
-  "enum": "enum0",
-  "html": "<h1>html</h1>",
-  "hyperlink": "http://www.molgenis.org/",
-  "int": 123,
-  "long": 9223372036854775807,
-  "mref": [
-    {
-      "_href": "/api/v2/refEntity/ref0",
-      "id": "ref0"
-    },
-    {
-      "_href": "/api/v2/refEntity/ref1",
-      "id": "ref1"
-    }
-  ],
-  "script": "print \"Hello world\"",
-  "string": "str",
-  "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam consectetur auctor lectus sed tincidunt. Fusce sodales quis mauris non aliquam. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Integer maximus imperdiet velit quis vehicula. Mauris pulvinar amet.",
-  "xref": {
-    "_href": "/api/v2/refEntity/ref0",
-    "id": "ref0"
-  },
-  "categorical_mrefOptional": [],
-  "mrefOptional": []
+  ]
 }

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourcePartialSubAttributeResponse.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourcePartialSubAttributeResponse.json
@@ -27,14 +27,14 @@
               "auto": false,
               "nillable": true,
               "readOnly": false,
-              "labelAttribute": false,
+              "labelAttribute": true,
               "unique": false,
               "visible": true,
               "lookupAttribute": false,
               "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -65,6 +65,6 @@
   "_href": "/api/v2/entity/0",
   "xref": {
     "_href": "/api/v2/refEntity/ref0",
-    "value": "val0"
+    "value": "label0"
   }
 }

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourcePartialSubAttributesResponse.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourcePartialSubAttributesResponse.json
@@ -27,7 +27,7 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
@@ -43,14 +43,14 @@
               "auto": false,
               "nillable": true,
               "readOnly": false,
-              "labelAttribute": false,
+              "labelAttribute": true,
               "unique": false,
               "visible": true,
               "lookupAttribute": false,
               "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -82,6 +82,6 @@
   "xref": {
     "_href": "/api/v2/refEntity/ref0",
     "id": "ref0",
-    "value": "val0"
+    "value": "label0"
   }
 }

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourcePartialSubSubAttributesResponse.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourcePartialSubSubAttributesResponse.json
@@ -27,7 +27,7 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
@@ -55,14 +55,14 @@
                     "auto": false,
                     "nillable": true,
                     "readOnly": false,
-                    "labelAttribute": false,
+                    "labelAttribute": true,
                     "unique": false,
                     "visible": true,
                     "lookupAttribute": false,
                     "isAggregatable": false
                   }
                 ],
-                "labelAttribute": "id",
+                "labelAttribute": "value",
                 "idAttribute": "id",
                 "lookupAttributes": [
                   "id"
@@ -81,7 +81,7 @@
               "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceResponse.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceResponse.json
@@ -58,14 +58,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -81,7 +97,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mref",
@@ -105,14 +131,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -128,7 +170,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/compound",
@@ -392,14 +444,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -487,14 +555,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -549,14 +633,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -572,7 +672,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mrefOptional",
@@ -596,14 +706,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -619,7 +745,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/dateOptional",
@@ -787,14 +923,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -882,14 +1034,30 @@
               "auto": false,
               "nillable": false,
               "readOnly": true,
-              "labelAttribute": true,
+              "labelAttribute": false,
               "unique": true,
               "visible": true,
               "lookupAttribute": true,
               "isAggregatable": false
+            },
+            {
+              "href": "/api/v2/refEntity/meta/value",
+              "fieldType": "STRING",
+              "name": "value",
+              "label": "value",
+              "attributes": [],
+              "maxLength": 255,
+              "auto": false,
+              "nillable": true,
+              "readOnly": false,
+              "labelAttribute": true,
+              "unique": false,
+              "visible": true,
+              "lookupAttribute": false,
+              "isAggregatable": false
             }
           ],
-          "labelAttribute": "id",
+          "labelAttribute": "value",
           "idAttribute": "id",
           "lookupAttributes": [
             "id"
@@ -930,8 +1098,8 @@
       "id": "ref0"
     },
     {
-      "_href": "/api/v2/refEntity/ref0",
-      "id": "ref0"
+      "_href": "/api/v2/refEntity/ref1",
+      "id": "ref1"
     }
   ],
   "compound_attr0": "compoundAttr0Str",
@@ -951,8 +1119,8 @@
       "id": "ref0"
     },
     {
-      "_href": "/api/v2/refEntity/ref0",
-      "id": "ref0"
+      "_href": "/api/v2/refEntity/ref1",
+      "id": "ref1"
     }
   ],
   "script": "print \"Hello world\"",

--- a/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceResponseIncludingCategories.json
+++ b/molgenis-data-rest/src/test/resources/org/molgenis/data/rest/v2/resourceResponseIncludingCategories.json
@@ -97,7 +97,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mref",
@@ -160,7 +170,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/compound",
@@ -652,7 +672,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/categorical_mrefOptional",
@@ -715,7 +745,17 @@
         "unique": false,
         "visible": true,
         "lookupAttribute": false,
-        "isAggregatable": false
+        "isAggregatable": false,
+        "categoricalOptions": [
+          {
+            "id": "ref0",
+            "label": "label0"
+          },
+          {
+            "id": "ref1",
+            "label": "label1"
+          }
+        ]
       },
       {
         "href": "/api/v2/entity/meta/dateOptional",

--- a/molgenis-swagger/src/main/resources/templates/view-swagger.ftl
+++ b/molgenis-swagger/src/main/resources/templates/view-swagger.ftl
@@ -396,6 +396,11 @@ paths:
           type: string
           in: query
           description: Defines which fields from the Entity to select
+        - name: includeCategories
+          type: boolean
+          in: query
+          required: false
+          description: Flag to include category options as part of meta data, if not set defaults to false.
         - name: _method
           type: string
           in: query
@@ -767,6 +772,10 @@ definitions:
         type: string
       validationExpression:
         type: string
+      categoricalOptions:
+        type: array
+        items:
+          $ref: "#/definitions/CategoricalOptionV2"
     required:
       - href
       - fieldType
@@ -789,6 +798,13 @@ definitions:
       max:
         type: integer
         format: int64
+  CategoricalOptionV2:
+    type: object
+    properties:
+      id:
+        type: object
+      label:
+        type: object
   Error:
     type: object
     properties:


### PR DESCRIPTION
Add flag to entity request on V2 api to include the category options in the metadata of the response.
Flag is set to false by default to ensure backwards compatibility

- Merge branch to include category options
- Add flag to turn off include by default
- Add tests to check flag

_Background: The questionnaire module using the vue-forms module makes a large amount ( > 100 for large questionnaire) of requests to create the questionnaire answer options, these can be reduced significantly by including the options with the meta-data._

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated **(TEST AUTOMATED)**
- [x] Clean commits
- [x] Added Feature/Fix to release notes
- [x] Integration tests run correctly
