### PR TITLE
Speed up javascript and magmascript evaluation

### DIFF
--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/ExpressionValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/ExpressionValidator.java
@@ -7,13 +7,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-import javax.script.Bindings;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.Collections.singletonList;
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 
 /**
  * Validates entities using JavaScript expressions. Expressions can use the Magma API.
@@ -58,14 +58,14 @@ public class ExpressionValidator
 			return Collections.emptyList();
 		}
 
-		Bindings bindings = jsMagmaScriptEvaluator.createBindings(entity);
+		return jsMagmaScriptEvaluator.evalList(expressions, entity)
+									 .stream()
+									 .map(this::convertToBoolean)
+									 .collect(toList());
+	}
 
-		List<Boolean> validationResults = new ArrayList<>(expressions.size());
-		for (String expression : expressions)
-		{
-			Object value = jsMagmaScriptEvaluator.eval(bindings, expression);
-			validationResults.add(value != null ? Boolean.valueOf(value.toString()) : null);
-		}
-		return validationResults;
+	private Boolean convertToBoolean(Object value)
+	{
+		return Optional.ofNullable(value).map(Object::toString).map(Boolean::valueOf).orElse(null);
 	}
 }

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/ExpressionValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/ExpressionValidator.java
@@ -58,7 +58,7 @@ public class ExpressionValidator
 			return Collections.emptyList();
 		}
 
-		return jsMagmaScriptEvaluator.evalList(expressions, entity)
+		return jsMagmaScriptEvaluator.eval(expressions, entity)
 									 .stream()
 									 .map(this::convertToBoolean)
 									 .collect(toList());

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/ExpressionValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/ExpressionValidator.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import javax.script.Bindings;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -57,10 +58,12 @@ public class ExpressionValidator
 			return Collections.emptyList();
 		}
 
+		Bindings bindings = jsMagmaScriptEvaluator.createBindings(entity);
+
 		List<Boolean> validationResults = new ArrayList<>(expressions.size());
 		for (String expression : expressions)
 		{
-			Object value = jsMagmaScriptEvaluator.eval(expression, entity);
+			Object value = jsMagmaScriptEvaluator.eval(bindings, expression);
 			validationResults.add(value != null ? Boolean.valueOf(value.toString()) : null);
 		}
 		return validationResults;

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/ExpressionValidatorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/ExpressionValidatorTest.java
@@ -1,0 +1,63 @@
+package org.molgenis.data.validation;
+
+import org.mockito.Mock;
+import org.molgenis.data.Entity;
+import org.molgenis.js.magma.JsMagmaScriptEvaluator;
+import org.molgenis.script.core.ScriptException;
+import org.molgenis.test.AbstractMockitoTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static java.lang.Boolean.FALSE;
+import static java.lang.Boolean.TRUE;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+public class ExpressionValidatorTest extends AbstractMockitoTest
+{
+	@Mock
+	private JsMagmaScriptEvaluator jsMagmaScriptEvaluator;
+	@Mock
+	private Entity entity;
+	private ExpressionValidator expressionValidator;
+
+	@BeforeMethod
+	public void beforeMethod()
+	{
+		expressionValidator = new ExpressionValidator(jsMagmaScriptEvaluator);
+	}
+
+	@Test
+	public void testResolveBooleanExpressions()
+	{
+		List<String> expressions = Arrays.asList("a", "b");
+		when(jsMagmaScriptEvaluator.eval(expressions, entity)).thenReturn(Arrays.asList(TRUE, FALSE));
+		assertEquals(expressionValidator.resolveBooleanExpressions(expressions, entity), Arrays.asList(true, false));
+	}
+
+	@DataProvider(name = "resultProvider")
+	public Object[][] resultProvider()
+	{
+		// @formatter:off
+		return new Object[][] {
+				new Object[] { FALSE, false },
+				new Object[] { "true", true },
+				new Object[] { "TRUE", true },
+				new Object[] { 0, false },
+				new Object[] { 1, false },
+				new Object[] { new ScriptException("Evaluation failed on line 0, column 10: Undefined is not an object"), false } };
+		// @formatter:on
+	}
+
+	@Test(dataProvider = "resultProvider")
+	public void testResolveBooleanExpression(Object result, boolean expected)
+	{
+		when(jsMagmaScriptEvaluator.eval(singletonList("expression"), entity)).thenReturn(singletonList(result));
+		assertEquals(expressionValidator.resolveBooleanExpression("expression", entity), expected);
+	}
+}

--- a/molgenis-js/pom.xml
+++ b/molgenis-js/pom.xml
@@ -53,5 +53,9 @@
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
+++ b/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
@@ -71,7 +71,14 @@ public class JsMagmaScriptEvaluator
 		jsScriptEngine.eval(magmaBindings, string);
 	}
 
-	public List<Object> evalList(Collection<String> expressions, Entity entity)
+	/**
+	 * Evaluates multiple expressions for a single entity instance.
+	 *
+	 * @param expressions {@link Collection} containing the expression {@link String}s
+	 * @param entity      the entity to bind the magmascript $ function to
+	 * @return Collection containing the expression result {@link Object}s
+	 */
+	public Collection<Object> eval(Collection<String> expressions, Entity entity)
 	{
 		Stopwatch stopwatch = null;
 		if (LOG.isTraceEnabled())
@@ -94,7 +101,7 @@ public class JsMagmaScriptEvaluator
 	}
 
 	/**
-	 * Evaluate a expression for the given entity.
+	 * Evaluate a expression for a given entity.
 	 *
 	 * @param expression JavaScript expression
 	 * @param entity     entity
@@ -122,7 +129,7 @@ public class JsMagmaScriptEvaluator
 		{
 			return new ScriptException(t.getCause());
 		}
-		catch (Throwable t)
+		catch (Exception t)
 		{
 			return new ScriptException(t);
 		}

--- a/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
+++ b/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
@@ -126,7 +126,7 @@ public class JsMagmaScriptEvaluator
 		}
 		catch (javax.script.ScriptException t)
 		{
-			return t;
+			return new ScriptException(t.getCause());
 		}
 		catch (Throwable t)
 		{

--- a/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
+++ b/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
@@ -2,6 +2,7 @@ package org.molgenis.js.magma;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.Maps;
+import jdk.nashorn.api.scripting.JSObject;
 import jdk.nashorn.api.scripting.ScriptObjectMirror;
 import org.molgenis.data.Entity;
 import org.molgenis.data.meta.AttributeType;
@@ -115,7 +116,15 @@ public class JsMagmaScriptEvaluator
 	 */
 	public Bindings createBindings(Entity entity, int depth)
 	{
-		return jsScriptEngine.createBindings(toScriptEngineValueMap(entity, depth));
+		Bindings bindings = jsScriptEngine.copyEngineBindings();
+		JSObject magmaScript = (JSObject) bindings.get("MagmaScript");
+		JSObject dollarFunction = (JSObject) magmaScript.getMember("$");
+		JSObject bindFunction = (JSObject) dollarFunction.getMember("bind");
+		Object boundDollar = bindFunction.call(dollarFunction, toScriptEngineValueMap(entity, depth));
+		bindings.put("$", boundDollar);
+		bindings.put("newValue", magmaScript.getMember("newValue"));
+		bindings.put("_isNull", magmaScript.getMember("_isNull"));
+		return bindings;
 	}
 
 	/**

--- a/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
+++ b/molgenis-js/src/main/java/org/molgenis/js/magma/JsMagmaScriptEvaluator.java
@@ -73,18 +73,12 @@ public class JsMagmaScriptEvaluator
 
 	public List<Object> evalList(Collection<String> expressions, Entity entity)
 	{
-		return evalList(expressions, entity, ENTITY_REFERENCE_DEFAULT_FETCHING_DEPTH);
-	}
-
-	public List<Object> evalList(Collection<String> expressions, Entity entity, int depth)
-	{
 		Stopwatch stopwatch = null;
 		if (LOG.isTraceEnabled())
 		{
 			stopwatch = Stopwatch.createStarted();
 		}
-
-		Bindings bindings = createBindings(entity, depth);
+		Bindings bindings = createBindings(entity, ENTITY_REFERENCE_DEFAULT_FETCHING_DEPTH);
 		List<Object> result = expressions.stream().map(expression -> eval(bindings, expression)).collect(toList());
 		if (stopwatch != null)
 		{

--- a/molgenis-js/src/main/java/org/molgenis/js/nashorn/NashornScriptEngine.java
+++ b/molgenis-js/src/main/java/org/molgenis/js/nashorn/NashornScriptEngine.java
@@ -46,26 +46,7 @@ public class NashornScriptEngine
 		return convertNashornValue(scriptEngine.eval(script, copyEngineBindings()));
 	}
 
-	/**
-	 * Binds magmascript $ function to an entity value map.
-	 *
-	 * @param entityValueMap the map to bind the $ functions to
-	 * @return Bindings object where the $ function is bound to the entity value map
-	 */
-	public Bindings createBindings(Object entityValueMap)
-	{
-		Bindings bindings = copyEngineBindings();
-		JSObject magmaScript = (JSObject) bindings.get("MagmaScript");
-		JSObject dollarFunction = (JSObject) magmaScript.getMember("$");
-		JSObject bindFunction = (JSObject) dollarFunction.getMember("bind");
-		Object boundDollar = bindFunction.call(dollarFunction, entityValueMap);
-		bindings.put("$", boundDollar);
-		bindings.put("newValue", magmaScript.getMember("newValue"));
-		bindings.put("_isNull", magmaScript.getMember("_isNull"));
-		return bindings;
-	}
-
-	private Bindings copyEngineBindings()
+	public Bindings copyEngineBindings()
 	{
 		Bindings bindings = new SimpleBindings();
 		bindings.putAll(scriptEngine.getBindings(ENGINE_SCOPE));

--- a/molgenis-js/src/main/resources/js/script-evaluator.js
+++ b/molgenis-js/src/main/resources/js/script-evaluator.js
@@ -8,445 +8,445 @@
  * @returns the evaluated script result
  */
 function evalScript (script, entity) {
-  function Attribute (value) {
+    var $ = $.bind(entity)
+    return eval(script)
+}
+
+function Attribute (value) {
 
     var attribute = {
-      /**
-       *
-       * Gives you the value of the attribute specified between $('')
-       * notation
-       *
-       * Example: $('Height').value() returns the values of the height
-       * attribute
-       *
-       * If the value is an object, return the idValue
-       *
-       * @memberof $
-       * @method value
-       *
-       */
-      value: function () {
-        if (this.val !== null && typeof this.val === 'object') {
-          if (this.val['_idValue'] !== undefined) {
+        /**
+         *
+         * Gives you the value of the attribute specified between $('')
+         * notation
+         *
+         * Example: $('Height').value() returns the values of the height
+         * attribute
+         *
+         * If the value is an object, return the idValue
+         *
+         * @memberof $
+         * @method value
+         *
+         */
+        value: function () {
+            if (this.val !== null && typeof this.val === 'object') {
+                if (this.val['_idValue'] !== undefined) {
 
-            // Map a list of entities to a list of ID's
-            if (Array.isArray(this.val)) {
-              return this.val.map(function(value) {
-                return newValue(value).value()
-              })
+                    // Map a list of entities to a list of ID's
+                    if (Array.isArray(this.val)) {
+                        return this.val.map(function (value) {
+                            return newValue(value).value()
+                        })
+                    }
+                    return this.val['_idValue']
+                }
             }
-            return this.val['_idValue']
-          }
-        }
-        return this.val
-      },
+            return this.val
+        },
 
-      /**
-       * Returns true if your value is valid JSON
-       * Returns false if not
-       */
-      isValidJson: function () {
-        try {
-          JSON.parse(this.val)
-          this.val = true
-        } catch (e) {
-          this.val = false
-        }
-        return this
-      },
+        /**
+         * Returns true if your value is valid JSON
+         * Returns false if not
+         */
+        isValidJson: function () {
+            try {
+                JSON.parse(this.val)
+                this.val = true
+            } catch (e) {
+                this.val = false
+            }
+            return this
+        },
 
-      /**
-       * returns the result of the first value plus the second value
-       *
-       * @param value: the number you want to add to the current value
-       */
-      plus: function (value) {
-        if (!_isNull(value)) {
-          if (typeof value === 'object' || typeof value === 'function') {
-            this.val = this.val + value.value()
-          } else {
-            this.val = this.val + value
-          }
-        }
-        return this
-      },
+        /**
+         * returns the result of the first value plus the second value
+         *
+         * @param value: the number you want to add to the current value
+         */
+        plus: function (value) {
+            if (!_isNull(value)) {
+                if (typeof value === 'object' || typeof value === 'function') {
+                    this.val = this.val + value.value()
+                } else {
+                    this.val = this.val + value
+                }
+            }
+            return this
+        },
 
-      /**
-       * Gives you the exponent value of the attribute specified between
-       * $('') notation
-       *
-       * Example: $('Height').pow(2).value() returns the result of
-       * height_value ^ 2
-       *
-       * @param exp :
-        *            The number you use to execute the power function
-       *
-       * @memberof $
-       * @method pow
-       */
-      pow: function (exp) {
-        if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
-          exp = exp.value()
-        }
-        this.val = Math.pow(this.val, exp)
-        return this
-      },
-      /**
-       * Gives you the multiplication value of the attribute specified between
-       * $('') notation
-       *
-       * Example: $('Height').times(2).value() returns the result of
-       * height_value * 2
-       *
-       * @param factor :
-        *            The number you multiply by
-       *
-       * @memberof $
-       * @method div
-       */
-      times: function (factor) {
-        if ((typeof factor === 'object') && (typeof factor.value === 'function')) {
-          factor = factor.value()
-        }
-        this.val = (this.val * factor)
-        return this
-      },
-      /**
-       * Gives you the division value of the attribute specified between
-       * $('') notation
-       *
-       * Example: $('Height').div(2).value() returns the result of
-       * height_value / 2
-       *
-       * @param denominator :
-        *            The number you divide by
-       *
-       * @memberof $
-       * @method div
-       */
-      div: function (denominator) {
-        if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
-          denominator = denominator.value()
-        }
-        this.val = (this.val / denominator)
-        return this
-      },
-      /**
-       * Returns the age based on the date of birth and the current year
-       *
-       * Example: $('Date_Of_Birth').age().value()
-       *
-       * @memberof $
-       * @method age
-       */
-      age: function () {
-        if (_isNull(this.val)) {
-          this.val = undefined
-        } else {
-          this.val = Math.floor((Date.now() - this.val) / (365.2425 * 24 * 60 * 60 * 1000))
-        }
-        return this
-      },
-      /**
-       * Maps categories to eachother.
-       *
-       * Example: Dataset1 -> Male = 1, Female = 2 Dataset2 -> Male = 0,
-       * Female = 1 $('Dataset2').map({0:1, 1:2}).value()
-       *
-       * @param categoryMapping :
-        *            The mapping in JSON format to apply
-       * @param defaultValue :
-        *            a value to use for categories that are not mentioned
-       *            in the categoryMappign
-       * @param nullValue :
-        *            a value to use for null instances
-       *
-       * @memberof $
-       * @method map
-       */
-      map: function (categoryMapping, defaultValue, nullValue) {
-        if (typeof categoryMapping === 'function') {
-          this.val = this.val.map(newValue).map(categoryMapping)
-        } else {
-          this.val = this.value()
-          if (this.val in categoryMapping) {
-            this.val = categoryMapping[this.val]
-          } else {
-            if (nullValue !== undefined && ((this.val === undefined) || (this.val === null))) {
-              this.val = nullValue
+        /**
+         * Gives you the exponent value of the attribute specified between
+         * $('') notation
+         *
+         * Example: $('Height').pow(2).value() returns the result of
+         * height_value ^ 2
+         *
+         * @param exp :
+            *            The number you use to execute the power function
+         *
+         * @memberof $
+         * @method pow
+         */
+        pow: function (exp) {
+            if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
+                exp = exp.value()
+            }
+            this.val = Math.pow(this.val, exp)
+            return this
+        },
+        /**
+         * Gives you the multiplication value of the attribute specified between
+         * $('') notation
+         *
+         * Example: $('Height').times(2).value() returns the result of
+         * height_value * 2
+         *
+         * @param factor :
+            *            The number you multiply by
+         *
+         * @memberof $
+         * @method div
+         */
+        times: function (factor) {
+            if ((typeof factor === 'object') && (typeof factor.value === 'function')) {
+                factor = factor.value()
+            }
+            this.val = (this.val * factor)
+            return this
+        },
+        /**
+         * Gives you the division value of the attribute specified between
+         * $('') notation
+         *
+         * Example: $('Height').div(2).value() returns the result of
+         * height_value / 2
+         *
+         * @param denominator :
+            *            The number you divide by
+         *
+         * @memberof $
+         * @method div
+         */
+        div: function (denominator) {
+            if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
+                denominator = denominator.value()
+            }
+            this.val = (this.val / denominator)
+            return this
+        },
+        /**
+         * Returns the age based on the date of birth and the current year
+         *
+         * Example: $('Date_Of_Birth').age().value()
+         *
+         * @memberof $
+         * @method age
+         */
+        age: function () {
+            if (_isNull(this.val)) {
+                this.val = undefined
             } else {
-              this.val = defaultValue
+                this.val = Math.floor((Date.now() - this.val) / (365.2425 * 24 * 60 * 60 * 1000))
             }
-          }
-        }
-        return this
-      },
-      /**
-       * Group values into defined ranges
-       *
-       * Example: age -> 19, 39, 50, 75
-       * $('age').group({18, 35, 50, 75}).value() produces the following ranges which are left inclusive, (-∞, 18), [18, 35), [35, 50), [50, 75), [75, +∞)
-       * the text representations are '-18','18-35','35-50','50-75','75+'
-       *
-       * @param arrayOfBounds :
-        *            a list of values that will be the bounds of the ranges.
-       * @param arrayOfOutliers :
-        *            a list of outlier values that will be not be grouped and will be returned as is.
-       * @param nullValue :
-        *            a value to use for null instances
-       *
-       *
-       * @memberof $
-       * @method group
-       */
-      group: function (arrayOfBounds, arrayOfOutliers, nullValue) {
-
-        // Check if the the value is an outlier value
-        if (arrayOfOutliers && arrayOfOutliers.length > 0) {
-          for (var i = 0; i < arrayOfOutliers.length; i++) {
-            if (this.val === arrayOfOutliers[i]) {
-              return this
+            return this
+        },
+        /**
+         * Maps categories to eachother.
+         *
+         * Example: Dataset1 -> Male = 1, Female = 2 Dataset2 -> Male = 0,
+         * Female = 1 $('Dataset2').map({0:1, 1:2}).value()
+         *
+         * @param categoryMapping :
+            *            The mapping in JSON format to apply
+         * @param defaultValue :
+            *            a value to use for categories that are not mentioned
+         *            in the categoryMappign
+         * @param nullValue :
+            *            a value to use for null instances
+         *
+         * @memberof $
+         * @method map
+         */
+        map: function (categoryMapping, defaultValue, nullValue) {
+            if (typeof categoryMapping === 'function') {
+                this.val = this.val.map(newValue).map(categoryMapping)
+            } else {
+                this.val = this.value()
+                if (this.val in categoryMapping) {
+                    this.val = categoryMapping[this.val]
+                } else {
+                    if (nullValue !== undefined && ((this.val === undefined) || (this.val === null))) {
+                        this.val = nullValue
+                    } else {
+                        this.val = defaultValue
+                    }
+                }
             }
-          }
-        }
-        // find the ranges that the value fits into
-        if (arrayOfBounds && arrayOfBounds.length > 0) {
-          var originalValue = this.val
-          if (originalValue < arrayOfBounds[0]) {
-            this.val = '-' + arrayOfBounds[0]
-          } else if (originalValue >= arrayOfBounds[arrayOfBounds.length - 1]) {
-            this.val = arrayOfBounds[arrayOfBounds.length - 1] + '+'
-          }
-          if (arrayOfBounds.length > 1) {
-            for (var i = 1; i < arrayOfBounds.length; i++) {
-              var lowerBound = arrayOfBounds[i - 1]
-              var upperBound = arrayOfBounds[i]
-              //If lowerBound is bigger than upperBound, restore the original value and stop the function
-              if (lowerBound > upperBound) {
-                this.val = nullValue ? nullValue : null
-                break
-              }
-              if (originalValue >= lowerBound && originalValue < upperBound) {
-                this.val = lowerBound + '-' + upperBound
-                break
-              }
+            return this
+        },
+        /**
+         * Group values into defined ranges
+         *
+         * Example: age -> 19, 39, 50, 75
+         * $('age').group({18, 35, 50, 75}).value() produces the following ranges which are left inclusive, (-∞, 18), [18, 35), [35, 50), [50, 75), [75, +∞)
+         * the text representations are '-18','18-35','35-50','50-75','75+'
+         *
+         * @param arrayOfBounds :
+            *            a list of values that will be the bounds of the ranges.
+         * @param arrayOfOutliers :
+            *            a list of outlier values that will be not be grouped and will be returned as is.
+         * @param nullValue :
+            *            a value to use for null instances
+         *
+         *
+         * @memberof $
+         * @method group
+         */
+        group: function (arrayOfBounds, arrayOfOutliers, nullValue) {
+
+            // Check if the the value is an outlier value
+            if (arrayOfOutliers && arrayOfOutliers.length > 0) {
+                for (var i = 0; i < arrayOfOutliers.length; i++) {
+                    if (this.val === arrayOfOutliers[i]) {
+                        return this
+                    }
+                }
             }
-          }
-          return this
-        }
+            // find the ranges that the value fits into
+            if (arrayOfBounds && arrayOfBounds.length > 0) {
+                var originalValue = this.val
+                if (originalValue < arrayOfBounds[0]) {
+                    this.val = '-' + arrayOfBounds[0]
+                } else if (originalValue >= arrayOfBounds[arrayOfBounds.length - 1]) {
+                    this.val = arrayOfBounds[arrayOfBounds.length - 1] + '+'
+                }
+                if (arrayOfBounds.length > 1) {
+                    for (var i = 1; i < arrayOfBounds.length; i++) {
+                        var lowerBound = arrayOfBounds[i - 1]
+                        var upperBound = arrayOfBounds[i]
+                        //If lowerBound is bigger than upperBound, restore the original value and stop the function
+                        if (lowerBound > upperBound) {
+                            this.val = nullValue ? nullValue : null
+                            break
+                        }
+                        if (originalValue >= lowerBound && originalValue < upperBound) {
+                            this.val = lowerBound + '-' + upperBound
+                            break
+                        }
+                    }
+                }
+                return this
+            }
 
-        this.val = nullValue ? nullValue : null
-        return this
-      },
-      /**
-       * Compares two values and returns true or false
-       *
-       * Example: $('Height').eq(100).value()
-       *
-       * @param other :
-        *            the value you wish to compare with
-       *
-       * @memberof $
-       * @method eq
-       */
-      eq: function (other) {
-        if (_isNull(this.val) && _isNull(other)) {
-          this.val = false
-        } else if (_isNull(this.val) && !_isNull(other)) {
-          this.val = false
-        } else {
-          this.val = (this.value() === other)
+            this.val = nullValue ? nullValue : null
+            return this
+        },
+        /**
+         * Compares two values and returns true or false
+         *
+         * Example: $('Height').eq(100).value()
+         *
+         * @param other :
+            *            the value you wish to compare with
+         *
+         * @memberof $
+         * @method eq
+         */
+        eq: function (other) {
+            if (_isNull(this.val) && _isNull(other)) {
+                this.val = false
+            } else if (_isNull(this.val) && !_isNull(other)) {
+                this.val = false
+            } else {
+                this.val = (this.value() === other)
+            }
+            return this
+        },
+        /**
+         * Check if a value matches a regular expression
+         *
+         * Example: $('Username').matches(/^[a-z0-9_-]{6,18}$/).value()
+         */
+        matches: function (regex) {
+            this.val = regex.test(this.val)
+            return this
+        },
+        /**
+         * Check if a value is null
+         *
+         * Example: $('Height').isNull().value()
+         *
+         * @memberof $
+         * @method isNull
+         */
+        isNull: function () {
+            this.val = _isNull(this.val)
+            return this
+        },
+        /**
+         * Checks if a boolean is not
+         *
+         * Example: $('Has_Ears').not().value()
+         *
+         * @memberof $
+         * @method not
+         */
+        not: function () {
+            this.val = !this.val
+            return this
+        },
+        /**
+         * Checks if something is one value or the other
+         *
+         * Example: $('male').or($('female')).value()
+         *
+         * @param other :
+            *            Another value
+         *
+         * @memberof $
+         * @method or
+         */
+        or: function (other) {
+            this.val = (this.val || other.value())
+            return this
+        },
+        /**
+         * Checks if something is one value and the other
+         *
+         * Example: $('female').and($('pregnant')).value()
+         *
+         * @param other :
+            *            Another value
+         *
+         * @memberof $
+         * @method and
+         */
+        and: function (other) {
+            this.val = (this.val && other.value())
+            return this
+        },
+        /**
+         * Returns true or false if Greater then the submitted value
+         *
+         * Example: $('Height').gt(100).value()
+         *
+         * @param value :
+            *            The value you compare with
+         *
+         * @memberof $
+         * @method gt
+         */
+        gt: function (value) {
+            this.val = _isNull(this.val) ? false : (this.value() > value)
+            return this
+        },
+        /**
+         * Returns true or false if Less then the submitted value
+         *
+         * Example: $('Height').lt(100).value()
+         *
+         * @param value :
+            *            The value you compare with
+         *
+         * @memberof $
+         * @method lt
+         */
+        lt: function (value) {
+            this.val = _isNull(this.val) ? false : (this.value() < value)
+            return this
+        },
+        /**
+         * Returns true or false if Greater or equal then the submitted
+         * value
+         *
+         * Example: $('Height').ge(100).value()
+         *
+         * @param value :
+            *            The value you compare with
+         *
+         * @memberof $
+         * @method ge
+         */
+        ge: function (value) {
+            this.val = _isNull(this.val) ? false : (this.value() >= value)
+            return this
+        },
+        /**
+         * Returns true or false if Less or equal then the submitted value
+         *
+         * Example: $('Height').le(100).value()
+         *
+         * @param value :
+            *            The value you compare with
+         *
+         * @memberof $
+         * @method le
+         */
+        le: function (value) {
+            this.val = _isNull(this.val) ? false : (this.value() <= value)
+            return this
+        },
+        /**
+         * Sets the measurement unit of the current value to the specified
+         * unit. Returns the current unit when no argument is supplied.
+         *
+         * @memberof $
+         * @method unit
+         */
+        unit: function (newUnit) {
+            if (!newUnit) {
+                return this.unit
+            }
+            this.unit = newUnit
+            return this
+        },
+        /**
+         * Measurement unit conversion: converts the current value into a
+         * different measurement unit.
+         *
+         * @memberof $
+         * @method toUnit
+         */
+        toUnit: function (targetUnit) {
+            var unit = math.unit(this.val, this.unit)
+            this.val = unit.toNumber(targetUnit)
+            return this
         }
-        return this
-      },
-      /**
-       * Check if a value matches a regular expression
-       *
-       * Example: $('Username').matches(/^[a-z0-9_-]{6,18}$/).value()
-       */
-      matches: function (regex) {
-        this.val = regex.test(this.val)
-        return this
-      },
-      /**
-       * Check if a value is null
-       *
-       * Example: $('Height').isNull().value()
-       *
-       * @memberof $
-       * @method isNull
-       */
-      isNull: function () {
-        this.val = _isNull(this.val)
-        return this
-      },
-      /**
-       * Checks if a boolean is not
-       *
-       * Example: $('Has_Ears').not().value()
-       *
-       * @memberof $
-       * @method not
-       */
-      not: function () {
-        this.val = !this.val
-        return this
-      },
-      /**
-       * Checks if something is one value or the other
-       *
-       * Example: $('male').or($('female')).value()
-       *
-       * @param other :
-        *            Another value
-       *
-       * @memberof $
-       * @method or
-       */
-      or: function (other) {
-        this.val = (this.val || other.value())
-        return this
-      },
-      /**
-       * Checks if something is one value and the other
-       *
-       * Example: $('female').and($('pregnant')).value()
-       *
-       * @param other :
-        *            Another value
-       *
-       * @memberof $
-       * @method and
-       */
-      and: function (other) {
-        this.val = (this.val && other.value())
-        return this
-      },
-      /**
-       * Returns true or false if Greater then the submitted value
-       *
-       * Example: $('Height').gt(100).value()
-       *
-       * @param value :
-        *            The value you compare with
-       *
-       * @memberof $
-       * @method gt
-       */
-      gt: function (value) {
-        this.val = _isNull(this.val) ? false : (this.value() > value)
-        return this
-      },
-      /**
-       * Returns true or false if Less then the submitted value
-       *
-       * Example: $('Height').lt(100).value()
-       *
-       * @param value :
-        *            The value you compare with
-       *
-       * @memberof $
-       * @method lt
-       */
-      lt: function (value) {
-        this.val = _isNull(this.val) ? false : (this.value() < value)
-        return this
-      },
-      /**
-       * Returns true or false if Greater or equal then the submitted
-       * value
-       *
-       * Example: $('Height').ge(100).value()
-       *
-       * @param value :
-        *            The value you compare with
-       *
-       * @memberof $
-       * @method ge
-       */
-      ge: function (value) {
-        this.val = _isNull(this.val) ? false : (this.value() >= value)
-        return this
-      },
-      /**
-       * Returns true or false if Less or equal then the submitted value
-       *
-       * Example: $('Height').le(100).value()
-       *
-       * @param value :
-        *            The value you compare with
-       *
-       * @memberof $
-       * @method le
-       */
-      le: function (value) {
-        this.val = _isNull(this.val) ? false : (this.value() <= value)
-        return this
-      },
-      /**
-       * Sets the measurement unit of the current value to the specified
-       * unit. Returns the current unit when no argument is supplied.
-       *
-       * @memberof $
-       * @method unit
-       */
-      unit: function (newUnit) {
-        if (!newUnit) {
-          return this.unit
-        }
-        this.unit = newUnit
-        return this
-      },
-      /**
-       * Measurement unit conversion: converts the current value into a
-       * different measurement unit.
-       *
-       * @memberof $
-       * @method toUnit
-       */
-      toUnit: function (targetUnit) {
-        var unit = math.unit(this.val, this.unit)
-        this.val = unit.toNumber(targetUnit)
-        return this
-      }
-    }
-
-    function _isNull (value) {
-      if (value === null || value === undefined)
-        return true
-      if ((typeof value === 'string') && (value.length == 0))
-        return true
-      return false
     }
 
     attribute.val = value
     return attribute
-  }
+}
 
-  /**
-   * Stores the computed attribute value after applying on of the mathematical
-   * functions listed below
-   *
-   * In case of deep referencing attribute e.g. xref.xref2.label, we loop through these attributes and only return
-   * new Attribute(label)
-   *
-   * @version 1.0
-   * @namespace $
-   */
-  function $ (attr) {
+function _isNull (value) {
+    if (value === null || value === undefined)
+        return true
+    if ((typeof value === 'string') && (value.length == 0))
+        return true
+    return false
+}
+
+function newValue (value) {
+    return new Attribute(value)
+}
+
+/**
+ * Stores the computed attribute value after applying on of the mathematical
+ * functions listed below
+ *
+ * In case of deep referencing attribute e.g. xref.xref2.label, we loop through these attributes and only return
+ * new Attribute(label)
+ *
+ * @version 1.0
+ * @namespace $
+ */
+function $ (attr) {
     var attributes = attr.split('\.')
     var result = this
 
     for (var i = 0; i < attributes.length && result !== null; i++) {
-      result = result[attributes[i]]
+        result = result[attributes[i]]
     }
     return new Attribute(result)
-  }
-
-  function newValue (value) {
-    return new Attribute(value)
-  }
-
-  $ = $.bind(entity)
-  return eval(script)
 }

--- a/molgenis-js/src/main/resources/js/script-evaluator.js
+++ b/molgenis-js/src/main/resources/js/script-evaluator.js
@@ -7,9 +7,12 @@
  */
 function evalScript (script, entity) {
     // make functions available to the script in local scope
-    var $ = MagmaScript.$.bind(entity)
-    var newValue = MagmaScript.newValue
-    var _isNull = MagmaScript._isNull
+    // noinspection JSUnusedLocalSymbols
+    var $ = MagmaScript.$.bind(entity) //NOSONAR
+    // noinspection JSUnusedLocalSymbols
+    var newValue = MagmaScript.newValue // NOSONAR
+    // noinspection JSUnusedLocalSymbols
+    var _isNull = MagmaScript._isNull // NOSONAR
     return eval(script)
 }
 

--- a/molgenis-js/src/main/resources/js/script-evaluator.js
+++ b/molgenis-js/src/main/resources/js/script-evaluator.js
@@ -1,452 +1,444 @@
 /**
  * Evaluates a script.
  *
- * @param script
- *            the script
- * @param entity
- *            the entity
+ * @param script the script
+ * @param entity object mapping attribute name key to attribute value
  * @returns the evaluated script result
  */
 function evalScript (script, entity) {
-    var $ = $.bind(entity)
+    // make functions available to the script in local scope
+    var $ = MagmaScript.$.bind(entity)
+    var newValue = MagmaScript.newValue
+    var _isNull = MagmaScript._isNull
     return eval(script)
 }
 
-function Attribute (value) {
-
-    var attribute = {
-        /**
-         *
-         * Gives you the value of the attribute specified between $('')
-         * notation
-         *
-         * Example: $('Height').value() returns the values of the height
-         * attribute
-         *
-         * If the value is an object, return the idValue
-         *
-         * @memberof $
-         * @method value
-         *
-         */
-        value: function () {
-            if (this.val !== null && typeof this.val === 'object') {
-                if (this.val['_idValue'] !== undefined) {
-
-                    // Map a list of entities to a list of ID's
-                    if (Array.isArray(this.val)) {
-                        return this.val.map(function (value) {
-                            return newValue(value).value()
-                        })
-                    }
-                    return this.val['_idValue']
-                }
-            }
-            return this.val
-        },
-
-        /**
-         * Returns true if your value is valid JSON
-         * Returns false if not
-         */
-        isValidJson: function () {
-            try {
-                JSON.parse(this.val)
-                this.val = true
-            } catch (e) {
-                this.val = false
-            }
-            return this
-        },
-
-        /**
-         * returns the result of the first value plus the second value
-         *
-         * @param value: the number you want to add to the current value
-         */
-        plus: function (value) {
-            if (!_isNull(value)) {
-                if (typeof value === 'object' || typeof value === 'function') {
-                    this.val = this.val + value.value()
-                } else {
-                    this.val = this.val + value
-                }
-            }
-            return this
-        },
-
-        /**
-         * Gives you the exponent value of the attribute specified between
-         * $('') notation
-         *
-         * Example: $('Height').pow(2).value() returns the result of
-         * height_value ^ 2
-         *
-         * @param exp :
-            *            The number you use to execute the power function
-         *
-         * @memberof $
-         * @method pow
-         */
-        pow: function (exp) {
-            if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
-                exp = exp.value()
-            }
-            this.val = Math.pow(this.val, exp)
-            return this
-        },
-        /**
-         * Gives you the multiplication value of the attribute specified between
-         * $('') notation
-         *
-         * Example: $('Height').times(2).value() returns the result of
-         * height_value * 2
-         *
-         * @param factor :
-            *            The number you multiply by
-         *
-         * @memberof $
-         * @method div
-         */
-        times: function (factor) {
-            if ((typeof factor === 'object') && (typeof factor.value === 'function')) {
-                factor = factor.value()
-            }
-            this.val = (this.val * factor)
-            return this
-        },
-        /**
-         * Gives you the division value of the attribute specified between
-         * $('') notation
-         *
-         * Example: $('Height').div(2).value() returns the result of
-         * height_value / 2
-         *
-         * @param denominator :
-            *            The number you divide by
-         *
-         * @memberof $
-         * @method div
-         */
-        div: function (denominator) {
-            if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
-                denominator = denominator.value()
-            }
-            this.val = (this.val / denominator)
-            return this
-        },
-        /**
-         * Returns the age based on the date of birth and the current year
-         *
-         * Example: $('Date_Of_Birth').age().value()
-         *
-         * @memberof $
-         * @method age
-         */
-        age: function () {
-            if (_isNull(this.val)) {
-                this.val = undefined
-            } else {
-                this.val = Math.floor((Date.now() - this.val) / (365.2425 * 24 * 60 * 60 * 1000))
-            }
-            return this
-        },
-        /**
-         * Maps categories to eachother.
-         *
-         * Example: Dataset1 -> Male = 1, Female = 2 Dataset2 -> Male = 0,
-         * Female = 1 $('Dataset2').map({0:1, 1:2}).value()
-         *
-         * @param categoryMapping :
-            *            The mapping in JSON format to apply
-         * @param defaultValue :
-            *            a value to use for categories that are not mentioned
-         *            in the categoryMappign
-         * @param nullValue :
-            *            a value to use for null instances
-         *
-         * @memberof $
-         * @method map
-         */
-        map: function (categoryMapping, defaultValue, nullValue) {
-            if (typeof categoryMapping === 'function') {
-                this.val = this.val.map(newValue).map(categoryMapping)
-            } else {
-                this.val = this.value()
-                if (this.val in categoryMapping) {
-                    this.val = categoryMapping[this.val]
-                } else {
-                    if (nullValue !== undefined && ((this.val === undefined) || (this.val === null))) {
-                        this.val = nullValue
-                    } else {
-                        this.val = defaultValue
-                    }
-                }
-            }
-            return this
-        },
-        /**
-         * Group values into defined ranges
-         *
-         * Example: age -> 19, 39, 50, 75
-         * $('age').group({18, 35, 50, 75}).value() produces the following ranges which are left inclusive, (-∞, 18), [18, 35), [35, 50), [50, 75), [75, +∞)
-         * the text representations are '-18','18-35','35-50','50-75','75+'
-         *
-         * @param arrayOfBounds :
-            *            a list of values that will be the bounds of the ranges.
-         * @param arrayOfOutliers :
-            *            a list of outlier values that will be not be grouped and will be returned as is.
-         * @param nullValue :
-            *            a value to use for null instances
-         *
-         *
-         * @memberof $
-         * @method group
-         */
-        group: function (arrayOfBounds, arrayOfOutliers, nullValue) {
-
-            // Check if the the value is an outlier value
-            if (arrayOfOutliers && arrayOfOutliers.length > 0) {
-                for (var i = 0; i < arrayOfOutliers.length; i++) {
-                    if (this.val === arrayOfOutliers[i]) {
-                        return this
-                    }
-                }
-            }
-            // find the ranges that the value fits into
-            if (arrayOfBounds && arrayOfBounds.length > 0) {
-                var originalValue = this.val
-                if (originalValue < arrayOfBounds[0]) {
-                    this.val = '-' + arrayOfBounds[0]
-                } else if (originalValue >= arrayOfBounds[arrayOfBounds.length - 1]) {
-                    this.val = arrayOfBounds[arrayOfBounds.length - 1] + '+'
-                }
-                if (arrayOfBounds.length > 1) {
-                    for (var i = 1; i < arrayOfBounds.length; i++) {
-                        var lowerBound = arrayOfBounds[i - 1]
-                        var upperBound = arrayOfBounds[i]
-                        //If lowerBound is bigger than upperBound, restore the original value and stop the function
-                        if (lowerBound > upperBound) {
-                            this.val = nullValue ? nullValue : null
-                            break
-                        }
-                        if (originalValue >= lowerBound && originalValue < upperBound) {
-                            this.val = lowerBound + '-' + upperBound
-                            break
-                        }
-                    }
-                }
-                return this
-            }
-
-            this.val = nullValue ? nullValue : null
-            return this
-        },
-        /**
-         * Compares two values and returns true or false
-         *
-         * Example: $('Height').eq(100).value()
-         *
-         * @param other :
-            *            the value you wish to compare with
-         *
-         * @memberof $
-         * @method eq
-         */
-        eq: function (other) {
-            if (_isNull(this.val) && _isNull(other)) {
-                this.val = false
-            } else if (_isNull(this.val) && !_isNull(other)) {
-                this.val = false
-            } else {
-                this.val = (this.value() === other)
-            }
-            return this
-        },
-        /**
-         * Check if a value matches a regular expression
-         *
-         * Example: $('Username').matches(/^[a-z0-9_-]{6,18}$/).value()
-         */
-        matches: function (regex) {
-            this.val = regex.test(this.val)
-            return this
-        },
-        /**
-         * Check if a value is null
-         *
-         * Example: $('Height').isNull().value()
-         *
-         * @memberof $
-         * @method isNull
-         */
-        isNull: function () {
-            this.val = _isNull(this.val)
-            return this
-        },
-        /**
-         * Checks if a boolean is not
-         *
-         * Example: $('Has_Ears').not().value()
-         *
-         * @memberof $
-         * @method not
-         */
-        not: function () {
-            this.val = !this.val
-            return this
-        },
-        /**
-         * Checks if something is one value or the other
-         *
-         * Example: $('male').or($('female')).value()
-         *
-         * @param other :
-            *            Another value
-         *
-         * @memberof $
-         * @method or
-         */
-        or: function (other) {
-            this.val = (this.val || other.value())
-            return this
-        },
-        /**
-         * Checks if something is one value and the other
-         *
-         * Example: $('female').and($('pregnant')).value()
-         *
-         * @param other :
-            *            Another value
-         *
-         * @memberof $
-         * @method and
-         */
-        and: function (other) {
-            this.val = (this.val && other.value())
-            return this
-        },
-        /**
-         * Returns true or false if Greater then the submitted value
-         *
-         * Example: $('Height').gt(100).value()
-         *
-         * @param value :
-            *            The value you compare with
-         *
-         * @memberof $
-         * @method gt
-         */
-        gt: function (value) {
-            this.val = _isNull(this.val) ? false : (this.value() > value)
-            return this
-        },
-        /**
-         * Returns true or false if Less then the submitted value
-         *
-         * Example: $('Height').lt(100).value()
-         *
-         * @param value :
-            *            The value you compare with
-         *
-         * @memberof $
-         * @method lt
-         */
-        lt: function (value) {
-            this.val = _isNull(this.val) ? false : (this.value() < value)
-            return this
-        },
-        /**
-         * Returns true or false if Greater or equal then the submitted
-         * value
-         *
-         * Example: $('Height').ge(100).value()
-         *
-         * @param value :
-            *            The value you compare with
-         *
-         * @memberof $
-         * @method ge
-         */
-        ge: function (value) {
-            this.val = _isNull(this.val) ? false : (this.value() >= value)
-            return this
-        },
-        /**
-         * Returns true or false if Less or equal then the submitted value
-         *
-         * Example: $('Height').le(100).value()
-         *
-         * @param value :
-            *            The value you compare with
-         *
-         * @memberof $
-         * @method le
-         */
-        le: function (value) {
-            this.val = _isNull(this.val) ? false : (this.value() <= value)
-            return this
-        },
-        /**
-         * Sets the measurement unit of the current value to the specified
-         * unit. Returns the current unit when no argument is supplied.
-         *
-         * @memberof $
-         * @method unit
-         */
-        unit: function (newUnit) {
-            if (!newUnit) {
-                return this.unit
-            }
-            this.unit = newUnit
-            return this
-        },
-        /**
-         * Measurement unit conversion: converts the current value into a
-         * different measurement unit.
-         *
-         * @memberof $
-         * @method toUnit
-         */
-        toUnit: function (targetUnit) {
-            var unit = math.unit(this.val, this.unit)
-            this.val = unit.toNumber(targetUnit)
-            return this
-        }
-    }
-
-    attribute.val = value
-    return attribute
-}
-
-function _isNull (value) {
-    if (value === null || value === undefined)
-        return true
-    if ((typeof value === 'string') && (value.length == 0))
-        return true
-    return false
-}
-
-function newValue (value) {
-    return new Attribute(value)
+function MagmaScript (val) {
+    this.val = val
 }
 
 /**
- * Stores the computed attribute value after applying on of the mathematical
+ *
+ * Gives you the value of the attribute specified between $('')
+ * notation
+ *
+ * Example: $('Height').value() returns the values of the height
+ * attribute
+ *
+ * If the value is an object, returns the idValue
+ *
+ * @memberof MagmaScript
+ * @method value
+ *
+ */
+MagmaScript.prototype.value = function () {
+    if (this.val !== null && typeof this.val === 'object') {
+        if (this.val['_idValue'] !== undefined) {
+
+            // Map a list of entities to a list of ID's
+            if (Array.isArray(this.val)) {
+                return this.val.map(function (value) {
+                    return new MagmaScript.newValue(value).value()
+                })
+            }
+            return this.val['_idValue']
+        }
+    }
+    return this.val
+}
+
+/**
+ * Returns true if your value is valid JSON
+ * Returns false if not
+ */
+MagmaScript.prototype.isValidJson = function () {
+    try {
+        JSON.parse(this.val)
+        this.val = true
+    } catch (e) {
+        this.val = false
+    }
+    return this
+}
+
+/**
+ * returns the result of the first value plus the second value
+ *
+ * @param value: the number you want to add to the current value
+ */
+MagmaScript.prototype.plus = function (value) {
+    if (!_isNull(value)) {
+        if (typeof value === 'object' || typeof value === 'function') {
+            this.val = this.val + value.value()
+        } else {
+            this.val = this.val + value
+        }
+    }
+    return this
+}
+
+/**
+ * Gives you the exponent value of the attribute specified between
+ * $('') notation
+ *
+ * Example: $('Height').pow(2).value() returns the result of
+ * height_value ^ 2
+ *
+ * @param exp The number you use to execute the power function
+ *
+ * @memberof MagmaScript
+ * @method pow
+ */
+MagmaScript.prototype.pow = function (exp) {
+    if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
+        exp = exp.value()
+    }
+    this.val = Math.pow(this.val, exp)
+    return this
+}
+
+/**
+ * Gives you the multiplication value of the attribute specified between
+ * $('') notation
+ *
+ * Example: $('Height').times(2).value() returns the result of
+ * height_value * 2
+ *
+ * @param factor :
+    *            The number you multiply by
+ *
+ * @memberof MagmaScript
+ * @method div
+ */
+MagmaScript.prototype.times = function (factor) {
+    if ((typeof factor === 'object') && (typeof factor.value === 'function')) {
+        factor = factor.value()
+    }
+    this.val = (this.val * factor)
+    return this
+}
+
+/**
+ * Gives you the division value of the attribute specified between
+ * $('') notation
+ *
+ * Example: $('Height').div(2).value() returns the result of
+ * height_value / 2
+ *
+ * @param denominator The number you divide by
+ *
+ * @memberof MagmaScript
+ * @method div
+ */
+MagmaScript.prototype.div = function (denominator) {
+    if ((typeof denominator === 'object') && (typeof denominator.value === 'function')) {
+        denominator = denominator.value()
+    }
+    this.val = (this.val / denominator)
+    return this
+}
+
+/**
+ * Returns the age based on the date of birth and the current year
+ *
+ * Example: $('Date_Of_Birth').age().value()
+ *
+ * @memberof MagmaScript
+ * @method age
+ */
+MagmaScript.prototype.age = function () {
+    if (MagmaScript._isNull(this.val)) {
+        this.val = undefined
+    } else {
+        this.val = Math.floor((Date.now() - this.val) / (365.2425 * 24 * 60 * 60 * 1000))
+    }
+    return this
+}
+
+/**
+ * Maps categories to each other.
+ *
+ * Example: Dataset1 -> Male = 1, Female = 2 Dataset2 -> Male = 0,
+ * Female = 1 $('Dataset2').map({0:1, 1:2}).value()
+ *
+ * @param categoryMapping  The mapping in JSON format to apply
+ * @param defaultValue     a value to use for categories that are not mentioned in the categoryMappign
+ * @param nullValue        a value to use for null instances
+ *
+ * @memberof MagmaScript
+ * @method map
+ */
+MagmaScript.prototype.map = function (categoryMapping, defaultValue, nullValue) {
+    if (typeof categoryMapping === 'function') {
+        this.val = this.val.map(MagmaScript.newValue).map(categoryMapping)
+    } else {
+        this.val = this.value()
+        if (this.val in categoryMapping) {
+            this.val = categoryMapping[this.val]
+        } else {
+            if (nullValue !== undefined && ((this.val === undefined) || (this.val === null))) {
+                this.val = nullValue
+            } else {
+                this.val = defaultValue
+            }
+        }
+    }
+    return this
+}
+
+/**
+ * Group values into defined ranges
+ *
+ * Example: age -> 19, 39, 50, 75
+ * $('age').group({18, 35, 50, 75}).value() produces the following ranges which are left inclusive, (-∞, 18), [18, 35), [35, 50), [50, 75), [75, +∞)
+ * the text representations are '-18','18-35','35-50','50-75','75+'
+ *
+ * @param arrayOfBounds a list of values that will be the bounds of the ranges.
+ * @param arrayOfOutliers a list of outlier values that will be not be grouped and will be returned as is.
+ * @param nullValue a value to use for null instances
+ *
+ * @memberof MagmaScript
+ * @method group
+ */
+MagmaScript.prototype.group = function (arrayOfBounds, arrayOfOutliers, nullValue) {
+
+    // Check if the the value is an outlier value
+    if (arrayOfOutliers && arrayOfOutliers.length > 0) {
+        for (var i = 0; i < arrayOfOutliers.length; i++) {
+            if (this.val === arrayOfOutliers[i]) {
+                return this
+            }
+        }
+    }
+    // find the ranges that the value fits into
+    if (arrayOfBounds && arrayOfBounds.length > 0) {
+        var originalValue = this.val
+        if (originalValue < arrayOfBounds[0]) {
+            this.val = '-' + arrayOfBounds[0]
+        } else if (originalValue >= arrayOfBounds[arrayOfBounds.length - 1]) {
+            this.val = arrayOfBounds[arrayOfBounds.length - 1] + '+'
+        }
+        if (arrayOfBounds.length > 1) {
+            for (var i = 1; i < arrayOfBounds.length; i++) {
+                var lowerBound = arrayOfBounds[i - 1]
+                var upperBound = arrayOfBounds[i]
+                //If lowerBound is bigger than upperBound, restore the original value and stop the function
+                if (lowerBound > upperBound) {
+                    this.val = nullValue ? nullValue : null
+                    break
+                }
+                if (originalValue >= lowerBound && originalValue < upperBound) {
+                    this.val = lowerBound + '-' + upperBound
+                    break
+                }
+            }
+        }
+        return this
+    }
+
+    this.val = nullValue ? nullValue : null
+    return this
+}
+
+/**
+ * Compares two values and returns true or false
+ *
+ * Example: $('Height').eq(100).value()
+ *
+ * @param other the value you wish to compare with
+ *
+ * @memberof MagmaScript
+ * @method eq
+ */
+MagmaScript.prototype.eq = function (other) {
+    if (MagmaScript._isNull(this.val) && MagmaScript._isNull(other)) {
+        this.val = false
+    } else if (MagmaScript._isNull(this.val) && !MagmaScript._isNull(other)) {
+        this.val = false
+    } else {
+        this.val = (this.value() === other)
+    }
+    return this
+}
+
+/**
+ * Check if a value matches a regular expression
+ *
+ * Example: $('Username').matches(/^[a-z0-9_-]{6,18}$/).value()
+ */
+MagmaScript.prototype.matches = function (regex) {
+    this.val = regex.test(this.val)
+    return this
+}
+
+/**
+ * Check if a value is null
+ *
+ * Example: $('Height').isNull().value()
+ *
+ * @memberof MagmaScript
+ * @method isNull
+ */
+MagmaScript.prototype.isNull = function () {
+    this.val = MagmaScript._isNull(this.val)
+    return this
+}
+
+/**
+ * Checks if a boolean is not
+ *
+ * Example: $('Has_Ears').not().value()
+ *
+ * @memberof MagmaScript
+ * @method not
+ */
+MagmaScript.prototype.not = function () {
+    this.val = !this.val
+    return this
+}
+
+/**
+ * Checks if something is one value or the other
+ *
+ * Example: $('male').or($('female')).value()
+ *
+ * @param other Another value
+ *
+ * @memberof MagmaScript
+ * @method or
+ */
+MagmaScript.prototype.or = function (other) {
+    this.val = (this.val || other.value())
+    return this
+}
+
+/**
+ * Checks if something is one value and the other
+ *
+ * Example: $('female').and($('pregnant')).value()
+ *
+ * @param other Another value
+ *
+ * @memberof MagmaScript
+ * @method and
+ */
+MagmaScript.prototype.and = function (other) {
+    this.val = (this.val && other.value())
+    return this
+}
+
+/**
+ * Returns true or false if Greater then the submitted value
+ *
+ * Example: $('Height').gt(100).value()
+ *
+ * @param value The value you compare with
+ *
+ * @memberof MagmaScript
+ * @method gt
+ */
+MagmaScript.prototype.gt = function (value) {
+    this.val = MagmaScript._isNull(this.val) ? false : (this.value() > value)
+    return this
+}
+
+/**
+ * Returns true or false if Less then the submitted value
+ *
+ * Example: $('Height').lt(100).value()
+ *
+ * @param value The value you compare with
+ *
+ * @memberof MagmaScript
+ * @method lt
+ */
+MagmaScript.prototype.lt = function (value) {
+    this.val = MagmaScript._isNull(this.val) ? false : (this.value() < value)
+    return this
+}
+/**
+ * Returns true or false if Greater or equal then the submitted
+ * value
+ *
+ * Example: $('Height').ge(100).value()
+ *
+ * @param value The value you compare with
+ *
+ * @memberof MagmaScript
+ * @method ge
+ */
+MagmaScript.prototype.ge = function (value) {
+    this.val = MagmaScript._isNull(this.val) ? false : (this.value() >= value)
+    return this
+}
+/**
+ * Returns true or false if Less or equal then the submitted value
+ *
+ * Example: $('Height').le(100).value()
+ *
+ * @param value The value you compare with
+ *
+ * @memberof MagmaScript
+ * @method le
+ */
+MagmaScript.prototype.le = function (value) {
+    this.val = MagmaScript._isNull(this.val) ? false : (this.value() <= value)
+    return this
+}
+/**
+ * Sets the measurement unit of the current value to the specified
+ * unit. Returns the current unit when no argument is supplied.
+ *
+ * @memberof MagmaScript
+ * @method unit
+ */
+MagmaScript.prototype.unit = function (newUnit) {
+    if (!newUnit) {
+        return this.unit
+    }
+    this.unit = newUnit
+    return this
+}
+
+/**
+ * Measurement unit conversion: converts the current value into a
+ * different measurement unit.
+ *
+ * @memberof MagmaScript
+ * @method toUnit
+ */
+MagmaScript.prototype.toUnit = function (targetUnit) {
+    var unit = math.unit(this.val, this.unit)
+    this.val = unit.toNumber(targetUnit)
+    return this
+}
+
+/**
+ * Stores the computed MagmaScript value after applying on of the mathematical
  * functions listed below
  *
  * In case of deep referencing attribute e.g. xref.xref2.label, we loop through these attributes and only return
- * new Attribute(label)
+ * new MagmaScript(label)
  *
  * @version 1.0
- * @namespace $
+ * @namespace MagmaScript
  */
-function $ (attr) {
+MagmaScript.$ = function (attr) {
     var attributes = attr.split('\.')
-    var result = this
+    var result = this // we expect the $ function be bound to the entity we're evaluating
 
     for (var i = 0; i < attributes.length && result !== null; i++) {
         result = result[attributes[i]]
     }
-    return new Attribute(result)
+    return new MagmaScript(result)
+}
+
+MagmaScript._isNull = function (value) {
+    if (value === null || value === undefined)
+        return true
+    return (typeof value === 'string') && (value.length === 0)
+}
+
+MagmaScript.newValue = function (value) {
+    return new MagmaScript(value)
 }

--- a/molgenis-js/src/main/resources/js/script-evaluator.js
+++ b/molgenis-js/src/main/resources/js/script-evaluator.js
@@ -67,7 +67,7 @@ MagmaScript.prototype.isValidJson = function () {
  * @param value: the number you want to add to the current value
  */
 MagmaScript.prototype.plus = function (value) {
-    if (!_isNull(value)) {
+    if (!MagmaScript._isNull(value)) {
         if (typeof value === 'object' || typeof value === 'function') {
             this.val = this.val + value.value()
         } else {

--- a/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
@@ -159,7 +159,7 @@ public class JsMagmaScriptEvaluatorTest
 
 		Object scriptExceptionObj = jsMagmaScriptEvaluator.eval("$('gender.xref.label').value()", person);
 		assertEquals(scriptExceptionObj.toString(),
-				"javax.script.ScriptException: TypeError: Cannot read property \"label\" from undefined in <eval> at line number 510");
+				"javax.script.ScriptException: TypeError: Cannot read property \"label\" from undefined in <eval> at line number 492");
 	}
 
 	@Test
@@ -509,7 +509,7 @@ public class JsMagmaScriptEvaluatorTest
 		Entity person = new DynamicEntity(personBirthDateMeta);
 		person.set("birthdate", now().atOffset(UTC).toLocalDate());
 
-		Bindings bindings = jsMagmaScriptEvaluator.createBindings(person, 3);
+		Bindings bindings = jsMagmaScriptEvaluator.createBindings(person);
 
 		Object result = jsMagmaScriptEvaluator.eval(bindings, "$('birthdate').age().value()");
 		assertEquals(result, 0d);
@@ -525,7 +525,7 @@ public class JsMagmaScriptEvaluatorTest
 
 		for (int i = 0; i < 10000; i++)
 		{
-			jsMagmaScriptEvaluator.eval("$('birthdate').age().value()", person, 3);
+			jsMagmaScriptEvaluator.eval("$('birthdate').age().value()", person);
 		}
 		System.out.println(sw.elapsed(TimeUnit.MILLISECONDS) + " millis passed old");
 	}

--- a/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
@@ -510,18 +510,36 @@ public class JsMagmaScriptEvaluatorTest
 	{
 		Entity person = new DynamicEntity(personBirthDateMeta);
 		person.set("birthdate", now().atOffset(UTC).toLocalDate());
+		Object result = jsMagmaScriptEvaluator.eval("$('birthdate').age().value()", person);
+		assertEquals(result, 0d);
+	}
+
+	@Test
+	public void evalWithBindings()
+	{
+		Entity person = new DynamicEntity(personBirthDateMeta);
+		person.set("birthdate", now().atOffset(UTC).toLocalDate());
 
 		Bindings bindings = jsMagmaScriptEvaluator.createBindings(person);
-
 		Object result = jsMagmaScriptEvaluator.eval(bindings, "$('birthdate').age().value()");
 		assertEquals(result, 0d);
+	}
+
+	@Test(enabled = false)
+	public void testPerformance()
+	{
+		Entity person = new DynamicEntity(personBirthDateMeta);
+		person.set("birthdate", now().atOffset(UTC).toLocalDate());
+
+		Bindings bindings = jsMagmaScriptEvaluator.createBindings(person);
+		jsMagmaScriptEvaluator.eval(bindings, "$('birthdate').age().value()");
 
 		Stopwatch sw = Stopwatch.createStarted();
 		for (int i = 0; i < 10000; i++)
 		{
 			jsMagmaScriptEvaluator.eval(bindings, "$('birthdate').age().value()");
 		}
-		System.out.println(sw.elapsed(TimeUnit.MILLISECONDS) + " millis passed new");
+		System.out.println(sw.elapsed(TimeUnit.MILLISECONDS) + " millis passed reusing same bindings");
 
 		sw.reset().start();
 
@@ -529,7 +547,8 @@ public class JsMagmaScriptEvaluatorTest
 		{
 			jsMagmaScriptEvaluator.eval("$('birthdate').age().value()", person);
 		}
-		System.out.println(sw.elapsed(TimeUnit.MILLISECONDS) + " millis passed old");
+		System.out.println(
+				sw.elapsed(TimeUnit.MILLISECONDS) + " millis passed recreating bindings for each evaluation");
 	}
 
 	@Test

--- a/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
@@ -519,15 +519,16 @@ public class JsMagmaScriptEvaluatorTest
 	@Test
 	public void evalList()
 	{
-		Entity person = new DynamicEntity(personBirthDateMeta);
-		person.set("birthdate", now().atOffset(UTC).toLocalDate());
+		Entity person = new DynamicEntity(personWeightAndHeightEntityType);
+		person.set("weight", 80);
+		person.set("height", 20);
 
 		List<Object> result = jsMagmaScriptEvaluator.evalList(
-				Arrays.asList("$('birthdate').age().value()", "$('height').pow(2).value()"), person);
-		assertEquals(result, Arrays.asList(0d, 400d));
+				Arrays.asList("$('weight').value()", "$('height').pow(2).value()"), person);
+		assertEquals(result, Arrays.asList(80, 400d));
 	}
 
-	@Test
+	@Test(enabled = false)
 	public void testPerformance()
 	{
 		Entity person = new DynamicEntity(personBirthDateMeta);
@@ -580,6 +581,16 @@ public class JsMagmaScriptEvaluatorTest
 		person1.set("weight", 99);
 		result = jsMagmaScriptEvaluator.eval(script, person1, 3);
 		assertEquals(result, false);
+	}
+
+	@Test
+	public void testIsValidJson()
+	{
+		Entity person = new DynamicEntity(personWeightEntityType);
+		List<Object> result = jsMagmaScriptEvaluator.evalList(
+				Arrays.asList("newValue('{\"foo\":3}').isValidJson().value()",
+						"newValue('{foo:3}').isValidJson().value()"), person);
+		assertEquals(result, Arrays.asList(true, false));
 	}
 
 	@Test

--- a/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
@@ -1,5 +1,6 @@
 package org.molgenis.js;
 
+import com.google.common.base.Stopwatch;
 import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
@@ -13,6 +14,7 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
 import java.util.Locale;
+import java.util.concurrent.TimeUnit;
 
 import static com.google.common.collect.Lists.newArrayList;
 import static java.time.Instant.now;
@@ -507,6 +509,13 @@ public class JsMagmaScriptEvaluatorTest
 
 		Object result = jsMagmaScriptEvaluator.eval("$('birthdate').age().value()", person, 3);
 		assertEquals(result, 0d);
+
+		Stopwatch sw = Stopwatch.createStarted();
+		for (int i = 0; i < 10000; i++)
+		{
+			jsMagmaScriptEvaluator.eval("$('birthdate').age().value()", person, 1);
+		}
+		System.out.println(sw.elapsed(TimeUnit.MILLISECONDS) + " millis passed");
 	}
 
 	@Test

--- a/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
@@ -11,6 +11,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import javax.script.Bindings;
+import javax.script.ScriptException;
+import java.io.IOException;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.time.LocalDate;
@@ -45,7 +47,7 @@ public class JsMagmaScriptEvaluatorTest
 	private static JsMagmaScriptEvaluator jsMagmaScriptEvaluator;
 
 	@BeforeClass
-	protected static void beforeClass()
+	protected static void beforeClass() throws ScriptException, IOException
 	{
 		Attribute idAttribute = mock(Attribute.class);
 		when(idAttribute.getName()).thenReturn("id");
@@ -159,7 +161,7 @@ public class JsMagmaScriptEvaluatorTest
 
 		Object scriptExceptionObj = jsMagmaScriptEvaluator.eval("$('gender.xref.label').value()", person);
 		assertEquals(scriptExceptionObj.toString(),
-				"javax.script.ScriptException: TypeError: Cannot read property \"label\" from undefined in <eval> at line number 492");
+				"javax.script.ScriptException: TypeError: Cannot read property \"label\" from undefined in <eval> at line number 431");
 	}
 
 	@Test

--- a/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/JsMagmaScriptEvaluatorTest.java
@@ -163,7 +163,7 @@ public class JsMagmaScriptEvaluatorTest
 
 		Object scriptExceptionObj = jsMagmaScriptEvaluator.eval("$('gender.xref.label').value()", person);
 		assertEquals(scriptExceptionObj.toString(),
-				"javax.script.ScriptException: TypeError: Cannot read property \"label\" from undefined in <eval> at line number 431");
+				"org.molgenis.script.core.ScriptException: <eval>:434 TypeError: Cannot read property \"label\" from undefined");
 	}
 
 	@Test

--- a/molgenis-js/src/test/java/org/molgenis/js/nashorn/NashornScriptEngineTest.java
+++ b/molgenis-js/src/test/java/org/molgenis/js/nashorn/NashornScriptEngineTest.java
@@ -3,6 +3,7 @@ package org.molgenis.js.nashorn;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import javax.script.ScriptException;
 import java.time.LocalDate;
 import java.time.ZoneId;
 
@@ -25,8 +26,7 @@ public class NashornScriptEngineTest
 	public void testInvokeFunction() throws Exception
 	{
 		long epoch = 1487342481434L;
-		assertEquals(nashornScriptEngine.invokeFunction("evalScript", "new Date(" + epoch + ")"), epoch);
-
+		assertEquals(nashornScriptEngine.eval("new Date(" + epoch + ")"), epoch);
 	}
 
 	@Test
@@ -36,7 +36,14 @@ public class NashornScriptEngineTest
 		String script = String.format("new Date(%d,%d,%d)", localDate.getYear(), localDate.getMonth().getValue() - 1,
 				localDate.getDayOfMonth());
 		long epochMilli = localDate.atStartOfDay(ZoneId.systemDefault()).toInstant().toEpochMilli();
-		assertEquals(nashornScriptEngine.invokeFunction("evalScript", script), epochMilli);
+		assertEquals(nashornScriptEngine.eval(script), epochMilli);
+	}
+
+	@Test(expectedExceptions = ScriptException.class, expectedExceptionsMessageRegExp = "ReferenceError: \"piet\" is not defined in <eval> at line number 1")
+	public void doesntDirtyContext() throws ScriptException
+	{
+		nashornScriptEngine.eval("piet = 3");
+		nashornScriptEngine.eval("piet");
 	}
 
 }

--- a/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/service/impl/AlgorithmServiceImplIT.java
+++ b/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/service/impl/AlgorithmServiceImplIT.java
@@ -41,6 +41,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import javax.script.ScriptException;
+import java.io.IOException;
 import java.text.ParseException;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -505,13 +507,13 @@ public class AlgorithmServiceImplIT extends AbstractMolgenisSpringTest
 		}
 
 		@Bean
-		public JsMagmaScriptEvaluator jsScriptEvaluator()
+		public JsMagmaScriptEvaluator jsScriptEvaluator() throws ScriptException, IOException
 		{
 			return new JsMagmaScriptEvaluator(new NashornScriptEngine());
 		}
 
 		@Bean
-		public AlgorithmService algorithmService()
+		public AlgorithmService algorithmService() throws ScriptException, IOException
 		{
 			return new AlgorithmServiceImpl(ontologyTagService(), semanticSearchService(), algorithmGeneratorService(),
 					entityManager(), jsScriptEvaluator());


### PR DESCRIPTION
A couple of changes:
* Cache compiled expressions
* Don't keep threadlocal bindings between requests, the global namespace will get polluted in the long run (this is a bugfix not a speedup)
    - Create new empty bindings for each simple script evaluation
    - Copy existing bindings for magmascript and bind them to the magmascript $ function in java code. 
* Reuse entity bindings for evaluation of multiple Boolean expressions on same entity, assuming that they do not pollute the context
* Create MagmaScript javascript class to scope the static functions and speed up attribute instance creation both client and server side by putting class method functions on the prototype instead of each instance. 
* Move magma-specific scripts and bindings to the JsMagmaScriptEvaluator

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly