### PR TITLE
Fix "Dataexplorer should be usable without permission on genomebrowser config entities"

### DIFF
--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -3,7 +3,6 @@ package org.molgenis.dataexplorer.controller;
 import com.google.gson.Gson;
 import freemarker.core.ParseException;
 import org.apache.commons.lang3.StringUtils;
-import org.json.JSONObject;
 import org.molgenis.core.ui.menu.MenuReaderService;
 import org.molgenis.data.*;
 import org.molgenis.data.annotation.web.meta.AnnotationJobExecutionMetaData;
@@ -200,7 +199,7 @@ public class DataExplorerController extends PluginController
 			case MOD_DATA:
 				selectedEntityType = dataService.getMeta().getEntityTypeById(entityTypeId);
 				entityTracks = genomeBrowserService.getGenomeBrowserTracks(selectedEntityType);
-				model.addAttribute("genomeTracks", getTracksJson(entityTracks));
+				model.addAttribute("genomeTracks", genomeBrowserService.getTracksJson(entityTracks));
 				//if multiple tracks are available we assume chrom and pos attribute are the same
 				if (!entityTracks.isEmpty())
 				{
@@ -216,7 +215,7 @@ public class DataExplorerController extends PluginController
 				//TODO: figure out if we need to know pos and chrom attrs here
 				selectedEntityType = dataService.getMeta().getEntityTypeById(entityTypeId);
 				entityTracks = genomeBrowserService.getGenomeBrowserTracks(selectedEntityType);
-				model.addAttribute("genomeTracks", getTracksJson(entityTracks));
+				model.addAttribute("genomeTracks", genomeBrowserService.getTracksJson(entityTracks));
 				model.addAttribute("showDirectoryButton", directoryController.showDirectoryButton(entityTypeId));
 				model.addAttribute("NegotiatorEnabled", directoryController.showDirectoryButton(entityTypeId));
 
@@ -249,8 +248,7 @@ public class DataExplorerController extends PluginController
 	public boolean showCopy(@RequestParam("entity") String entityTypeId)
 	{
 		return permissionService.hasPermission(new EntityTypeIdentity(entityTypeId), EntityTypePermission.READ)
-				&& dataService.getCapabilities(
-				entityTypeId).contains(RepositoryCapability.WRITABLE);
+				&& dataService.getCapabilities(entityTypeId).contains(RepositoryCapability.WRITABLE);
 	}
 
 	/**
@@ -355,20 +353,6 @@ public class DataExplorerController extends PluginController
 			pack = pack.getParent();
 			getNavigatorLinks(result, pack, navigatorPath);
 		}
-	}
-
-	/**
-	 * Get readable genome entities
-	 */
-	private List<JSONObject> getTracksJson(Map<String, GenomeBrowserTrack> entityTracks)
-	{
-		Map<String, GenomeBrowserTrack> allTracks = new HashMap<>();
-		allTracks.putAll(entityTracks);
-		for (GenomeBrowserTrack track : entityTracks.values())
-		{
-			allTracks.putAll(genomeBrowserService.getReferenceTracks(track));
-		}
-		return allTracks.values().stream().map(track -> track.toTrackJson()).collect(Collectors.toList());
 	}
 
 	@PostMapping("/download")

--- a/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/meta/GenomeBrowserSettingsMetadata.java
+++ b/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/meta/GenomeBrowserSettingsMetadata.java
@@ -98,6 +98,9 @@ public class GenomeBrowserSettingsMetadata extends SystemEntityType
 											   .setVisibleExpression(
 													   "$('" + MOLGENIS_REFERENCES_MODE + "').eq('" + CONFIGURED
 															   + "').value()")
+											   .setNullableExpression(
+													   "!($('" + MOLGENIS_REFERENCES_MODE + "').eq('" + CONFIGURED
+															   + "')).value()")
 											   .setDescription(
 													   "the genome browser settings that should be shown as reference tracks");
 		addAttribute(ACTIONS).setLabel("Actions")

--- a/molgenis-genomebrowser/src/test/java/org/molgenis/genomebrowser/GenomeBrowserTrackTest.java
+++ b/molgenis-genomebrowser/src/test/java/org/molgenis/genomebrowser/GenomeBrowserTrackTest.java
@@ -1,26 +1,37 @@
 package org.molgenis.genomebrowser;
 
+import org.molgenis.core.ui.util.GsonConfig;
+import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.genomebrowser.meta.GenomeBrowserAttributes;
 import org.molgenis.genomebrowser.meta.GenomeBrowserSettings;
-import org.molgenis.genomebrowser.service.GenomeBrowserServiceTest;
+import org.molgenis.test.AbstractMockitoTestNGSpringContextTests;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
+import static org.molgenis.genomebrowser.meta.GenomeBrowserAttributesMetadata.*;
 import static org.molgenis.genomebrowser.meta.GenomeBrowserSettings.TrackType.VARIANT;
 import static org.testng.Assert.assertEquals;
 
-public class GenomeBrowserTrackTest
+@WebAppConfiguration
+@ContextConfiguration(classes = GsonConfig.class)
+public class GenomeBrowserTrackTest extends AbstractMockitoTestNGSpringContextTests
 {
 	@Test
-	public void testToTrack() throws Exception
+	public void testToTrack()
 	{
 		EntityType entity = mock(EntityType.class);
-		GenomeBrowserAttributes genomeBrowserAttributes = GenomeBrowserServiceTest.getGenomeBrowserAttributes("postion",
-				"chrom", "normal", "mutant");
+		Entity attrsEntity = mock(Entity.class);
+		GenomeBrowserAttributes genomeBrowserAttributes = new GenomeBrowserAttributes(attrsEntity);
+
+		doReturn("position").when(attrsEntity).getString(POS);
+		doReturn("chrom").when(attrsEntity).getString(CHROM);
+		doReturn("normal").when(attrsEntity).getString(REF);
+		doReturn("mutant").when(attrsEntity).getString(ALT);
 		GenomeBrowserTrack reference = GenomeBrowserTrack.create("ref_id", "label", "ref_label", entity, VARIANT, null,
 				GenomeBrowserSettings.MolgenisReferenceMode.NONE, genomeBrowserAttributes, null, null, null, null);
 
@@ -30,7 +41,7 @@ public class GenomeBrowserTrackTest
 				genomeBrowserAttributes, "alert(\"test\")",
 				"attr 1:attr1,reference attribute:REF,position on genome:POS", null, null);
 
-		String expected = "{\"genome_attrs\":{\"ref\":\"normal\",\"pos\":\"postion\",\"alt\":\"mutant\",\"chr\":\"chrom\"},\"name\":\"label\",\"label_attr\":\"entityLabel\",\"tier_type\":\"molgenis\",\"uri\":\"/api/v2/molgenisEntityType\",\"actions\":\"alert(\\\"test\\\")\",\"track_type\":\"VARIANT\",\"entity\":\"molgenisEntityType\",\"attrs\":[\"attr 1:attr1\",\"reference attribute:REF\",\"position on genome:POS\"]}";
+		String expected = "{\"genome_attrs\":{\"ref\":\"normal\",\"pos\":\"position\",\"alt\":\"mutant\",\"chr\":\"chrom\"},\"name\":\"label\",\"label_attr\":\"entityLabel\",\"tier_type\":\"molgenis\",\"uri\":\"/api/v2/molgenisEntityType\",\"actions\":\"alert(\\\"test\\\")\",\"track_type\":\"VARIANT\",\"entity\":\"molgenisEntityType\",\"attrs\":[\"attr 1:attr1\",\"reference attribute:REF\",\"position on genome:POS\"]}";
 
 		assertEquals(track.toTrackJson().toString(), expected);
 	}


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
- [x] Integration tests run correctly
