### PR TITLE
Make SORTA a superuser plugin by default

### DIFF
--- a/docs/user_documentation/admin-features/guide-ref-security.md
+++ b/docs/user_documentation/admin-features/guide-ref-security.md
@@ -67,25 +67,17 @@ The default permissions for these roles are as follows:
     * One click importer
   * Navigator
   * Data Explorer
-  * Data Integration
-    * Mapping service
-    * SORTA
   * Plugins
     * Search all
     * Job overview
-    * Questionnaires
     
 **Editor**:
 * You can edit data in the group
 * You get access to the following plugins:
   * Import Data
     * Advanced importer
-    * One click importer
   * Navigator
   * Data Explorer
-  * Data Integration
-    * Mapping service
-    * SORTA
   * Plugins
     * Search all
     * Job overview
@@ -98,7 +90,6 @@ The default permissions for these roles are as follows:
   * Data Explorer
   * Plugins
     * Search all
-    * Questionnaires
 
 ![Membership overview](../../images/security/membership_overview.png?raw=true, "Membership overview")
 

--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppPermissionRegistry.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppPermissionRegistry.java
@@ -14,7 +14,6 @@ import org.molgenis.dataexplorer.controller.DataExplorerController;
 import org.molgenis.dataexplorer.negotiator.NegotiatorController;
 import org.molgenis.datarowedit.controller.DataRowEditController;
 import org.molgenis.navigator.NavigatorController;
-import org.molgenis.ontology.sorta.controller.SortaController;
 import org.molgenis.questionnaires.controller.QuestionnaireController;
 import org.molgenis.searchall.controller.SearchAllPluginController;
 import org.molgenis.security.core.PermissionSet;
@@ -45,7 +44,6 @@ import static org.molgenis.oneclickimporter.job.OneClickImportJobExecutionMetada
 import static org.molgenis.ontology.core.model.OntologyPackage.PACKAGE_ONTOLOGY;
 import static org.molgenis.ontology.sorta.meta.MatchingTaskContentMetaData.MATCHING_TASK_CONTENT;
 import static org.molgenis.ontology.sorta.meta.OntologyTermHitMetaData.ONTOLOGY_TERM_HIT;
-import static org.molgenis.ontology.sorta.meta.SortaJobExecutionMetaData.SORTA_JOB_EXECUTION;
 import static org.molgenis.security.core.PermissionSet.*;
 import static org.molgenis.security.core.SidUtils.createAuthoritySid;
 import static org.molgenis.security.core.SidUtils.createUserSid;
@@ -90,10 +88,8 @@ public class WebAppPermissionRegistry implements PermissionRegistry
 		register(PLUGIN, DataRowEditController.ID, editor, READ);
 		register(PLUGIN, JobsController.ID, editor, READ);
 		register(ENTITY_TYPE, IMPORT_RUN, editor, WRITE);
-		register(PLUGIN, SortaController.ID, editor, READ);
 		register(ENTITY_TYPE, MATCHING_TASK_CONTENT, editor, WRITE);
 		register(ENTITY_TYPE, ONTOLOGY_TERM_HIT, editor, WRITE);
-		register(ENTITY_TYPE, SORTA_JOB_EXECUTION, editor, WRITE);
 		register(PACKAGE, PACKAGE_ONTOLOGY, user, READ);
 		register(PLUGIN, QuestionnaireController.ID, editor, READ);
 		register(PACKAGE, PACKAGE_GENOME_BROWSER, viewer, READ);

--- a/molgenis-ontology/src/main/java/org/molgenis/ontology/sorta/controller/SortaController.java
+++ b/molgenis-ontology/src/main/java/org/molgenis/ontology/sorta/controller/SortaController.java
@@ -79,7 +79,6 @@ import static org.molgenis.ontology.utils.SortaServiceUtil.getEntityAsMap;
 
 @Controller
 @RequestMapping(URI)
-@PreAuthorize("hasAnyRole('ROLE_SU')")
 public class SortaController extends PluginController
 {
 	private static final Logger LOG = LoggerFactory.getLogger(SortaController.class);

--- a/molgenis-ontology/src/main/java/org/molgenis/ontology/sorta/controller/SortaController.java
+++ b/molgenis-ontology/src/main/java/org/molgenis/ontology/sorta/controller/SortaController.java
@@ -43,7 +43,6 @@ import org.molgenis.web.PluginController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;

--- a/molgenis-ontology/src/main/java/org/molgenis/ontology/sorta/controller/SortaController.java
+++ b/molgenis-ontology/src/main/java/org/molgenis/ontology/sorta/controller/SortaController.java
@@ -43,6 +43,7 @@ import org.molgenis.web.PluginController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -78,6 +79,7 @@ import static org.molgenis.ontology.utils.SortaServiceUtil.getEntityAsMap;
 
 @Controller
 @RequestMapping(URI)
+@PreAuthorize("hasAnyRole('ROLE_SU')")
 public class SortaController extends PluginController
 {
 	private static final Logger LOG = LoggerFactory.getLogger(SortaController.class);

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/service/impl/MappingServiceImpl.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/service/impl/MappingServiceImpl.java
@@ -36,6 +36,7 @@ import static org.molgenis.data.util.EntityTypeUtils.isReferenceType;
 import static org.molgenis.semanticmapper.meta.MappingProjectMetaData.MAPPING_PROJECT;
 import static org.molgenis.semanticmapper.meta.MappingProjectMetaData.NAME;
 
+@PreAuthorize("hasAnyRole('ROLE_SU')")
 public class MappingServiceImpl implements MappingService
 {
 	public static final int MAPPING_BATCH_SIZE = 1000;
@@ -62,7 +63,6 @@ public class MappingServiceImpl implements MappingService
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@Transactional
 	public MappingProject addMappingProject(String projectName, String target)
 	{
@@ -73,7 +73,6 @@ public class MappingServiceImpl implements MappingService
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@Transactional
 	public void deleteMappingProject(String mappingProjectId)
 	{
@@ -81,7 +80,6 @@ public class MappingServiceImpl implements MappingService
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@Transactional
 	public MappingProject cloneMappingProject(String mappingProjectId)
 	{
@@ -116,7 +114,6 @@ public class MappingServiceImpl implements MappingService
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@Transactional
 	public MappingProject cloneMappingProject(String mappingProjectId, String clonedMappingProjectName)
 	{
@@ -138,14 +135,12 @@ public class MappingServiceImpl implements MappingService
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	public List<MappingProject> getAllMappingProjects()
 	{
 		return mappingProjectRepository.getAllMappingProjects();
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@Transactional
 	public void updateMappingProject(MappingProject mappingProject)
 	{
@@ -153,14 +148,12 @@ public class MappingServiceImpl implements MappingService
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	public MappingProject getMappingProject(String identifier)
 	{
 		return mappingProjectRepository.getMappingProject(identifier);
 	}
 
 	@Override
-	@PreAuthorize("hasAnyRole('ROLE_SU')")
 	@Transactional
 	public long applyMappings(String mappingProjectId, String entityTypeId, Boolean addSourceAttribute,
 			String packageId, String label, Progress progress)
@@ -255,7 +248,10 @@ public class MappingServiceImpl implements MappingService
 	 */
 	public Stream<EntityType> getCompatibleEntityTypes(EntityType target)
 	{
-		return dataService.getMeta().getEntityTypes().filter(candidate -> !candidate.isAbstract()).filter(isCompatible(target));
+		return dataService.getMeta()
+						  .getEntityTypes()
+						  .filter(candidate -> !candidate.isAbstract())
+						  .filter(isCompatible(target));
 	}
 
 	private Predicate<EntityType> isCompatible(EntityType target)


### PR DESCRIPTION
Documentation updated for this PR and #7593 

I also looked at the testplans:
 - Questionnaires (now uses the Editor role)
 - One-Click-Importer (already used the Manager role, no change needed) 
 - SORTA (wasn't updated to new group security yet. no change needed)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
