### PR TITLE
Fix #7438: 2FA pincode entry does not acquire focus

### DIFF
--- a/molgenis-security/src/main/resources/templates/view-2fa-activation-modal.ftl
+++ b/molgenis-security/src/main/resources/templates/view-2fa-activation-modal.ftl
@@ -60,14 +60,14 @@
                                            name="verificationCode"
                                            required/>
                                     <script>
-                                        $('#verification-code-field').pincodeInput({
+                                        var pincodeInput = $('#verification-code-field').pincodeInput({
                                             inputs: 6,
                                             hidedigits: false,
-                                            complete: function (value, e) {
+                                            complete: function () {
                                                 $('#activation-form').submit()
                                             }
-                                        })
-                                        $('input.pincode-input-text.first').attr('autofocus', 'autofocus')
+                                        }).data('plugin_pincodeInput')
+                                        setTimeout(pincodeInput.focus, 1000)
                                     </script>
                                     <input type="hidden" name="secretKey" value="${secretKey}"/>
                                 </div>

--- a/molgenis-security/src/main/resources/templates/view-2fa-configured-modal.ftl
+++ b/molgenis-security/src/main/resources/templates/view-2fa-configured-modal.ftl
@@ -41,14 +41,14 @@
                                 <input id="verification-code-field" type="text"
                                        class="form-control" name="verificationCode">
                                 <script>
-                                    $('#verification-code-field').pincodeInput({
+                                    var pincodeInput = $('#verification-code-field').pincodeInput({
                                         inputs: 6,
                                         hidedigits: false,
-                                        complete: function (value, e) {
+                                        complete: function () {
                                             $('#verification-form').submit()
                                         }
-                                    })
-                                    $('input.pincode-input-text.first').attr('autofocus', 'autofocus')
+                                    }).data('plugin_pincodeInput')
+                                    setTimeout(pincodeInput.focus, 1000)
                                 </script>
                             </div>
                         </form>


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [na] Code unit/integration/system tested
- [na] User documentation updated
- [na] (If you have changed REST API interface) view-swagger.ftl updated
- [na] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
