### PR TITLE
Fix #292 Freemarker number formatting default: 'computer'

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisWebAppConfig.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisWebAppConfig.java
@@ -315,6 +315,7 @@ public abstract class MolgenisWebAppConfig implements WebMvcConfigurer
 		result.setDefaultEncoding("UTF-8");
 		Properties freemarkerSettings = new Properties();
 		freemarkerSettings.setProperty(Configuration.LOCALIZED_LOOKUP_KEY, Boolean.FALSE.toString());
+		freemarkerSettings.setProperty(Configuration.NUMBER_FORMAT_KEY, "computer");
 		result.setFreemarkerSettings(freemarkerSettings);
 		Map<String, Object> freemarkerVariables = Maps.newHashMap();
 		freemarkerVariables.put("limit", new LimitMethod());


### PR DESCRIPTION
Tested using the following model attributes:
```
model.addAttribute("int", 1234);
model.addAttribute("long", 123456789012L);
model.addAttribute("decimal", 3.1415);
```
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes