### PR TITLE
Fix #7263 Row-level secured findOne: return first readable entity

### DIFF
--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/AbstractRowLevelSecurityRepositoryDecorator.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/AbstractRowLevelSecurityRepositoryDecorator.java
@@ -75,14 +75,7 @@ public abstract class AbstractRowLevelSecurityRepositoryDecorator<E extends Enti
 	@Override
 	public E findOne(Query<E> q)
 	{
-		E entity = delegate().findOne(q);
-
-		if (entity != null && !isOperationPermitted(entity, Action.READ))
-		{
-			return null;
-		}
-
-		return entity;
+		return findAllPermitted(q, Action.READ).findFirst().orElse(null);
 	}
 
 	@Override

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/meta/EntityTypeRepositorySecurityDecoratorTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/meta/EntityTypeRepositorySecurityDecoratorTest.java
@@ -209,7 +209,7 @@ public class EntityTypeRepositorySecurityDecoratorTest extends AbstractMockitoTe
 		EntityType entityType0 = when(mock(EntityType.class).getId()).thenReturn(entityType0Name).getMock();
 		@SuppressWarnings("unchecked")
 		Query q = mock(Query.class);
-		when(delegateRepository.findOne(q)).thenReturn(entityType0);
+		when(delegateRepository.findAll(any(Query.class))).thenReturn(Stream.of(entityType0));
 		when(permissionService.hasPermission(new EntityTypeIdentity(entityType0Name),
 				EntityTypePermission.COUNT)).thenReturn(true);
 		assertEquals(repo.findOne(q), entityType0);
@@ -223,7 +223,7 @@ public class EntityTypeRepositorySecurityDecoratorTest extends AbstractMockitoTe
 		EntityType entityType0 = when(mock(EntityType.class).getId()).thenReturn(entityType0Name).getMock();
 		@SuppressWarnings("unchecked")
 		Query q = mock(Query.class);
-		when(delegateRepository.findOne(q)).thenReturn(entityType0);
+		when(delegateRepository.findAll(any(Query.class))).thenReturn(Stream.of(entityType0));
 		when(permissionService.hasPermission(new EntityTypeIdentity(entityType0Name),
 				EntityTypePermission.COUNT)).thenReturn(false);
 		assertNull(repo.findOne(q));

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/owned/RowLevelSecurityRepositoryDecoratorTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/owned/RowLevelSecurityRepositoryDecoratorTest.java
@@ -331,7 +331,8 @@ public class RowLevelSecurityRepositoryDecoratorTest extends AbstractMockitoTest
 		@SuppressWarnings("unchecked")
 		Query<Entity> query = mock(Query.class);
 		Entity entity = getEntityMock();
-		when(delegateRepository.findOne(query)).thenReturn(entity);
+		when(delegateRepository.findAll(new QueryImpl<>().setOffset(0).setPageSize(Integer.MAX_VALUE))).thenAnswer(
+				invocation -> Stream.of(entity));
 		when(userPermissionEvaluator.hasPermission(new EntityIdentity(entity), READ)).thenReturn(true);
 		assertEquals(entity, rowLevelSecurityRepositoryDecorator.findOne(query));
 	}
@@ -342,7 +343,8 @@ public class RowLevelSecurityRepositoryDecoratorTest extends AbstractMockitoTest
 		@SuppressWarnings("unchecked")
 		Query<Entity> query = mock(Query.class);
 		Entity entity = getEntityMock();
-		when(delegateRepository.findOne(query)).thenReturn(entity);
+		when(delegateRepository.findAll(new QueryImpl<>().setOffset(0).setPageSize(Integer.MAX_VALUE))).thenAnswer(
+				invocation -> Stream.of(entity));
 		assertNull(rowLevelSecurityRepositoryDecorator.findOne(query));
 	}
 


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
- [x] Integration tests run correctly
