### PR TITLE
Fix #7474 Metadata manager one-to-many attribute creation not possible

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerAttributeEditForm.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerAttributeEditForm.vue
@@ -145,7 +145,7 @@
             </div>
           </div>
 
-          <div v-else-if="isOneToManyType">
+          <div v-if="isOneToManyType">
             <div class="form-group row">
               <label class="col-3 col-form-label text-muted">{{ 'attribute-edit-form-mapped-by-label' | i18n }}</label>
               <div class="col">
@@ -305,7 +305,7 @@
         mappedByAttributes: 'getMappedByAttributes'
       }),
       isReferenceType: function () {
-        return ['file', 'xref', 'mref', 'categorical', 'categoricalmref'].includes(this.selectedAttribute.type)
+        return ['file', 'xref', 'mref', 'categorical', 'categoricalmref', 'onetomany'].includes(this.selectedAttribute.type)
       },
       isNumericType: function () {
         return ['int', 'long'].includes(this.selectedAttribute.type)


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- (n.a.) Code unit/integration/system tested
- (n.a.) User documentation updated
- (n.a.) (If you have changed REST API interface) view-swagger.ftl updated
- (n.a.) Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
