### PR TITLE
Fix #7247 Hidden attributes can be used as lookups

### DIFF
--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
@@ -106,6 +106,13 @@ public class EntityTypeValidator
 				throw new MolgenisValidationException(new ConstraintViolation(
 						format("Lookup attribute [%s] is not part of the entity attributes", ownLookupAttr.getName())));
 			}
+
+			// Validate that the lookup attribute is visible
+			if (!ownLookupAttr.isVisible())
+			{
+				throw new MolgenisValidationException(new ConstraintViolation(
+						format("Lookup attribute [%s] must be visible", ownLookupAttr.getName())));
+			}
 		});
 	}
 

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/EntityTypeValidatorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/EntityTypeValidatorTest.java
@@ -64,6 +64,7 @@ public class EntityTypeValidatorTest
 		labelAttr = when(mock(Attribute.class).getName()).thenReturn("labelAttr").getMock();
 		when(labelAttr.getIdentifier()).thenReturn("#labelAttr");
 		when(labelAttr.getDataType()).thenReturn(STRING);
+		when(labelAttr.isVisible()).thenReturn(true);
 
 		entityQ = mock(Query.class);
 		when(dataService.query(ENTITY_TYPE_META_DATA, EntityType.class)).thenReturn(entityQ);
@@ -247,6 +248,13 @@ public class EntityTypeValidatorTest
 	{
 		when(entityType.getOwnAllAttributes()).thenReturn(singletonList(idAttr));
 		when(entityType.getOwnLabelAttribute()).thenReturn(null);
+		entityTypeValidator.validate(entityType);
+	}
+
+	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Lookup attribute \\[labelAttr\\] must be visible")
+	public void testValidateLookupAttributeHidden()
+	{
+		when(labelAttr.isVisible()).thenReturn(false);
 		entityTypeValidator.validate(entityType);
 	}
 


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
