### PR TITLE
Fix #7684: PENDING index jobs aren't picked up after an application r…

### DIFF
--- a/molgenis-data-index/src/main/java/org/molgenis/data/index/bootstrap/IndexBootstrapper.java
+++ b/molgenis-data-index/src/main/java/org/molgenis/data/index/bootstrap/IndexBootstrapper.java
@@ -6,6 +6,7 @@ import org.molgenis.data.index.IndexService;
 import org.molgenis.data.index.job.IndexJobExecution;
 import org.molgenis.data.index.job.IndexJobExecutionMeta;
 import org.molgenis.data.index.meta.IndexAction;
+import org.molgenis.data.index.meta.IndexActionGroupMetaData;
 import org.molgenis.data.index.meta.IndexActionMetaData;
 import org.molgenis.data.meta.MetaDataService;
 import org.molgenis.data.meta.model.AttributeMetadata;
@@ -67,10 +68,14 @@ public class IndexBootstrapper
 	private void registerNewIndexActionForDirtyJobs(IndexJobExecution indexJobExecution)
 	{
 		String id = indexJobExecution.getIndexActionJobID();
-		dataService.findAll(IndexActionMetaData.INDEX_ACTION,
+		List<IndexAction> actions = dataService.findAll(IndexActionMetaData.INDEX_ACTION,
 				new QueryImpl<IndexAction>().eq(IndexActionMetaData.INDEX_ACTION_GROUP_ATTR, id), IndexAction.class)
-				   .forEach(this::registerIndexAction);
+											   .collect(Collectors.toList());
+		actions.forEach(this::registerIndexAction);
+
 		dataService.delete(IndexJobExecutionMeta.INDEX_JOB_EXECUTION, indexJobExecution);
+		dataService.deleteAll(IndexActionMetaData.INDEX_ACTION, actions.stream().map(IndexAction::getId));
+		dataService.deleteById(IndexActionGroupMetaData.INDEX_ACTION_GROUP, id);
 	}
 
 	private void registerIndexAction(IndexAction action)


### PR DESCRIPTION
…estart

The index jobs are picked up okay, however a copy of the existing actions is created and used, the old pending ones were not cleaned up.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- (n.a.) User documentation updated
- (n.a.) (If you have changed REST API interface) view-swagger.ftl updated
- (n.a.) Test plan template updated
- [x] Clean commits
- (n.a.) Added Feature/Fix to release notes
