### PR TITLE
Fix #7408 Can not fill out c6 questionnaire

### DIFF
--- a/molgenis-questionnaires/src/main/frontend/config/index.js
+++ b/molgenis-questionnaires/src/main/frontend/config/index.js
@@ -15,7 +15,17 @@ module.exports = {
     // Paths
     assetsSubDirectory: 'static',
     assetsPublicPath: '/',
-    proxyTable: {},
+    proxyTable: {
+      // '/login': {
+      //   target: 'http://localhost:8080'
+      // },
+      // '/api': {
+      //   target: 'http://localhost:8080'
+      // },
+      // '/menu/plugins/questionnaires': {
+      //   target: 'http://localhost:8080'
+      // }
+    },
 
     // Various Dev Server settings
     host: 'localhost', // can be overwritten by process.env.HOST

--- a/molgenis-questionnaires/src/main/frontend/src/flow.types.js
+++ b/molgenis-questionnaires/src/main/frontend/src/flow.types.js
@@ -40,3 +40,26 @@ export type Chapter = {
   children?: Array<ChapterField | ChapterFieldGroup>
 }
 
+export type QuestionnaireEntityResponse = {
+  href: string,
+  items: Array,
+  meta: ResponseMeta,
+  num: number,
+  start: number,
+  total: number
+}
+
+export type ResponseMeta = {
+  attributes: Array<ResponseMetaAttribute>
+}
+
+export type ResponseMetaAttribute = {
+  attributes: Array<ResponseMetaAttribute>,
+  fieldType: EntityFieldType,
+  name: string
+}
+
+export type EntityFieldType = 'BOOL' | 'CATEGORICAL' | 'ENUM' | 'XREF' | 'MREF' | 'ONETOMANY' |
+  'INT' | 'DECIMAL' | 'LONG' | 'TEXT' | 'SCRIPT' | 'HTML' | 'DATE' | 'DATE_TIME' | 'CATEGORICAL_MREF' |
+  'STRING' | 'HYPERLINK' | 'EMAIL' | 'FILE' | 'ONE_TO_MANY' | 'COMPOUND'
+

--- a/molgenis-questionnaires/src/main/frontend/src/flow.types.js
+++ b/molgenis-questionnaires/src/main/frontend/src/flow.types.js
@@ -1,24 +1,3 @@
-export type QuestionnaireState = {
-  chapters: Array<Chapter>,
-  error: string,
-  formData: Object,
-  loading: boolean,
-  mapperOptions: Object,
-  navigationBlocked: boolean,
-  questionnaire: Object,
-  questionnaireList: Array<*>,
-  questionnaireRowId: string,
-  numberOfOutstandingCalls: number,
-  submissionText: string
-}
-
-export type VuexContext = {
-  state: QuestionnaireState,
-  commit: Function,
-  dispatch: Function,
-  getters: Object
-}
-
 export type ChapterField = {
   id: string,
   label: string,
@@ -40,6 +19,41 @@ export type Chapter = {
   children?: Array<ChapterField | ChapterFieldGroup>
 }
 
+export type QuestionnaireState = {
+  chapters: Array<Chapter>,
+  error: string,
+  formData: Object,
+  loading: boolean,
+  mapperOptions: Object,
+  navigationBlocked: boolean,
+  questionnaire: Object,
+  questionnaireList: Array<*>,
+  questionnaireRowId: string,
+  numberOfOutstandingCalls: number,
+  submissionText: string
+}
+
+export type VuexContext = {
+  state: QuestionnaireState,
+  commit: Function,
+  dispatch: Function,
+  getters: Object
+}
+
+export type EntityFieldType = 'BOOL' | 'CATEGORICAL' | 'ENUM' | 'XREF' | 'MREF' | 'ONETOMANY' |
+  'INT' | 'DECIMAL' | 'LONG' | 'TEXT' | 'SCRIPT' | 'HTML' | 'DATE' | 'DATE_TIME' | 'CATEGORICAL_MREF' |
+  'STRING' | 'HYPERLINK' | 'EMAIL' | 'FILE' | 'ONE_TO_MANY' | 'COMPOUND'
+
+export type ResponseMetaAttribute = {
+  attributes: Array<ResponseMetaAttribute>,
+  fieldType: EntityFieldType,
+  name: string
+}
+
+export type ResponseMeta = {
+  attributes: Array<ResponseMetaAttribute>
+}
+
 export type QuestionnaireEntityResponse = {
   href: string,
   items: Array,
@@ -48,18 +62,3 @@ export type QuestionnaireEntityResponse = {
   start: number,
   total: number
 }
-
-export type ResponseMeta = {
-  attributes: Array<ResponseMetaAttribute>
-}
-
-export type ResponseMetaAttribute = {
-  attributes: Array<ResponseMetaAttribute>,
-  fieldType: EntityFieldType,
-  name: string
-}
-
-export type EntityFieldType = 'BOOL' | 'CATEGORICAL' | 'ENUM' | 'XREF' | 'MREF' | 'ONETOMANY' |
-  'INT' | 'DECIMAL' | 'LONG' | 'TEXT' | 'SCRIPT' | 'HTML' | 'DATE' | 'DATE_TIME' | 'CATEGORICAL_MREF' |
-  'STRING' | 'HYPERLINK' | 'EMAIL' | 'FILE' | 'ONE_TO_MANY' | 'COMPOUND'
-

--- a/molgenis-questionnaires/src/main/frontend/src/services/questionnaireService.js
+++ b/molgenis-questionnaires/src/main/frontend/src/services/questionnaireService.js
@@ -1,0 +1,31 @@
+import type { QuestionnaireEntityResponse } from '../flow.types.js'
+import {ResponseMetaAttribute} from "../flow.types"
+
+const compoundFields = (compound) => {
+  return compound.attributes.reduce((accum, attribute: ResponseMetaAttribute) => {
+    if(attribute.fieldType !== 'COMPOUND') {
+      accum[attribute.name] = []
+    } else {
+      accum = {...accum, ...compoundFields(attribute)}
+    }
+    return accum
+  }, {})
+}
+
+export default {
+  /**
+   * Build a object to hold the questionnaire answers in, based on the questionnaire's metadata structure
+   * @param questionnaireResp
+   * @returns Object key values map with question ids as key and empty values
+   */
+  buildFormDataObject: function (questionnaireResp: QuestionnaireEntityResponse) {
+    return questionnaireResp.meta.attributes.reduce((accum, attribute: ResponseMetaAttribute) => {
+      if(attribute.fieldType !== 'COMPOUND') {
+        accum[attribute.name] = []
+      } else {
+        accum = {...accum, ...compoundFields(attribute)}
+      }
+      return accum
+    }, {})
+  }
+}

--- a/molgenis-questionnaires/src/main/frontend/src/services/questionnaireService.js
+++ b/molgenis-questionnaires/src/main/frontend/src/services/questionnaireService.js
@@ -1,9 +1,9 @@
 import type { QuestionnaireEntityResponse } from '../flow.types.js'
-import {ResponseMetaAttribute} from "../flow.types"
+import {ResponseMetaAttribute} from '../flow.types'
 
 const compoundFields = (compound) => {
   return compound.attributes.reduce((accum, attribute: ResponseMetaAttribute) => {
-    if(attribute.fieldType !== 'COMPOUND') {
+    if (attribute.fieldType !== 'COMPOUND') {
       accum[attribute.name] = []
     } else {
       accum = {...accum, ...compoundFields(attribute)}
@@ -20,7 +20,7 @@ export default {
    */
   buildFormDataObject: function (questionnaireResp: QuestionnaireEntityResponse) {
     return questionnaireResp.meta.attributes.reduce((accum, attribute: ResponseMetaAttribute) => {
-      if(attribute.fieldType !== 'COMPOUND') {
+      if (attribute.fieldType !== 'COMPOUND') {
         accum[attribute.name] = []
       } else {
         accum = {...accum, ...compoundFields(attribute)}

--- a/molgenis-questionnaires/src/main/frontend/src/store/actions.js
+++ b/molgenis-questionnaires/src/main/frontend/src/store/actions.js
@@ -4,6 +4,7 @@ import type { VuexContext } from '../flow.types.js'
 // $FlowFixMe
 import Vue from 'vue'
 import { EntityToFormMapper } from '@molgenis/molgenis-ui-form'
+import questionnaireService from '../services/questionnaireService'
 
 const handleError = (commit: Function, error: Error) => {
   commit('SET_ERROR', error)
@@ -48,7 +49,7 @@ const actions = {
       return api.get(`/api/v2/${questionnaireId}?includeCategories=true`).then(response => {
         commit('SET_QUESTIONNAIRE', response)
 
-        const data = response.items.length > 0 ? response.items[0] : {}
+        const data = response.items.length > 0 ? response.items[0] : questionnaireService.buildFormDataObject(response)
         commit('SET_QUESTIONNAIRE_ROW_ID', data[response.meta.idAttribute])
 
         const form = EntityToFormMapper.generateForm(response.meta, data, state.mapperOptions)

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/services/questionnaireService.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/services/questionnaireService.spec.js
@@ -2,18 +2,28 @@ import type {QuestionnaireEntityResponse} from '../../../../src/flow.types'
 import questionnaireService from '../../../../src/services/questionnaireService'
 
 describe('Questionniare service', () => {
-
   describe('buildFormDataObject', () => {
-
     const response: QuestionnaireEntityResponse = {
       href: 'http://foo.bar',
       items: [],
       meta: {
         attributes: [
-          {attributes:[], fieldType: 'BOOL', name: 'question1'},
-          {attributes:[
-              {attributes:[], fieldType: 'STRING', name: 'question2'}
-            ], fieldType: 'COMPOUND', name: 'section1'}
+          {
+            attributes: [],
+            fieldType: 'BOOL',
+            name: 'question1'
+          },
+          {
+            attributes: [
+              {
+                attributes: [],
+                fieldType: 'STRING',
+                name: 'question2'
+              }
+            ],
+            fieldType: 'COMPOUND',
+            name: 'section1'
+          }
         ]
       },
       num: 0,
@@ -22,10 +32,8 @@ describe('Questionniare service', () => {
     }
 
     it('should build the empty formData object', () => {
-     const formData = questionnaireService.buildFormDataObject(response)
-      expect(formData).to.deep.equal({question1: [],  question2: []})
+      const formData = questionnaireService.buildFormDataObject(response)
+      expect(formData).to.deep.equal({question1: [], question2: []})
     })
   })
 })
-
-

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/services/questionnaireService.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/services/questionnaireService.spec.js
@@ -1,0 +1,31 @@
+import type {QuestionnaireEntityResponse} from '../../../../src/flow.types'
+import questionnaireService from '../../../../src/services/questionnaireService'
+
+describe('Questionniare service', () => {
+
+  describe('buildFormDataObject', () => {
+
+    const response: QuestionnaireEntityResponse = {
+      href: 'http://foo.bar',
+      items: [],
+      meta: {
+        attributes: [
+          {attributes:[], fieldType: 'BOOL', name: 'question1'},
+          {attributes:[
+              {attributes:[], fieldType: 'STRING', name: 'question2'}
+            ], fieldType: 'COMPOUND', name: 'section1'}
+        ]
+      },
+      num: 0,
+      start: 0,
+      total: 100
+    }
+
+    it('should build the empty formData object', () => {
+     const formData = questionnaireService.buildFormDataObject(response)
+      expect(formData).to.deep.equal({question1: [],  question2: []})
+    })
+  })
+})
+
+

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/actions.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/actions.spec.js
@@ -3,7 +3,6 @@ import td from 'testdouble'
 import api from '@molgenis/molgenis-api-client'
 import { EntityToFormMapper } from '@molgenis/molgenis-ui-form'
 import questionnaireService from '../../../../src/services/questionnaireService'
-import Vue from 'vue'
 
 const getters = {
   getQuestionnaireId: 'test_quest'

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/actions.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/actions.spec.js
@@ -2,6 +2,7 @@ import actions from 'src/store/actions'
 import td from 'testdouble'
 import api from '@molgenis/molgenis-api-client'
 import { EntityToFormMapper } from '@molgenis/molgenis-ui-form'
+import questionnaireService from '../../../../src/services/questionnaireService'
 import Vue from 'vue'
 
 const getters = {
@@ -195,6 +196,10 @@ describe('actions', () => {
       const generateForm = td.function('EntityToFormMapper.generateForm')
       td.when(generateForm(questionnaire.meta, {}, state.mapperOptions)).thenReturn(generatedForm)
       td.replace(EntityToFormMapper, 'generateForm', generateForm)
+
+      const buildFormDataObject = td.function('questionnaireService.buildFormDataObject')
+      td.when(buildFormDataObject(questionnaire)).thenReturn({})
+      td.replace(questionnaireService, 'buildFormDataObject', buildFormDataObject)
 
       const chapters = [{
         id: 'compound',

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/getters.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/getters.spec.js
@@ -229,7 +229,9 @@ describe('getters', () => {
               {
                 id: 'chapter-1-field-1',
                 type: 'text',
-                visible: (data) => { throw new Error('This can\'t be happening!') }
+                visible: (data) => {
+                  throw new Error('This can\'t be happening!')
+                }
               }
             ]
           }
@@ -318,7 +320,4 @@ describe('getters', () => {
       expect(() => getters.getQuestionLabel(state)(questionId)).to.throw()
     })
   })
-
-
-
 })


### PR DESCRIPTION
Use the questionnaire metadata to generate object to hold the form-values, this prevents null pointers when no row has been created yet.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
