### PR TITLE
update bootstrap hide div to 4.0 style

### DIFF
--- a/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
+++ b/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
@@ -92,7 +92,7 @@
           description: {
             label: this.$t('table-col-header-description'),
             sortable: false,
-            'class': 'hidden-sm-down'
+            'class': 'd-none d-md-block d-lg-block d-xl-block'
           }
         },
         filter: null,

--- a/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
+++ b/molgenis-navigator/src/main/frontend/src/components/Navigator.vue
@@ -92,7 +92,7 @@
           description: {
             label: this.$t('table-col-header-description'),
             sortable: false,
-            'class': 'd-none d-md-block d-lg-block d-xl-block'
+            'class': 'd-none d-md-block'
           }
         },
         filter: null,


### PR DESCRIPTION
4-alpha used a different class naming style to hide/show elements based on screen size, this PR updates this to 4.0 style class names

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
- [x] Integration tests run correctly
