### PR TITLE
Remove integration test checkbox

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,4 +7,3 @@
 - [ ] Test plan template updated
 - [ ] Clean commits
 - [ ] Added Feature/Fix to release notes
-- [ ] Integration tests run correctly


### PR DESCRIPTION
The integration tests run on travis just fine, so no need any more for the checkbox on the PR template that we introduced a couple of months ago.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
- [ ] Integration tests run correctly
