### PR TITLE
Fix #7251: Parallel build fails if yarn cache is empty

### DIFF
--- a/molgenis-settings-ui/pom.xml
+++ b/molgenis-settings-ui/pom.xml
@@ -76,7 +76,7 @@
                         </goals>
                         <configuration>
                             <skip>${skip.js}</skip>
-                            <arguments>--frozen-lockfile</arguments>
+                            <arguments>--mutex network --frozen-lockfile</arguments>
                             <failOnError>true</failOnError>
                         </configuration>
                     </execution>


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
