### PR TITLE
Fix #7406: IE11 input wizard file select broken

### DIFF
--- a/molgenis-core/src/main/java/org/molgenis/core/util/FileUploadUtils.java
+++ b/molgenis-core/src/main/java/org/molgenis/core/util/FileUploadUtils.java
@@ -8,6 +8,8 @@ import javax.servlet.http.Part;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class FileUploadUtils
 {
@@ -66,8 +68,9 @@ public class FileUploadUtils
 
 				if (cd.trim().startsWith("filename"))
 				{
-					String filename = cd.substring(cd.indexOf('=') + 1).trim().replace("\"", "");
-					return StringUtils.hasText(filename) ? filename : null;
+					String path = cd.substring(cd.indexOf('=') + 1).replaceAll("\"", "").trim();
+					Path filename = Paths.get(path).getFileName();
+					return StringUtils.hasText(filename.toString()) ? filename.toString() : null;
 				}
 			}
 		}

--- a/molgenis-core/src/test/java/org/molgenis/core/util/FileUploadUtilsTest.java
+++ b/molgenis-core/src/test/java/org/molgenis/core/util/FileUploadUtilsTest.java
@@ -34,7 +34,8 @@ public class FileUploadUtilsTest
 	{
 		//In internet explorer the filename part of the disposition contains the path
 		when(part.getHeader("content-disposition")).thenReturn(
-				"form-data; name=\"upload\"; filename=\"c:\\test\\path\\example.xls\"");
+				"form-data; name=\"upload\"; filename=\"c:" + File.separator + "test" + File.separator + "path"
+						+ File.separator + "example.xls\"");
 		String filename = FileUploadUtils.getOriginalFileName(part);
 		assertEquals(filename, "example.xls");
 	}

--- a/molgenis-core/src/test/java/org/molgenis/core/util/FileUploadUtilsTest.java
+++ b/molgenis-core/src/test/java/org/molgenis/core/util/FileUploadUtilsTest.java
@@ -30,6 +30,16 @@ public class FileUploadUtilsTest
 	}
 
 	@Test
+	public void getOriginalFileNameIE()
+	{
+		//In internet explorer the filename part of the disposition contains the path
+		when(part.getHeader("content-disposition")).thenReturn(
+				"form-data; name=\"upload\"; filename=\"c:\\test\\path\\example.xls\"");
+		String filename = FileUploadUtils.getOriginalFileName(part);
+		assertEquals(filename, "example.xls");
+	}
+
+	@Test
 	public void getOriginalFileNameWithMissingHeader()
 	{
 		when(part.getHeader("content-disposition")).thenReturn(null);


### PR DESCRIPTION
Tested the fix on both Chrome and Internet Explorer

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
