### PR TITLE
Fix #7529: Entities without a data sheet cannot be imported

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxDataProvider.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/emx/EmxDataProvider.java
@@ -47,7 +47,10 @@ class EmxDataProvider implements DataProvider
 		else
 		{
 			Optional<String> packageId = job.getPackageId();
-			return packageId.isPresent() && entityType.getId().startsWith(packageId.get() + PACKAGE_SEPARATOR);
+			return packageId.isPresent() && entityType.getId().startsWith(packageId.get() + PACKAGE_SEPARATOR)
+					&& job.getSource()
+						  .hasRepository(
+								  entityType.getId().substring(packageId.get().length() + PACKAGE_SEPARATOR.length()));
 		}
 	}
 

--- a/molgenis-data-import/src/test/java/org/molgenis/data/importer/emx/EmxDataProviderTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/importer/emx/EmxDataProviderTest.java
@@ -78,6 +78,20 @@ public class EmxDataProviderTest extends AbstractMockitoTest
 	}
 
 	@Test
+	public void testHasEntitiesExistingPackageFalse() throws Exception
+	{
+		String entityTypeId = "test_EntityTypeId";
+		EntityType entityType = when(mock(EntityType.class).getId()).thenReturn(entityTypeId).getMock();
+
+		RepositoryCollection repositoryCollection = mock(RepositoryCollection.class);
+		when(repositoryCollection.hasRepository(entityType)).thenReturn(false);
+		when(emxImportJob.getSource()).thenReturn(repositoryCollection);
+		when(emxImportJob.getPackageId()).thenReturn(Optional.of("test"));
+
+		assertFalse(emxDataProvider.hasEntities(entityType));
+	}
+
+	@Test
 	public void testHasEntitiesAlternativeEntityTypeIdTrue() throws Exception
 	{
 		String entityTypeId = "base_EntityTypeId";


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
