### PR TITLE
Use label instead of id's 

### DIFF
--- a/molgenis-questionnaires/src/main/frontend/src/components/ChapterNavigation.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/components/ChapterNavigation.vue
@@ -137,8 +137,11 @@
             this.submitting = true
             this.submitQuestionnaire()
           } else {
-            const incompleteChapters = Object.keys(this.chapterCompletion).find(chapter => !this.chapterCompletion[chapter])
-            const error = this.$t('questionnaire_forgotten_chapters') + ': ' + incompleteChapters
+            const getChapterLabel = this.$store.getters.getChapterLabel
+            const incompleteChaptersIds = Object.keys(this.chapterCompletion)
+              .filter(chapter => !this.chapterCompletion[chapter])
+            const incompleteChaptersLabels = incompleteChaptersIds.map((chapterKey) => getChapterLabel(chapterKey))
+            const error = this.$t('questionnaire_forgotten_chapters') + ': ' + incompleteChaptersLabels.join(',')
 
             this.$store.commit('SET_ERROR', error)
           }

--- a/molgenis-questionnaires/src/main/frontend/src/flow.types.js
+++ b/molgenis-questionnaires/src/main/frontend/src/flow.types.js
@@ -1,5 +1,5 @@
 export type QuestionnaireState = {
-  chapterFields: Array<*>,
+  chapters: Array<Chapter>,
   error: string,
   formData: Object,
   loading: boolean,
@@ -18,3 +18,23 @@ export type VuexContext = {
   dispatch: Function,
   getters: Object
 }
+
+export type ChapterField = {
+  id: string,
+  label: string,
+  description?: string,
+}
+
+export type ChapterFieldGroup = {
+  id: string,
+  label: string,
+  children?: Array<ChapterField | ChapterFieldGroup>
+}
+
+export type Chapter = {
+  id: string,
+  label: string,
+  description?: string,
+  children?: Array<ChapterField | ChapterFieldGroup>
+}
+

--- a/molgenis-questionnaires/src/main/frontend/src/pages/QuestionnaireChapter.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/pages/QuestionnaireChapter.vue
@@ -43,7 +43,8 @@
                 <!-- ================ ERROR BLOCK ================ -->
                 <div v-if="navigationBlocked" class="alert alert-warning mb-0" role="alert">
                   {{ 'questionnaire_chapter_incomplete_message' | i18n }}
-                  <span v-for="(value, key) in formState.$error" >{{ key }} </span>
+                  <span v-for="(value, key, index) in formState.$error" >{{ getQuestionLabelById(key) }}<span v-if="index !== Object.keys(formState.$error).length - 1">, </span>
+                  </span>
                 </div>
 
                 <div v-if="error" class="alert alert-warning mb-0" role="alert">
@@ -128,6 +129,11 @@
       },
       totalNumberOfChapters () {
         return this.$store.getters.getTotalNumberOfChapters
+      }
+    },
+    methods: {
+      getQuestionLabelById (questionId) {
+        return this.$store.getters.getQuestionLabel(questionId)
       }
     },
     created () {

--- a/molgenis-questionnaires/src/main/frontend/src/store/index.js
+++ b/molgenis-questionnaires/src/main/frontend/src/store/index.js
@@ -12,7 +12,7 @@ const state: QuestionnaireState = {
   /**
    * All the compound fields of the questionnaire metadata as chapters
    */
-  chapterFields: [],
+  chapters: [],
 
   /**
    * Error string filled when something goes wrong

--- a/molgenis-questionnaires/src/main/frontend/src/store/mutations.js
+++ b/molgenis-questionnaires/src/main/frontend/src/store/mutations.js
@@ -1,5 +1,5 @@
 // @flow
-import type { QuestionnaireState } from '../flow.types.js'
+import type { QuestionnaireState, Chapter } from '../flow.types.js'
 
 const mutations = {
   'BLOCK_NAVIGATION' (state: QuestionnaireState, block: boolean) {
@@ -7,7 +7,7 @@ const mutations = {
   },
 
   'CLEAR_STATE' (state: QuestionnaireState) {
-    state.chapterFields = []
+    state.chapters = []
     state.error = ''
     state.formData = {}
     state.loading = true
@@ -33,8 +33,8 @@ const mutations = {
     state.questionnaireList = questionnaireList
   },
 
-  'SET_CHAPTER_FIELDS' (state: QuestionnaireState, chapterFields: Array<*>) {
-    state.chapterFields = chapterFields
+  'SET_CHAPTER_FIELDS' (state: QuestionnaireState, chapters: Array<Chapter>) {
+    state.chapters = chapters
   },
 
   'SET_FORM_DATA' (state: QuestionnaireState, formData: Object) {

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/components/ChapterNavigation.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/components/ChapterNavigation.spec.js
@@ -39,7 +39,8 @@ describe('ChapterNavigation component', () => {
 
     getters = {
       getChapterCompletion: () => chapterCompletion,
-      getTotalNumberOfChapters: () => 2
+      getTotalNumberOfChapters: () => 2,
+      getChapterLabel: () => () => 'chapterLabel'
     }
 
     mutations = {
@@ -151,11 +152,11 @@ describe('ChapterNavigation component', () => {
     })
 
     it('should commit [SET_ERROR] if the current chapter is complete but not all chapters are', () => {
-      propsData.currentChapter = {id: 'chapter1'}
+      propsData.currentChapter = {id: 'chapter1', label: 'chapter1 label'}
 
       const wrapper = shallow(ChapterNavigation, {propsData, localVue, mocks, router, store, stubs})
       wrapper.vm.validateBeforeSubmit()
-      td.verify(mutations.SET_ERROR(td.matchers.anything(), 'forgot: chapter2'))
+      td.verify(mutations.SET_ERROR(td.matchers.anything(), 'forgot: chapterLabel'))
     })
 
     it('should commit [BLOCK_NAVIGATION] with the value "true" if the current chapter is not completed', () => {

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/components/QuestionnaireChapter.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/components/QuestionnaireChapter.spec.js
@@ -36,7 +36,8 @@ describe('QuestionnaireChapter component', () => {
 
     getters = {
       getChapterByIndex: () => () => ({id: 'chapter1'}),
-      getTotalNumberOfChapters: () => 1
+      getTotalNumberOfChapters: () => 1,
+      getQuestionLabel: () => () => 'questionLabel'
     }
 
     mutations = {

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/getters.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/getters.spec.js
@@ -2,7 +2,7 @@ import getters from 'src/store/getters'
 
 describe('getters', () => {
   const state = {
-    chapterFields: [
+    chapters: [
       {
         id: 'chapter-1',
         label: 'First chapter',
@@ -60,6 +60,7 @@ describe('getters', () => {
             children: [
               {
                 id: 'chapter-3-field-2',
+                label: 'chapter-3-field-2-label',
                 type: 'text',
                 visible: (data) => true,
                 required: () => false,
@@ -144,7 +145,7 @@ describe('getters', () => {
     it('should return a chapter based on index [1]', () => {
       const getChapterByIndex = getters.getChapterByIndex(state)
       const actual = getChapterByIndex(1)
-      const expected = state.chapterFields[0]
+      const expected = state.chapters[0]
 
       expect(actual).to.deep.equal(expected)
     })
@@ -152,7 +153,7 @@ describe('getters', () => {
     it('should return a chapter based on index [2]', () => {
       const getChapterByIndex = getters.getChapterByIndex(state)
       const actual = getChapterByIndex(2)
-      const expected = state.chapterFields[1]
+      const expected = state.chapters[1]
 
       expect(actual).to.deep.equal(expected)
     })
@@ -219,7 +220,7 @@ describe('getters', () => {
       let stub = sinon.stub(console, 'error')
 
       const stateWithError = {
-        chapterFields: [
+        chapters: [
           {
             id: 'chapter-1',
             label: 'First chapter',
@@ -293,4 +294,31 @@ describe('getters', () => {
       expect(getters.isSaving(state)).to.equal(true)
     })
   })
+
+  describe('getChapterLabel', () => {
+    it('should return the chapter label for a given chapter id', () => {
+      const chapterId = 'chapter-2'
+      expect(getters.getChapterLabel(state)(chapterId)).to.deep.equal('Second chapter')
+    })
+
+    it('should thrown an exception if the given id is not a chapter id', () => {
+      const chapterId = 'non-existent-id'
+      expect(() => getters.getChapterLabel(state)(chapterId)).to.throw()
+    })
+  })
+
+  describe('getQuestionLabel', () => {
+    it('should return the question label for a given question id', () => {
+      const questionId = 'chapter-3-field-2'
+      expect(getters.getQuestionLabel(state)(questionId)).to.deep.equal('chapter-3-field-2-label')
+    })
+
+    it('should thrown an exception if the given id is not a question id', () => {
+      const questionId = 'non-existent-id'
+      expect(() => getters.getQuestionLabel(state)(questionId)).to.throw()
+    })
+  })
+
+
+
 })

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/mutations.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/mutations.spec.js
@@ -2,7 +2,7 @@ import mutations from 'src/store/mutations'
 
 describe('mutations', () => {
   const state = {
-    chapterFields: [],
+    chapters: [],
     error: '',
     formData: {},
     loading: true,
@@ -36,11 +36,11 @@ describe('mutations', () => {
   })
 
   describe('SET_CHAPTER_FIELDS', () => {
-    it('should update the chapterFields in the state with the payload', () => {
+    it('should update the chapters in the state with the payload', () => {
       const payload = ['chapter1']
       mutations.SET_CHAPTER_FIELDS(state, payload)
 
-      expect(state.chapterFields).to.deep.equal(payload)
+      expect(state.chapters).to.deep.equal(payload)
     })
   })
 
@@ -98,7 +98,7 @@ describe('mutations', () => {
       mutations.CLEAR_STATE(state)
 
       expect(state.questionnaireId).to.deep.equal('')
-      expect(state.chapterFields).to.deep.equal([])
+      expect(state.chapters).to.deep.equal([])
       expect(state.formData).to.deep.equal({})
       expect(state.questionnaireLabel).to.deep.equal('')
       expect(state.questionnaireDescription).to.deep.equal('')


### PR DESCRIPTION
Use label instead of id's for warning user about missing required fields and incomplete chapters.
+
refactor store to use more specific flow typing

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
