### PR TITLE
Fix #7297 One-to-many with integer ids retrieval

### DIFF
--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlEntityFactory.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/PostgreSqlEntityFactory.java
@@ -192,15 +192,15 @@ class PostgreSqlEntityFactory
 		{
 			EntityType entityType = attr.getRefEntity();
 			Object value;
-			String[] postgreSqlMrefIds = (String[]) arrayValue.getArray();
+			Object[] postgreSqlMrefIds = (Object[]) arrayValue.getArray();
 			if (postgreSqlMrefIds.length > 0 && postgreSqlMrefIds[0] != null)
 			{
 				Attribute idAttr = entityType.getIdAttribute();
 				Object[] mrefIds = new Object[postgreSqlMrefIds.length];
 				for (int i = 0; i < postgreSqlMrefIds.length; ++i)
 				{
-					String mrefIdStr = postgreSqlMrefIds[i];
-					Object mrefId = mrefIdStr != null ? convertMrefIdValue(mrefIdStr, idAttr) : null;
+					Object mrefIdRaw = postgreSqlMrefIds[i];
+					Object mrefId = mrefIdRaw != null ? convertMrefIdValue(mrefIdRaw.toString(), idAttr) : null;
 					mrefIds[i] = mrefId;
 				}
 

--- a/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/PostgreSqlEntityFactoryTest.java
+++ b/molgenis-data-postgresql/src/test/java/org/molgenis/data/postgresql/PostgreSqlEntityFactoryTest.java
@@ -2,6 +2,7 @@ package org.molgenis.data.postgresql;
 
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityManager;
+import org.molgenis.data.meta.AttributeType;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 import org.testng.annotations.BeforeMethod;
@@ -56,6 +57,39 @@ public class PostgreSqlEntityFactoryTest
 		Entity refEntity1 = mock(Entity.class);
 		Entity refEntity0 = mock(Entity.class);
 		when(entityManager.getReferences(refEntityMeta, newArrayList("id0", "id1"))).thenReturn(
+				newArrayList(refEntity0, refEntity1));
+		assertEquals(postgreSqlEntityFactory.createRowMapper(entityType, null).mapRow(rs, rowNum), entity);
+		verify(entity).set(oneToManyAttrName, newArrayList(refEntity0, refEntity1));
+	}
+
+	@Test
+	public void createRowMapperOneToManyIntegerIds() throws Exception
+	{
+		Attribute refIdAttr = mock(Attribute.class);
+		when(refIdAttr.getDataType()).thenReturn(AttributeType.INT);
+
+		EntityType refEntityMeta = mock(EntityType.class);
+		when(refEntityMeta.getIdAttribute()).thenReturn(refIdAttr);
+
+		String oneToManyAttrName = "oneToManyAttr";
+		Attribute oneToManyAttr = mock(Attribute.class);
+		when(oneToManyAttr.getName()).thenReturn(oneToManyAttrName);
+		when(oneToManyAttr.getDataType()).thenReturn(ONE_TO_MANY);
+		when(oneToManyAttr.getRefEntity()).thenReturn(refEntityMeta);
+
+		EntityType entityType = mock(EntityType.class);
+		when(entityType.getAtomicAttributes()).thenReturn(singleton(oneToManyAttr));
+		ResultSet rs = mock(ResultSet.class);
+		Array oneToManyArray = mock(Array.class);
+		when(oneToManyArray.getArray()).thenReturn(new Integer[] { 0, 1 });
+		when(rs.getArray(oneToManyAttrName)).thenReturn(oneToManyArray);
+		int rowNum = 0;
+
+		Entity entity = mock(Entity.class);
+		when(entityManager.createFetch(entityType, null)).thenReturn(entity);
+		Entity refEntity1 = mock(Entity.class);
+		Entity refEntity0 = mock(Entity.class);
+		when(entityManager.getReferences(refEntityMeta, newArrayList(0, 1))).thenReturn(
 				newArrayList(refEntity0, refEntity1));
 		assertEquals(postgreSqlEntityFactory.createRowMapper(entityType, null).mapRow(rs, rowNum), entity);
 		verify(entity).set(oneToManyAttrName, newArrayList(refEntity0, refEntity1));


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
