### PR TITLE
Prevent timeout on the integration build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
   # This configures the parallel jobs to run
   - COV_FLAG="unit"        SONAR="true"  SCRIPT="./mvnw verify --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -Dskip.js.build=true -DskipITs"
   - COV_FLAG="api"                       SCRIPT="./mvnw verify -pl molgenis-api-tests --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password"
-  - COV_FLAG="integration"               SCRIPT="./mvnw verify -pl molgenis-platform-integration-tests --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password"
+  - COV_FLAG="integration"               SCRIPT="travis_wait ./mvnw verify -pl molgenis-platform-integration-tests --batch-mode --quiet -Dmaven.test.redirectTestOutputToFile=true -Dit_db_user=postgres -Dit_db_password"
   -                                      SCRIPT="./mvnw findbugs:check --batch-mode"
 services:
   - postgresql


### PR DESCRIPTION
See https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
