### PR TITLE
M5720 Elasticsearch performance: config changes

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/FieldConstants.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/FieldConstants.java
@@ -3,7 +3,6 @@ package org.molgenis.data.elasticsearch;
 public interface FieldConstants
 {
 	String FIELD_NOT_ANALYZED = "raw";
-	String FIELD_NGRAM_ANALYZED = "ngram";
 	String DEFAULT_ANALYZER = "default";
 	String NGRAM_ANALYZER = "ngram_analyzer";
 	String AGGREGATION_MISSING_POSTFIX = "_missing";

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/MappingContentBuilder.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/MappingContentBuilder.java
@@ -3,7 +3,6 @@ package org.molgenis.data.elasticsearch.client;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentType;
-import org.molgenis.data.elasticsearch.FieldConstants;
 import org.molgenis.data.elasticsearch.generator.model.FieldMapping;
 import org.molgenis.data.elasticsearch.generator.model.Mapping;
 import org.molgenis.util.UnexpectedEnumException;
@@ -13,7 +12,6 @@ import java.io.UncheckedIOException;
 import java.util.List;
 
 import static java.util.Objects.requireNonNull;
-import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NGRAM_ANALYZED;
 import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
 
 /**
@@ -99,7 +97,7 @@ class MappingContentBuilder
 				createFieldMappingNested(fieldMapping.getNestedFieldMappings(), contentBuilder);
 				break;
 			case TEXT:
-				createFieldMappingText(fieldMapping.isAnalyzeNGrams(), contentBuilder);
+				createFieldMappingText(contentBuilder);
 				break;
 			default:
 				throw new UnexpectedEnumException(fieldMapping.getType());
@@ -139,7 +137,7 @@ class MappingContentBuilder
 		createFieldMappings(nestedFieldMappings, contentBuilder);
 	}
 
-	private void createFieldMappingText(boolean analyzeNGrams, XContentBuilder contentBuilder) throws IOException
+	private void createFieldMappingText(XContentBuilder contentBuilder) throws IOException
 	{
 		// enable/disable norms based on given value
 		contentBuilder.field("type", "text");
@@ -151,14 +149,6 @@ class MappingContentBuilder
 													 .field("type", "keyword")
 													 .field("index", true)
 													 .endObject();
-		if (analyzeNGrams)
-		{
-			// add ngram analyzer (not applied to nested documents)
-			fieldsObject.startObject(FIELD_NGRAM_ANALYZED)
-						.field("type", "text")
-						.field("analyzer", FieldConstants.NGRAM_ANALYZER)
-						.endObject();
-		}
 		fieldsObject.endObject();
 	}
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/SettingsContentBuilder.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/SettingsContentBuilder.java
@@ -16,7 +16,6 @@ import static java.util.Objects.requireNonNull;
  */
 class SettingsContentBuilder
 {
-	private static final String NGRAM_TOKENIZER = "ngram_tokenizer";
 	private static final String DEFAULT_TOKENIZER = "default_tokenizer";
 	private static final String DEFAULT_STEMMER = "default_stemmer";
 
@@ -108,7 +107,6 @@ class SettingsContentBuilder
 	{
 		contentBuilder.startObject("analyzer");
 		createDefaultAnalyzerSettings(contentBuilder);
-		createNGramAnalyzerSettings(contentBuilder);
 		contentBuilder.endObject();
 	}
 
@@ -116,18 +114,9 @@ class SettingsContentBuilder
 	{
 		contentBuilder.startObject(FieldConstants.DEFAULT_ANALYZER);
 		contentBuilder.field("type", "custom");
-		contentBuilder.array("filter", "lowercase", DEFAULT_STEMMER);
+		contentBuilder.array("filter", "word_delimiter", "lowercase", "asciifolding", DEFAULT_STEMMER);
 		contentBuilder.field("tokenizer", DEFAULT_TOKENIZER);
 		contentBuilder.field("char_filter", "html_strip");
-		contentBuilder.endObject();
-	}
-
-	private void createNGramAnalyzerSettings(XContentBuilder contentBuilder) throws IOException
-	{
-		contentBuilder.startObject(FieldConstants.NGRAM_ANALYZER);
-		contentBuilder.field("type", "custom");
-		contentBuilder.array("filter", "lowercase");
-		contentBuilder.field("tokenizer", NGRAM_TOKENIZER);
 		contentBuilder.endObject();
 	}
 
@@ -135,24 +124,13 @@ class SettingsContentBuilder
 	{
 		contentBuilder.startObject("tokenizer");
 		createDefaultTokenizerSettings(contentBuilder);
-		createNGramTokenizerSettings(contentBuilder);
 		contentBuilder.endObject();
 	}
 
 	private void createDefaultTokenizerSettings(XContentBuilder contentBuilder) throws IOException
 	{
 		contentBuilder.startObject(DEFAULT_TOKENIZER);
-		contentBuilder.field("type", "pattern");
-		contentBuilder.field("pattern", "([^a-zA-Z0-9]+)");
-		contentBuilder.endObject();
-	}
-
-	private void createNGramTokenizerSettings(XContentBuilder contentBuilder) throws IOException
-	{
-		contentBuilder.startObject(NGRAM_TOKENIZER);
-		contentBuilder.field("type", "nGram");
-		contentBuilder.field("min_gram", 1);
-		contentBuilder.field("max_gram", 10);
+		contentBuilder.field("type", "whitespace");
 		contentBuilder.endObject();
 	}
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/MappingGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/MappingGenerator.java
@@ -48,44 +48,10 @@ class MappingGenerator
 	{
 		String fieldName = documentIdGenerator.generateId(attribute);
 		MappingType mappingType = toMappingType(attribute, depth, maxDepth);
-		boolean analyzeNGrams = isAnalyzeNGrams(attribute);
 		List<FieldMapping> nestedFieldMappings =
 				mappingType == MappingType.NESTED ? createFieldMappings(attribute.getRefEntity(), depth + 1,
 						maxDepth) : null;
-		return FieldMapping.create(fieldName, mappingType, analyzeNGrams, nestedFieldMappings);
-	}
-
-	private boolean isAnalyzeNGrams(Attribute attribute)
-	{
-		AttributeType attributeType = attribute.getDataType();
-		switch (attributeType)
-		{
-			case BOOL:
-			case CATEGORICAL:
-			case CATEGORICAL_MREF:
-			case DATE:
-			case DATE_TIME:
-			case DECIMAL:
-			case FILE:
-			case HTML:
-			case HYPERLINK:
-			case INT:
-			case LONG:
-			case MREF:
-			case ONE_TO_MANY:
-			case SCRIPT:
-			case XREF:
-				return false;
-			case EMAIL:
-			case ENUM:
-			case STRING:
-			case TEXT:
-				return true;
-			case COMPOUND:
-				throw new RuntimeException(format("Illegal attribute type '%s'", attributeType));
-			default:
-				throw new UnexpectedEnumException(attributeType);
-		}
+		return FieldMapping.create(fieldName, mappingType, nestedFieldMappings);
 	}
 
 	private MappingType toMappingType(Attribute attribute, int depth, int maxDepth)

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryGenerator.java
@@ -23,7 +23,8 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.concat;
 import static java.util.stream.Stream.of;
 import static org.molgenis.data.QueryRule.Operator.LIKE;
-import static org.molgenis.data.elasticsearch.FieldConstants.*;
+import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
+import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
 
 /**
  * Generates Elasticsearch queries from MOLGENIS queries.
@@ -495,7 +496,7 @@ public class QueryGenerator
 			case HYPERLINK:
 			case STRING:
 				return nestedQueryBuilder(attributePath,
-						QueryBuilders.matchQuery(fieldName + '.' + FIELD_NGRAM_ANALYZED, queryValue)
+						QueryBuilders.matchPhrasePrefixQuery(fieldName, queryValue).maxExpansions(50).slop(10)
 									 .analyzer(DEFAULT_ANALYZER));
 			case BOOL:
 			case COMPOUND:

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/FieldMapping.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/FieldMapping.java
@@ -12,24 +12,20 @@ public abstract class FieldMapping
 
 	public abstract MappingType getType();
 
-	public abstract boolean isAnalyzeNGrams();
-
 	@Nullable
 	public abstract List<FieldMapping> getNestedFieldMappings();
 
-	public static FieldMapping create(String newName, MappingType newType, boolean newAnalyzeNGrams,
-			List<FieldMapping> newNestedFieldMappings)
+	public static FieldMapping create(String newName, MappingType newType, List<FieldMapping> newNestedFieldMappings)
 	{
 		return builder().setName(newName)
 						.setType(newType)
-						.setAnalyzeNGrams(newAnalyzeNGrams)
 						.setNestedFieldMappings(newNestedFieldMappings)
 						.build();
 	}
 
 	public static Builder builder()
 	{
-		return new AutoValue_FieldMapping.Builder().setAnalyzeNGrams(false);
+		return new AutoValue_FieldMapping.Builder();
 	}
 
 	@AutoValue.Builder
@@ -38,8 +34,6 @@ public abstract class FieldMapping
 		public abstract Builder setName(String newName);
 
 		public abstract Builder setType(MappingType newType);
-
-		public abstract Builder setAnalyzeNGrams(boolean newAnalyzeNGrams);
 
 		public abstract Builder setNestedFieldMappings(List<FieldMapping> newNestedFieldMappings);
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/ClientFacadeTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/ClientFacadeTest.java
@@ -186,7 +186,7 @@ public class ClientFacadeTest
 	{
 		Index index = Index.create("indexname");
 		IndexSettings indexSettings = IndexSettings.create(1, 1);
-		FieldMapping idField = FieldMapping.create("id", MappingType.TEXT, true, emptyList());
+		FieldMapping idField = FieldMapping.create("id", MappingType.TEXT, emptyList());
 		Mapping mapping = Mapping.create("type", ImmutableList.of(idField));
 		Stream<Mapping> mappings = Stream.of(mapping);
 
@@ -205,7 +205,7 @@ public class ClientFacadeTest
 	{
 		Index index = Index.create("indexname");
 		IndexSettings indexSettings = IndexSettings.create(1, 1);
-		FieldMapping idField = FieldMapping.create("id", MappingType.TEXT, true, emptyList());
+		FieldMapping idField = FieldMapping.create("id", MappingType.TEXT, emptyList());
 		Mapping mapping = Mapping.create("type", ImmutableList.of(idField));
 		Stream<Mapping> mappings = Stream.of(mapping);
 
@@ -224,7 +224,7 @@ public class ClientFacadeTest
 	{
 		Index index = Index.create("indexname");
 		IndexSettings indexSettings = IndexSettings.create(1, 1);
-		FieldMapping idField = FieldMapping.create("id", MappingType.TEXT, true, emptyList());
+		FieldMapping idField = FieldMapping.create("id", MappingType.TEXT, emptyList());
 		Mapping mapping = Mapping.create("type", ImmutableList.of(idField));
 		Stream<Mapping> mappings = Stream.of(mapping);
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
@@ -50,15 +50,6 @@ public class MappingContentBuilderTest
 	}
 
 	@Test
-	public void testCreateMappingTextNGram() throws IOException
-	{
-		Mapping mapping = createMapping(
-				FieldMapping.builder().setName("field").setType(MappingType.TEXT).setAnalyzeNGrams(true).build());
-		XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
-		assertEquals(xContentBuilder.string(), JSON_TEXT_NGRAM);
-	}
-
-	@Test
 	public void testCreateMappingNested() throws IOException
 	{
 		FieldMapping nestedFieldMapping = FieldMapping.builder()
@@ -86,7 +77,5 @@ public class MappingContentBuilderTest
 	private static final String JSON_INTEGER = "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"integer\",\"doc_values\":true}}}";
 	private static final String JSON_LONG = "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"long\"}}}";
 	private static final String JSON_TEXT = "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"text\",\"norms\":true,\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
-
-	private static final String JSON_TEXT_NGRAM = "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"text\",\"norms\":true,\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true},\"ngram\":{\"type\":\"text\",\"analyzer\":\"ngram_analyzer\"}}}}}";
 	private static final String JSON_NESTED = "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"nested\",\"properties\":{\"nestedField\":{\"type\":\"boolean\"}}}}}";
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/MappingGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/MappingGeneratorTest.java
@@ -90,22 +90,6 @@ public class MappingGeneratorTest extends AbstractMockitoTest
 		return dataItems.iterator();
 	}
 
-	@Test(dataProvider = "createMappingProviderAnalyzeNGrams")
-	public void testCreateMappingAnalyzeNGrams(AttributeType attributeType)
-	{
-		String attrIdentifier = "attr";
-		EntityType entityType = createEntityType(attrIdentifier, attributeType);
-		Mapping mapping = mappingGenerator.createMapping(entityType);
-
-		FieldMapping fieldMapping = FieldMapping.builder()
-												.setName(attrIdentifier)
-												.setType(MappingType.TEXT)
-												.setAnalyzeNGrams(true)
-												.build();
-		Mapping expectedMapping = createMapping(fieldMapping);
-		assertEquals(mapping, expectedMapping);
-	}
-
 	@DataProvider(name = "createMappingProviderNested")
 	public static Iterator<Object[]> createMappingProviderNested()
 	{

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesTest.java
@@ -24,7 +24,8 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.molgenis.data.elasticsearch.FieldConstants.*;
+import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
+import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
 import static org.molgenis.data.meta.AttributeType.*;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_ID;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_LABEL;
@@ -36,6 +37,8 @@ import static org.testng.Assert.assertEquals;
 // FIXME add nillable tests
 public class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest
 {
+	private static final String FIELD_NGRAM_ANALYZED = "ngram";
+
 	private EntityType entityType;
 
 	private final String refBoolAttributeName = "xbool";
@@ -251,7 +254,7 @@ public class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest
 		Query<Entity> q = new QueryImpl<>().like(PREFIX + refCompoundPart0AttributeName, value);
 		QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
 		QueryBuilder expectedQuery = QueryBuilders.nestedQuery(REF_ENTITY_ATT,
-				QueryBuilders.matchQuery(PREFIX + refCompoundPart0AttributeName + '.' + FIELD_NGRAM_ANALYZED, value)
+				QueryBuilders.matchPhrasePrefixQuery(PREFIX + refCompoundPart0AttributeName, value).slop(10)
 							 .analyzer(DEFAULT_ANALYZER), ScoreMode.Avg);
 		assertQueryBuilderEquals(query, expectedQuery);
 	}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorTest.java
@@ -25,7 +25,8 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.molgenis.data.elasticsearch.FieldConstants.*;
+import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
+import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
 import static org.molgenis.data.meta.AttributeType.*;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_ID;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_LABEL;
@@ -34,6 +35,7 @@ import static org.testng.Assert.assertEquals;
 // FIXME add nillable tests
 public class QueryGeneratorTest extends AbstractMolgenisSpringTest
 {
+	private static final String FIELD_NGRAM_ANALYZED = "ngram";
 	private static final String idAttrName = "xid";
 
 	private static final String boolAttrName = "xbool";
@@ -659,7 +661,7 @@ public class QueryGeneratorTest extends AbstractMolgenisSpringTest
 		String value = "value";
 		Query<Entity> q = new QueryImpl<>().like(compoundPart0AttrName, value);
 		QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-		QueryBuilder expectedQuery = matchQuery(compoundPart0AttrName + '.' + FIELD_NGRAM_ANALYZED, value).analyzer(
+		QueryBuilder expectedQuery = matchPhrasePrefixQuery(compoundPart0AttrName, value).slop(10).analyzer(
 				DEFAULT_ANALYZER);
 		assertQueryBuilderEquals(query, expectedQuery);
 	}
@@ -694,7 +696,7 @@ public class QueryGeneratorTest extends AbstractMolgenisSpringTest
 		String value = "e@mail.com";
 		Query<Entity> q = new QueryImpl<>().like(emailAttrName, value);
 		QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-		QueryBuilder expectedQuery = matchQuery(emailAttrName + '.' + FIELD_NGRAM_ANALYZED, value).analyzer(
+		QueryBuilder expectedQuery = matchPhrasePrefixQuery(emailAttrName, value).slop(10).analyzer(
 				DEFAULT_ANALYZER);
 		assertQueryBuilderEquals(query, expectedQuery);
 	}
@@ -705,7 +707,7 @@ public class QueryGeneratorTest extends AbstractMolgenisSpringTest
 		String value = "enum0";
 		Query<Entity> q = new QueryImpl<>().like(enumAttrName, value);
 		QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-		QueryBuilder expectedQuery = matchQuery(enumAttrName + '.' + FIELD_NGRAM_ANALYZED, value).analyzer(
+		QueryBuilder expectedQuery = matchPhrasePrefixQuery(enumAttrName, value).slop(10).analyzer(
 				DEFAULT_ANALYZER);
 		assertQueryBuilderEquals(query, expectedQuery);
 	}
@@ -724,7 +726,7 @@ public class QueryGeneratorTest extends AbstractMolgenisSpringTest
 		String value = "http://www.website.com/";
 		Query<Entity> q = new QueryImpl<>().like(hyperlinkAttrName, value);
 		QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-		QueryBuilder expectedQuery = matchQuery(hyperlinkAttrName + '.' + FIELD_NGRAM_ANALYZED, value).analyzer(
+		QueryBuilder expectedQuery = matchPhrasePrefixQuery(hyperlinkAttrName, value).slop(10).analyzer(
 				DEFAULT_ANALYZER);
 		assertQueryBuilderEquals(query, expectedQuery);
 	}
@@ -767,7 +769,7 @@ public class QueryGeneratorTest extends AbstractMolgenisSpringTest
 		String value = "value";
 		Query<Entity> q = new QueryImpl<>().like(stringAttrName, value);
 		QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-		QueryBuilder expectedQuery = matchQuery(stringAttrName + '.' + FIELD_NGRAM_ANALYZED, value).analyzer(
+		QueryBuilder expectedQuery = matchPhrasePrefixQuery(stringAttrName, value).slop(10).analyzer(
 				DEFAULT_ANALYZER);
 		assertQueryBuilderEquals(query, expectedQuery);
 	}

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/SearchServiceIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/SearchServiceIT.java
@@ -413,7 +413,7 @@ public class SearchServiceIT extends AbstractTestNGSpringContextTests
 	@DataProvider(name = "findQueryOperatorLike")
 	private static Object[][] findQueryOperatorLike()
 	{
-		return new Object[][] { { "ring", asList("0", "1") }, { "Ring", asList("0", "1") },
+		return new Object[][] { { "stri", asList("0", "1") }, { "Stri", asList("0", "1") },
 				{ "nomatch", emptyList() } };
 	}
 


### PR DESCRIPTION
Release notes:
- Reduce Elasticsearch index size by a factor of ten
- Increase Elasticsearch indexing speed (Travis integration tests finish in 28.5 instead of 40.5 min)
- Split on case transitions: search query 'ontology' matches 'ontologyTerm'
- Split on  letter-number transitions: search query 'sample' matches' 'sample123'
- ASCII folding: search query 'role' matches 'rôle', 'strasse' matches 'Straße'
- Ngram tokenization changes: like query 'ring' doesn't match 'String', 'stri' does match 'String'

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [na] User documentation updated
- [na] (If you have changed REST API interface) view-swagger.ftl updated
- [na] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
- [x] Integration tests run correctly
