### PR TITLE
Fix #7459 RLS decorator silently ignores errors during stream update

### DIFF
--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/AbstractRowLevelSecurityRepositoryDecorator.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/AbstractRowLevelSecurityRepositoryDecorator.java
@@ -45,16 +45,14 @@ public abstract class AbstractRowLevelSecurityRepositoryDecorator<E extends Enti
 	public Iterator<E> iterator()
 	{
 		Iterable<E> iterable = () -> delegate().iterator();
-		return stream(iterable.spliterator(), false).filter(entity -> isActionPermitted(entity, READ))
-													.iterator();
+		return stream(iterable.spliterator(), false).filter(entity -> isActionPermitted(entity, READ)).iterator();
 	}
 
 	@Override
 	public void forEachBatched(Fetch fetch, Consumer<List<E>> consumer, int batchSize)
 	{
 		delegate().forEachBatched(fetch, entities -> consumer.accept(
-				entities.stream().filter(entity -> isActionPermitted(entity, READ)).collect(toList())),
-				batchSize);
+				entities.stream().filter(entity -> isActionPermitted(entity, READ)).collect(toList())), batchSize);
 	}
 
 	@Override
@@ -144,12 +142,15 @@ public abstract class AbstractRowLevelSecurityRepositoryDecorator<E extends Enti
 	{
 		delegate().update(entities.filter((E entity) ->
 		{
-			boolean result = isActionPermitted(entity, UPDATE);
-			if (result)
+			if (isActionPermitted(entity, UPDATE))
 			{
 				updateAcl(entity);
 			}
-			return result;
+			else
+			{
+				throwPermissionException(entity, UPDATE);
+			}
+			return true;
 		}));
 	}
 

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/owned/RowLevelSecurityRepositoryDecoratorTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/owned/RowLevelSecurityRepositoryDecoratorTest.java
@@ -77,8 +77,7 @@ public class RowLevelSecurityRepositoryDecoratorTest extends AbstractMockitoTest
 
 		rowLevelSecurityRepositoryDecorator.add(entity);
 
-		verify(acl).insertAce(0, PermissionSet.WRITE, new PrincipalSid(USERNAME),
-				true);
+		verify(acl).insertAce(0, PermissionSet.WRITE, new PrincipalSid(USERNAME), true);
 		verify(delegateRepository).add(entity);
 	}
 
@@ -96,8 +95,7 @@ public class RowLevelSecurityRepositoryDecoratorTest extends AbstractMockitoTest
 		ArgumentCaptor<Stream<Entity>> entityStreamCaptor = ArgumentCaptor.forClass(Stream.class);
 		verify(delegateRepository).add(entityStreamCaptor.capture());
 		assertEquals(entityStreamCaptor.getValue().collect(toList()), singletonList(entity));
-		verify(acl).insertAce(0, PermissionSet.WRITE, new PrincipalSid(USERNAME),
-				true);
+		verify(acl).insertAce(0, PermissionSet.WRITE, new PrincipalSid(USERNAME), true);
 	}
 
 	@Test
@@ -132,7 +130,7 @@ public class RowLevelSecurityRepositoryDecoratorTest extends AbstractMockitoTest
 		assertEquals(entityStreamCaptor.getValue().collect(toList()), singletonList(entity));
 	}
 
-	@Test
+	@Test(expectedExceptions = EntityPermissionDeniedException.class, expectedExceptionsMessageRegExp = "permission:UPDATE entityTypeId:entityTypeId entityId:entityId")
 	public void testUpdateStreamPermissionDenied()
 	{
 		Entity entity = getEntityMock();
@@ -383,7 +381,8 @@ public class RowLevelSecurityRepositoryDecoratorTest extends AbstractMockitoTest
 		Entity entity = getEntityMock();
 		when(delegateRepository.findAll(any(Stream.class))).thenAnswer(invocation -> Stream.of(entity));
 		when(userPermissionEvaluator.hasPermission(new EntityIdentity(entity), READ)).thenReturn(true);
-		assertEquals(rowLevelSecurityRepositoryDecorator.findAll(Stream.of(entityId)).collect(toList()), singletonList(entity));
+		assertEquals(rowLevelSecurityRepositoryDecorator.findAll(Stream.of(entityId)).collect(toList()),
+				singletonList(entity));
 	}
 
 	@SuppressWarnings("unchecked")


### PR DESCRIPTION
Probably also fixes #7291 EntityTypeRepositorySecurityDecorator filter streams for add and update instead of throwing exception

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
