### PR TITLE
Fix #7117 Swagger documentation error on non-localhost

### DIFF
--- a/molgenis-swagger/src/main/resources/templates/view-swagger-ui.ftl
+++ b/molgenis-swagger/src/main/resources/templates/view-swagger-ui.ftl
@@ -86,7 +86,8 @@
             plugins: [
                 SwaggerUIBundle.plugins.DownloadUrl
             ],
-            layout: "StandaloneLayout"
+            layout: "StandaloneLayout",
+            validatorUrl: null // Fix for https://github.com/molgenis/molgenis/issues/7117
         })
         <#if token??>
           ui.authActions.authorize({


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
