### PR TITLE
Fix 6969: Internal server error when idAttribute of refEntity is visi…

### DIFF
--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/EntityTypeValidator.java
@@ -66,7 +66,19 @@ public class EntityTypeValidator
 		validateOwnIdAttribute(entityType, ownAllAttrMap);
 		validateOwnLabelAttribute(entityType, ownAllAttrMap);
 		validateOwnLookupAttributes(entityType, ownAllAttrMap);
+		validateLabelAttribute(entityType);
 		validateBackend(entityType);
+	}
+
+	static void validateLabelAttribute(EntityType entityType)
+	{
+		if (!entityType.isAbstract() && !entityType.getIdAttribute().isVisible()
+				&& entityType.getLabelAttribute() == null)
+		{
+			throw new MolgenisValidationException(new ConstraintViolation(
+					format("EntityType [%s] must define a label attribute because the identifier is hidden",
+							entityType.getId())));
+		}
 	}
 
 	/**
@@ -136,15 +148,6 @@ public class EntityTypeValidator
 				throw new MolgenisValidationException(new ConstraintViolation(
 						format("Label attribute [%s] is not is not one of the attributes of entity [%s]",
 								ownLabelAttr.getName(), entityType.getId())));
-			}
-		}
-		else
-		{
-			if (!entityType.isAbstract() && !entityType.getIdAttribute().isVisible())
-			{
-				throw new MolgenisValidationException(new ConstraintViolation(
-						format("EntityType [%s] must define a label attribute because the identifier is hidden",
-								entityType.getId())));
 			}
 		}
 	}

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/EntityTypeValidatorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/meta/EntityTypeValidatorTest.java
@@ -242,18 +242,16 @@ public class EntityTypeValidatorTest extends AbstractMockitoTest
 	@Test
 	public void testValidateOwnLabelAttributeNullIdAttributeVisible()
 	{
-		when(entityType.getIdAttribute()).thenReturn(idAttr);
-		when(idAttr.isVisible()).thenReturn(true);
 		EntityTypeValidator.validateOwnLabelAttribute(entityType, emptyMap());
 	}
 
 	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "EntityType \\[entity\\] must define a label attribute because the identifier is hidden")
-	public void testValidateOwnLabelAttributeNullIdAttributeInvisible()
+	public void testValidateLabelAttributeNullIdAttributeInvisible()
 	{
 		when(entityType.getIdAttribute()).thenReturn(idAttr);
 		when(idAttr.isVisible()).thenReturn(false);
 		when(entityType.getId()).thenReturn("entity");
-		EntityTypeValidator.validateOwnLabelAttribute(entityType, emptyMap());
+		EntityTypeValidator.validateLabelAttribute(entityType);
 	}
 
 	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "Label attribute \\[label\\] is not is not one of the attributes of entity \\[entity\\]")
@@ -275,19 +273,18 @@ public class EntityTypeValidatorTest extends AbstractMockitoTest
 	}
 
 	@Test(expectedExceptions = MolgenisValidationException.class, expectedExceptionsMessageRegExp = "EntityType \\[package_name\\] must define a label attribute because the identifier is hidden")
-	public void testValidateOwnLabelAttributeIdHidden()
+	public void testValidateLabelAttributeIdHidden()
 	{
-		when(entityType.getOwnLabelAttribute()).thenReturn(null);
+		when(entityType.getLabelAttribute()).thenReturn(null);
 		when(entityType.getId()).thenReturn("package_name");
 		when(entityType.getIdAttribute()).thenReturn(idAttr);
-		EntityTypeValidator.validateOwnLabelAttribute(entityType, newHashMap());
+		EntityTypeValidator.validateLabelAttribute(entityType);
 	}
 
 	@Test
 	public void testValidateOwnLabelAttributeAbstractEntity()
 	{
 		when(entityType.getOwnLabelAttribute()).thenReturn(null);
-		when(entityType.isAbstract()).thenReturn(true);
 		EntityTypeValidator.validateOwnLabelAttribute(entityType, newHashMap());
 	}
 


### PR DESCRIPTION
…ble == false and no other labelAttribute specified

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- (n.a.) User documentation updated
- (n.a.) (If you have changed REST API interface) view-swagger.ftl updated
- (n.a.) Test plan template updated
- [x] Clean commits
- (n.a.) Added Feature/Fix to release notes
- [x] Integration tests run correctly
