### PR TITLE
Fix #7265 Settings plugin 'save' button has no label

### DIFF
--- a/molgenis-settings-ui/src/main/frontend/src/components/SettingsUi.vue
+++ b/molgenis-settings-ui/src/main/frontend/src/components/SettingsUi.vue
@@ -30,6 +30,7 @@
             type="submit"
             @click.prevent="onSubmit"
             :disabled="formState.$pristine || formState.$invalid">
+            Save changes
           </button>
 
           <button


### PR DESCRIPTION
Put back the label

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
