### PR TITLE
Fix 7714 Import zip file as manager in one click importer fails

### DIFF
--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/service/impl/EntityServiceImpl.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/service/impl/EntityServiceImpl.java
@@ -76,12 +76,15 @@ public class EntityServiceImpl implements EntityService
 		// Create a dataTable
 		EntityType entityType = entityTypeFactory.create();
 
-		Package aPackage = metaDataService.getPackage(packageName);
+		final Package parentPackage = getParentPackage().orElseThrow(NoWritablePackageException::new);
+		final String fullyQualifiedPackageName = parentPackage.getId() + "_" + packageName;
+		Package aPackage = metaDataService.getPackage(fullyQualifiedPackageName);
+
 		if (aPackage == null)
 		{
-			aPackage = packageFactory.create(packageName);
+			aPackage = packageFactory.create(fullyQualifiedPackageName);
 			aPackage.setLabel(packageName);
-			aPackage.setParent(getParentPackage().orElseThrow(NoWritablePackageException::new));
+			aPackage.setParent(parentPackage);
 			metaDataService.addPackage(aPackage);
 		}
 

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/EntityServiceImplTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/EntityServiceImplTest.java
@@ -8,6 +8,7 @@ import org.molgenis.data.meta.MetaDataService;
 import org.molgenis.data.meta.model.*;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.populate.IdGenerator;
+import org.molgenis.data.security.PackageIdentity;
 import org.molgenis.data.security.permission.PermissionSystemService;
 import org.molgenis.oneclickimporter.model.Column;
 import org.molgenis.oneclickimporter.model.DataCollection;
@@ -17,6 +18,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -25,6 +27,7 @@ import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 import static org.molgenis.data.EntityManager.CreationMode.NO_POPULATE;
 import static org.molgenis.data.meta.AttributeType.STRING;
+import static org.molgenis.data.security.PackagePermission.ADD_PACKAGE;
 import static org.testng.Assert.assertEquals;
 
 public class EntityServiceImplTest
@@ -112,7 +115,7 @@ public class EntityServiceImplTest
 
 		// mock package
 		Package package_ = mock(Package.class);
-		when(metaDataService.getPackage("package_")).thenReturn(package_);
+		when(metaDataService.getPackage("parent_package_")).thenReturn(package_);
 
 		when(dataService.getMeta()).thenReturn(metaDataService);
 
@@ -133,6 +136,10 @@ public class EntityServiceImplTest
 		when(oneClickImporterNamingService.getLabelWithPostFix("super-powers")).thenReturn("super-powers");
 
 		when(attributeTypeService.guessAttributeType(any())).thenReturn(STRING);
+
+		doReturn(true).when(userPermissionEvaluator).hasPermission(new PackageIdentity("parent"), ADD_PACKAGE);
+		when(metaDataService.getPackages()).thenReturn(Collections.singletonList(package_));
+		when(package_.getId()).thenReturn("parent");
 
 		entityService = new EntityServiceImpl(entityTypeFactory, attributeFactory, idGenerator, dataService,
 				metaDataService, entityManager, attributeTypeService, oneClickImporterService,


### PR DESCRIPTION
- Prefix package-name with parent-package-name to make package unique in group.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA - issue was introduced with new functionality since 6.x] Added Feature/Fix to release notes
