### PR TITLE
Parameterized Dynamic Decorators

### DIFF
--- a/.idea/fileTemplates/MolgenisDynamicDecorator.java
+++ b/.idea/fileTemplates/MolgenisDynamicDecorator.java
@@ -1,20 +1,33 @@
 #set( $DECORATOR_NAME = $Decorator_name)
 #set( $IDENTIFIER = $DECORATOR_NAME.toLowerCase())
 
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
 import org.molgenis.data.AbstractRepositoryDecorator;
 import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
 import org.molgenis.data.decorator.DynamicRepositoryDecoratorFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import static com.google.common.collect.ImmutableMap.of;
+
 @Component
-public class ${DECORATOR_NAME}RepositoryDecoratorFactory implements DynamicRepositoryDecoratorFactory
+public class ${DECORATOR_NAME}RepositoryDecoratorFactory implements DynamicRepositoryDecoratorFactory<Entity>
 {
 	private static final String ID = "${IDENTIFIER}";
+	private final Gson gson;
 
+	public ${DECORATOR_NAME}RepositoryDecoratorFactory(Gson gson)
+	{
+		this.gson = requireNonNull(gson);
+	}
+	
 	@Override
 	@SuppressWarnings("unchecked")
-	public Repository createDecoratedRepository(Repository repository)
+	public Repository createDecoratedRepository(Repository<Entity> repository, Map<String, Object> parameters)
 	{
 		return new ${DECORATOR_NAME}RepositoryDecorator(repository);
 	}
@@ -35,6 +48,14 @@ public class ${DECORATOR_NAME}RepositoryDecoratorFactory implements DynamicRepos
 	public String getDescription()
 	{
 		return ""; //TODO
+	}
+	
+	@Override
+	public String getSchema()
+	{
+	    return gson.toJson(of("title", "${DECORATOR_NAME}", "type", "object", "properties",
+				of("example", of("type", "string", "description", "An example of a parameter")), "required",
+				ImmutableList.of("example"))); //TODO
 	}
 }
     

--- a/.idea/fileTemplates/MolgenisException.java
+++ b/.idea/fileTemplates/MolgenisException.java
@@ -12,7 +12,7 @@ import static java.util.Objects.requireNonNull;
 * TODO
 */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false positives at dev time
-@SuppressWarnings("squid:MaximumInheritanceDepth", "squid:S2166")
+@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
 public class $EXCEPTION_CLASS_NAME extends $EXTENDS_FROM
 {
 	private static final String ERROR_CODE = "X01"; //TODO

--- a/molgenis-data/pom.xml
+++ b/molgenis-data/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>molgenis-security-core</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.molgenis</groupId>
+            <artifactId>molgenis-validation</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <!-- third party dependencies -->
         <dependency>
             <groupId>org.springframework</groupId>

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecorator.java
@@ -31,9 +31,9 @@ public class DecoratorParametersRepositoryDecorator extends AbstractRepositoryDe
 	@Override
 	public void update(Stream<DecoratorParameters> decoratorParameters)
 	{
-		delegate().update(decoratorParameters.filter(job ->
+		delegate().update(decoratorParameters.filter(parameters ->
 		{
-			validateParameters(job);
+			validateParameters(parameters);
 			return true;
 		}));
 	}
@@ -46,11 +46,11 @@ public class DecoratorParametersRepositoryDecorator extends AbstractRepositoryDe
 	}
 
 	@Override
-	public Integer add(Stream<DecoratorParameters> jobs)
+	public Integer add(Stream<DecoratorParameters> decoratorParameters)
 	{
-		return delegate().add(jobs.filter(job ->
+		return delegate().add(decoratorParameters.filter(parameters ->
 		{
-			validateParameters(job);
+			validateParameters(parameters);
 			return true;
 		}));
 	}

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecorator.java
@@ -1,0 +1,66 @@
+package org.molgenis.data.decorator;
+
+import org.molgenis.data.AbstractRepositoryDecorator;
+import org.molgenis.data.Repository;
+import org.molgenis.data.decorator.meta.DecoratorParameters;
+import org.molgenis.validation.JsonValidator;
+
+import java.util.stream.Stream;
+
+/**
+ * Triggers JSON validation for the 'parameters' field of a {@link DecoratorParameters) entity.
+ */
+public class DecoratorParametersRepositoryDecorator extends AbstractRepositoryDecorator<DecoratorParameters>
+{
+	private final JsonValidator jsonValidator;
+
+	DecoratorParametersRepositoryDecorator(Repository<DecoratorParameters> delegateRepository,
+			JsonValidator jsonValidator)
+	{
+		super(delegateRepository);
+		this.jsonValidator = jsonValidator;
+	}
+
+	@Override
+	public void update(DecoratorParameters decoratorParameters)
+	{
+		validateParameters(decoratorParameters);
+		delegate().update(decoratorParameters);
+	}
+
+	@Override
+	public void update(Stream<DecoratorParameters> decoratorParameters)
+	{
+		delegate().update(decoratorParameters.filter(job ->
+		{
+			validateParameters(job);
+			return true;
+		}));
+	}
+
+	@Override
+	public void add(DecoratorParameters decoratorParameters)
+	{
+		validateParameters(decoratorParameters);
+		delegate().add(decoratorParameters);
+	}
+
+	@Override
+	public Integer add(Stream<DecoratorParameters> jobs)
+	{
+		return delegate().add(jobs.filter(job ->
+		{
+			validateParameters(job);
+			return true;
+		}));
+	}
+
+	private void validateParameters(DecoratorParameters decoratorParameters)
+	{
+		String schema = decoratorParameters.getDecorator().getSchema();
+		if (schema != null)
+		{
+			jsonValidator.validate(decoratorParameters.getParameters(), schema);
+		}
+	}
+}

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecorator.java
@@ -58,9 +58,10 @@ public class DecoratorParametersRepositoryDecorator extends AbstractRepositoryDe
 	private void validateParameters(DecoratorParameters decoratorParameters)
 	{
 		String schema = decoratorParameters.getDecorator().getSchema();
-		if (schema != null)
+		String parameters = decoratorParameters.getParameters();
+		if (schema != null && parameters != null && !parameters.isEmpty())
 		{
-			jsonValidator.validate(decoratorParameters.getParameters(), schema);
+			jsonValidator.validate(parameters, schema);
 		}
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecoratorFactory.java
@@ -1,0 +1,30 @@
+package org.molgenis.data.decorator;
+
+import org.molgenis.data.AbstractSystemRepositoryDecoratorFactory;
+import org.molgenis.data.Repository;
+import org.molgenis.data.decorator.meta.DecoratorParameters;
+import org.molgenis.data.decorator.meta.DecoratorParametersMetadata;
+import org.molgenis.validation.JsonValidator;
+import org.springframework.stereotype.Component;
+
+import static java.util.Objects.requireNonNull;
+
+@Component
+public class DecoratorParametersRepositoryDecoratorFactory
+		extends AbstractSystemRepositoryDecoratorFactory<DecoratorParameters, DecoratorParametersMetadata>
+{
+	private final JsonValidator jsonValidator;
+
+	public DecoratorParametersRepositoryDecoratorFactory(DecoratorParametersMetadata decoratorParametersMetadata,
+			JsonValidator jsonValidator)
+	{
+		super(decoratorParametersMetadata);
+		this.jsonValidator = requireNonNull(jsonValidator);
+	}
+
+	@Override
+	public Repository<DecoratorParameters> createDecoratedRepository(Repository<DecoratorParameters> repository)
+	{
+		return new DecoratorParametersRepositoryDecorator(repository, jsonValidator);
+	}
+}

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
@@ -4,6 +4,8 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
 import org.molgenis.data.meta.model.EntityType;
 
+import java.util.Map;
+
 /**
  * Repository decorator factory that creates decorated {@link Repository repositories} for specific entity types.
  * Used to decorate (system) entity types dynamically.
@@ -24,5 +26,5 @@ public interface DynamicRepositoryDecoratorFactory<E extends Entity, M extends E
 	 * @param repository undecorated repository
 	 * @return decorated repository
 	 */
-	Repository<E> createDecoratedRepository(Repository<E> repository);
+	Repository<E> createDecoratedRepository(Repository repository, Map<String, String> parameters);
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
@@ -2,6 +2,7 @@ package org.molgenis.data.decorator;
 
 import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
+import org.molgenis.data.RepositoryDecoratorFactory;
 
 import java.util.Map;
 

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
@@ -21,6 +21,11 @@ public interface DynamicRepositoryDecoratorFactory<E extends Entity, M extends E
 	String getDescription();
 
 	/**
+	 * @return JSON schema for the parameters, null when no parameters
+	 */
+	String getSchema();
+
+	/**
 	 * Creates a decorated repository based on the given {@link Repository}
 	 *
 	 * @param repository undecorated repository

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactory.java
@@ -2,7 +2,6 @@ package org.molgenis.data.decorator;
 
 import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
-import org.molgenis.data.meta.model.EntityType;
 
 import java.util.Map;
 
@@ -12,7 +11,7 @@ import java.util.Map;
  *
  * @see RepositoryDecoratorFactory
  */
-public interface DynamicRepositoryDecoratorFactory<E extends Entity, M extends EntityType>
+public interface DynamicRepositoryDecoratorFactory<E extends Entity>
 {
 	String getId();
 
@@ -31,5 +30,5 @@ public interface DynamicRepositoryDecoratorFactory<E extends Entity, M extends E
 	 * @param repository undecorated repository
 	 * @return decorated repository
 	 */
-	Repository<E> createDecoratedRepository(Repository repository, Map<String, String> parameters);
+	Repository<E> createDecoratedRepository(Repository<E> repository, Map<String, Object> parameters);
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactoryRegistrar.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorFactoryRegistrar.java
@@ -12,7 +12,7 @@ public class DynamicRepositoryDecoratorFactoryRegistrar
 {
 	private final DynamicRepositoryDecoratorRegistry repositoryDecoratorRegistry;
 
-	public DynamicRepositoryDecoratorFactoryRegistrar(DynamicRepositoryDecoratorRegistry repositoryDecoratorRegistry)
+	DynamicRepositoryDecoratorFactoryRegistrar(DynamicRepositoryDecoratorRegistry repositoryDecoratorRegistry)
 	{
 		this.repositoryDecoratorRegistry = requireNonNull(repositoryDecoratorRegistry);
 	}

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
@@ -4,12 +4,11 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;
-import org.molgenis.data.Query;
 import org.molgenis.data.Repository;
 import org.molgenis.data.decorator.meta.DecoratorConfiguration;
 import org.molgenis.data.decorator.meta.DecoratorParameters;
+import org.molgenis.data.decorator.meta.DynamicDecorator;
 import org.molgenis.data.event.BootstrappingEvent;
-import org.molgenis.data.support.QueryImpl;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -19,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static java.lang.String.format;
 import static java.util.Collections.emptyMap;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
@@ -51,7 +51,7 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 		String factoryId = factory.getId();
 		if (factories.containsKey(factoryId))
 		{
-			throw new IllegalStateException(String.format("Duplicate decorator id [%s]", factoryId));
+			throw new IllegalArgumentException(format("Duplicate decorator id [%s]", factoryId));
 		}
 		factories.put(factoryId, factory);
 	}
@@ -65,9 +65,16 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 	@Override
 	public DynamicRepositoryDecoratorFactory getFactory(String id)
 	{
+		if (!factories.containsKey(id))
+		{
+			throw new IllegalArgumentException(format("Decorator [%s] does not exist", id));
+		}
 		return factories.get(id);
 	}
 
+	/**
+	 * Decorates a {@link Repository} if there is a {@link DecoratorConfiguration} specified for this repository.
+	 */
 	@Override
 	public synchronized Repository<Entity> decorate(Repository<Entity> repository)
 	{
@@ -75,30 +82,28 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 
 		if (!entityTypeId.equals(DECORATOR_CONFIGURATION) && bootstrappingDone)
 		{
-			Query query = new QueryImpl().eq(ENTITY_TYPE_ID, entityTypeId);
-			@SuppressWarnings("unchecked")
-			DecoratorConfiguration configuration = dataService.findOne(DECORATOR_CONFIGURATION, query,
-					DecoratorConfiguration.class);
+			DecoratorConfiguration config = dataService.query(DECORATOR_CONFIGURATION, DecoratorConfiguration.class)
+													   .eq(ENTITY_TYPE_ID, entityTypeId)
+													   .findOne();
 
-			if (configuration != null)
+			if (config != null)
 			{
-				repository = decorateRepository(repository, configuration);
+				repository = decorateRepository(repository, config);
 			}
 		}
 
 		return repository;
 	}
 
+	/**
+	 * Decorates a {@link Repository} with one or more {@link DynamicDecorator}s., based on the
+	 * {@link DecoratorConfiguration} entity.
+	 */
 	@SuppressWarnings("unchecked")
 	private Repository<Entity> decorateRepository(Repository<Entity> repository, DecoratorConfiguration configuration)
 	{
-		List<DecoratorParameters> decoratorParameters = configuration.getDecoratorParameters().collect(toList());
-		if (decoratorParameters.isEmpty())
-		{
-			return repository;
-		}
-
 		Map<String, Map<String, Object>> parameterMap = getParameterMap(configuration);
+		List<DecoratorParameters> decoratorParameters = configuration.getDecoratorParameters().collect(toList());
 		for (DecoratorParameters decoratorParam : decoratorParameters)
 		{
 			DynamicRepositoryDecoratorFactory factory = factories.get(decoratorParam.getDecorator().getId());
@@ -110,14 +115,18 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 		return repository;
 	}
 
-	private Map<String, Map<String, Object>> getParameterMap(DecoratorConfiguration configuration)
+	/**
+	 * Collects the JSON parameters of one or more DecoratorParameters entities in a map, with the decorator's ID as the
+	 * key and the JSON object as another key/value Map.
+	 */
+	Map<String, Map<String, Object>> getParameterMap(DecoratorConfiguration configuration)
 	{
 		return configuration.getDecoratorParameters()
 							.collect(toMap(param -> param.getDecorator().getId(),
-									param -> toParameterMap(param.getParameters())));
+									param -> jsonToMap(param.getParameters())));
 	}
 
-	private Map<String, Object> toParameterMap(String parameterJson)
+	private Map<String, Object> jsonToMap(String parameterJson)
 	{
 		if (parameterJson != null)
 		{

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
@@ -39,7 +39,7 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 	{
 	}.getType();
 
-	public DynamicRepositoryDecoratorRegistryImpl(DataService dataService, Gson gson)
+	DynamicRepositoryDecoratorRegistryImpl(DataService dataService, Gson gson)
 	{
 		this.dataService = requireNonNull(dataService);
 		this.gson = requireNonNull(gson);

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
@@ -35,7 +35,7 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 	private final Gson gson;
 	private boolean bootstrappingDone = false;
 
-	private static final Type MAP_TOKEN = new TypeToken<Map<String, String>>()
+	private static final Type MAP_TOKEN = new TypeToken<Map<String, Object>>()
 	{
 	}.getType();
 
@@ -98,7 +98,7 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 			return repository;
 		}
 
-		Map<String, Map<String, String>> parameters = configuration.getDecoratorParameters()
+		Map<String, Map<String, Object>> parameters = configuration.getDecoratorParameters()
 																   .collect(toMap(param -> param.getDecorator().getId(),
 																		   param -> toParameterMap(
 																				   param.getParameters())));
@@ -114,7 +114,7 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 		return repository;
 	}
 
-	private Map<String, String> toParameterMap(String parameterJson)
+	private Map<String, Object> toParameterMap(String parameterJson)
 	{
 		if (parameterJson != null)
 		{

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImpl.java
@@ -98,20 +98,23 @@ public class DynamicRepositoryDecoratorRegistryImpl implements DynamicRepository
 			return repository;
 		}
 
-		Map<String, Map<String, Object>> parameters = configuration.getDecoratorParameters()
-																   .collect(toMap(param -> param.getDecorator().getId(),
-																		   param -> toParameterMap(
-																				   param.getParameters())));
-
+		Map<String, Map<String, Object>> parameterMap = getParameterMap(configuration);
 		for (DecoratorParameters decoratorParam : decoratorParameters)
 		{
 			DynamicRepositoryDecoratorFactory factory = factories.get(decoratorParam.getDecorator().getId());
 			if (factory != null)
 			{
-				repository = factory.createDecoratedRepository(repository, parameters.get(factory.getId()));
+				repository = factory.createDecoratedRepository(repository, parameterMap.get(factory.getId()));
 			}
 		}
 		return repository;
+	}
+
+	private Map<String, Map<String, Object>> getParameterMap(DecoratorConfiguration configuration)
+	{
+		return configuration.getDecoratorParameters()
+							.collect(toMap(param -> param.getDecorator().getId(),
+									param -> toParameterMap(param.getParameters())));
 	}
 
 	private Map<String, Object> toParameterMap(String parameterJson)

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
@@ -6,6 +6,7 @@ import org.molgenis.data.support.StaticEntity;
 
 import java.util.stream.Stream;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_PARAMETERS;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.ENTITY_TYPE_ID;
@@ -35,5 +36,10 @@ public class DecoratorConfiguration extends StaticEntity
 	public Stream<DecoratorParameters> getDecoratorParameters()
 	{
 		return stream(getEntities(DECORATOR_PARAMETERS, DecoratorParameters.class).spliterator(), false);
+	}
+
+	public void setDecoratorParameters(Stream<DecoratorParameters> parameters)
+	{
+		set(DECORATOR_PARAMETERS, parameters.collect(toList()));
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
@@ -1,7 +1,5 @@
 package org.molgenis.data.decorator.meta;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
 import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
@@ -44,8 +42,8 @@ public class DecoratorConfiguration extends StaticEntity
 		set(DYNAMIC_DECORATORS, decorators);
 	}
 
-	public JsonElement getParameters()
+	public String getParameters()
 	{
-		return new JsonParser().parse(getString(PARAMETERS));
+		return getString(PARAMETERS);
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
@@ -4,11 +4,11 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
-import java.util.List;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
-import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.*;
+import static java.util.stream.StreamSupport.stream;
+import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_PARAMETERS;
+import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.ENTITY_TYPE_ID;
 
 public class DecoratorConfiguration extends StaticEntity
 {
@@ -32,18 +32,8 @@ public class DecoratorConfiguration extends StaticEntity
 		set(ENTITY_TYPE_ID, entityTypeId);
 	}
 
-	public Stream<DynamicDecorator> getDecorators()
+	public Stream<DecoratorParameters> getDecoratorParameters()
 	{
-		return StreamSupport.stream(getEntities(DYNAMIC_DECORATORS, DynamicDecorator.class).spliterator(), false);
-	}
-
-	public void setDecorators(List<DynamicDecorator> decorators)
-	{
-		set(DYNAMIC_DECORATORS, decorators);
-	}
-
-	public String getParameters()
-	{
-		return getString(PARAMETERS);
+		return stream(getEntities(DECORATOR_PARAMETERS, DecoratorParameters.class).spliterator(), false);
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
@@ -8,8 +8,8 @@ import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
-import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_PARAMETERS;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.ENTITY_TYPE_ID;
+import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.PARAMETERS;
 
 public class DecoratorConfiguration extends StaticEntity
 {
@@ -35,11 +35,11 @@ public class DecoratorConfiguration extends StaticEntity
 
 	public Stream<DecoratorParameters> getDecoratorParameters()
 	{
-		return stream(getEntities(DECORATOR_PARAMETERS, DecoratorParameters.class).spliterator(), false);
+		return stream(getEntities(PARAMETERS, DecoratorParameters.class).spliterator(), false);
 	}
 
 	public void setDecoratorParameters(Stream<DecoratorParameters> parameters)
 	{
-		set(DECORATOR_PARAMETERS, parameters.collect(toList()));
+		set(PARAMETERS, parameters.collect(toList()));
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
@@ -1,5 +1,7 @@
 package org.molgenis.data.decorator.meta;
 
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
@@ -8,8 +10,7 @@ import java.util.List;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
-import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DYNAMIC_DECORATORS;
-import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.ENTITY_TYPE_ID;
+import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.*;
 
 public class DecoratorConfiguration extends StaticEntity
 {
@@ -41,5 +42,10 @@ public class DecoratorConfiguration extends StaticEntity
 	public void setDecorators(List<DynamicDecorator> decorators)
 	{
 		set(DYNAMIC_DECORATORS, decorators);
+	}
+
+	public JsonElement getParameters()
+	{
+		return new JsonParser().parse(getString(PARAMETERS));
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import static java.util.Objects.requireNonNull;
 import static org.molgenis.data.decorator.meta.DecoratorPackage.PACKAGE_DECORATOR;
+import static org.molgenis.data.meta.AttributeType.TEXT;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_ID;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_LABEL;
 import static org.molgenis.data.meta.model.Package.PACKAGE_SEPARATOR;
@@ -19,6 +20,7 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 	public static final String ID = "id";
 	public static final String ENTITY_TYPE_ID = "entityTypeId";
 	public static final String DYNAMIC_DECORATORS = "dynamicDecorators";
+	public static final String PARAMETERS = "parameters";
 
 	private final DecoratorPackage decoratorPackage;
 	private final DynamicDecoratorMetadata dynamicDecoratorMetadata;
@@ -44,5 +46,9 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 										.setDataType(AttributeType.MREF)
 										.setRefEntity(dynamicDecoratorMetadata)
 										.setLabel("Decorators");
+		addAttribute(PARAMETERS).setDataType(TEXT)
+								.setNillable(true)
+								.setLabel("Parameters")
+								.setDescription("Decorator parameters in JSON");
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
@@ -18,7 +18,7 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 
 	public static final String ID = "id";
 	public static final String ENTITY_TYPE_ID = "entityTypeId";
-	public static final String DECORATOR_PARAMETERS = "decoratorParameters";
+	public static final String PARAMETERS = "parameters";
 
 	private final DecoratorPackage decoratorPackage;
 	private final DecoratorParametersMetadata decoratorParametersMetadata;
@@ -41,9 +41,9 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 
 		addAttribute(ID, ROLE_ID).setAuto(true).setVisible(false).setLabel("Identifier");
 		addAttribute(ENTITY_TYPE_ID, ROLE_LABEL).setNillable(false).setUnique(true).setLabel("Entity Type Identifier");
-		addAttribute(DECORATOR_PARAMETERS).setNillable(false)
-										  .setDataType(AttributeType.MREF)
-										  .setRefEntity(decoratorParametersMetadata)
-										  .setLabel("Decorator Parameters");
+		addAttribute(PARAMETERS).setNillable(false)
+								.setDataType(AttributeType.MREF)
+								.setRefEntity(decoratorParametersMetadata)
+								.setLabel("Decorator Parameters");
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
@@ -41,7 +41,7 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 
 		addAttribute(ID, ROLE_ID).setAuto(true).setVisible(false).setLabel("Identifier");
 		addAttribute(ENTITY_TYPE_ID, ROLE_LABEL).setNillable(false).setUnique(true).setLabel("Entity Type Identifier");
-		addAttribute(DECORATOR_PARAMETERS).setNillable(true)
+		addAttribute(DECORATOR_PARAMETERS).setNillable(false)
 										  .setDataType(AttributeType.MREF)
 										  .setRefEntity(decoratorParametersMetadata)
 										  .setLabel("Decorator Parameters");

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfigurationMetadata.java
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Component;
 
 import static java.util.Objects.requireNonNull;
 import static org.molgenis.data.decorator.meta.DecoratorPackage.PACKAGE_DECORATOR;
-import static org.molgenis.data.meta.AttributeType.TEXT;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_ID;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_LABEL;
 import static org.molgenis.data.meta.model.Package.PACKAGE_SEPARATOR;
@@ -19,17 +18,17 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 
 	public static final String ID = "id";
 	public static final String ENTITY_TYPE_ID = "entityTypeId";
-	public static final String DYNAMIC_DECORATORS = "dynamicDecorators";
-	public static final String PARAMETERS = "parameters";
+	public static final String DECORATOR_PARAMETERS = "decoratorParameters";
 
 	private final DecoratorPackage decoratorPackage;
-	private final DynamicDecoratorMetadata dynamicDecoratorMetadata;
+	private final DecoratorParametersMetadata decoratorParametersMetadata;
 
-	DecoratorConfigurationMetadata(DecoratorPackage decoratorPackage, DynamicDecoratorMetadata dynamicDecoratorMetadata)
+	DecoratorConfigurationMetadata(DecoratorPackage decoratorPackage,
+			DecoratorParametersMetadata decoratorParametersMetadata)
 	{
 		super(SIMPLE_NAME, PACKAGE_DECORATOR);
 		this.decoratorPackage = requireNonNull(decoratorPackage);
-		this.dynamicDecoratorMetadata = requireNonNull(dynamicDecoratorMetadata);
+		this.decoratorParametersMetadata = requireNonNull(decoratorParametersMetadata);
 	}
 
 	@Override
@@ -42,13 +41,9 @@ public class DecoratorConfigurationMetadata extends SystemEntityType
 
 		addAttribute(ID, ROLE_ID).setAuto(true).setVisible(false).setLabel("Identifier");
 		addAttribute(ENTITY_TYPE_ID, ROLE_LABEL).setNillable(false).setUnique(true).setLabel("Entity Type Identifier");
-		addAttribute(DYNAMIC_DECORATORS).setNillable(true)
-										.setDataType(AttributeType.MREF)
-										.setRefEntity(dynamicDecoratorMetadata)
-										.setLabel("Decorators");
-		addAttribute(PARAMETERS).setDataType(TEXT)
-								.setNillable(true)
-								.setLabel("Parameters")
-								.setDescription("Decorator parameters in JSON");
+		addAttribute(DECORATOR_PARAMETERS).setNillable(true)
+										  .setDataType(AttributeType.MREF)
+										  .setRefEntity(decoratorParametersMetadata)
+										  .setLabel("Decorator Parameters");
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParameters.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParameters.java
@@ -34,9 +34,19 @@ public class DecoratorParameters extends StaticEntity
 		return getString(ID);
 	}
 
+	public void setDecorator(DynamicDecorator decorator)
+	{
+		set(DECORATOR, decorator);
+	}
+
 	public DynamicDecorator getDecorator()
 	{
 		return getEntity(DECORATOR, DynamicDecorator.class);
+	}
+
+	public void setParameters(String parameters)
+	{
+		set(PARAMETERS, parameters);
 	}
 
 	public String getParameters()

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParameters.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParameters.java
@@ -1,0 +1,46 @@
+package org.molgenis.data.decorator.meta;
+
+import org.molgenis.data.Entity;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.support.StaticEntity;
+
+import static org.molgenis.data.decorator.meta.DecoratorParametersMetadata.*;
+
+public class DecoratorParameters extends StaticEntity
+{
+	public DecoratorParameters(Entity entity)
+	{
+		super(entity);
+	}
+
+	public DecoratorParameters(EntityType entityType)
+	{
+		super(entityType);
+	}
+
+	public DecoratorParameters(String id, EntityType entityType)
+	{
+		super(entityType);
+		setId(id);
+	}
+
+	public void setId(String id)
+	{
+		set(ID, id);
+	}
+
+	public String getId()
+	{
+		return getString(ID);
+	}
+
+	public DynamicDecorator getDecorator()
+	{
+		return getEntity(DECORATOR, DynamicDecorator.class);
+	}
+
+	public String getParameters()
+	{
+		return getString(PARAMETERS);
+	}
+}

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParametersFactory.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParametersFactory.java
@@ -1,0 +1,15 @@
+package org.molgenis.data.decorator.meta;
+
+import org.molgenis.data.AbstractSystemEntityFactory;
+import org.molgenis.data.populate.EntityPopulator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DecoratorParametersFactory
+		extends AbstractSystemEntityFactory<DecoratorParameters, DecoratorParametersMetadata, String>
+{
+	DecoratorParametersFactory(DecoratorParametersMetadata decoratorParametersMetadata, EntityPopulator entityPopulator)
+	{
+		super(DecoratorParameters.class, decoratorParametersMetadata, entityPopulator);
+	}
+}

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParametersMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParametersMetadata.java
@@ -1,0 +1,52 @@
+package org.molgenis.data.decorator.meta;
+
+import org.molgenis.data.meta.SystemEntityType;
+import org.springframework.stereotype.Component;
+
+import static java.util.Objects.requireNonNull;
+import static org.molgenis.data.decorator.meta.DecoratorPackage.PACKAGE_DECORATOR;
+import static org.molgenis.data.meta.AttributeType.TEXT;
+import static org.molgenis.data.meta.AttributeType.XREF;
+import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_ID;
+import static org.molgenis.data.meta.model.Package.PACKAGE_SEPARATOR;
+
+@Component
+public class DecoratorParametersMetadata extends SystemEntityType
+{
+	private static final String SIMPLE_NAME = "DecoratorParameters";
+	public static final String DECORATOR_PARAMETERS = PACKAGE_DECORATOR + PACKAGE_SEPARATOR + SIMPLE_NAME;
+
+	public static final String ID = "id";
+	public static final String DECORATOR = "decorator";
+	public static final String PARAMETERS = "parameters";
+
+	private final DecoratorPackage decoratorPackage;
+	private final DynamicDecoratorMetadata dynamicDecoratorMetadata;
+
+	public DecoratorParametersMetadata(DecoratorPackage decoratorPackage,
+			DynamicDecoratorMetadata dynamicDecoratorMetadata)
+	{
+		super(SIMPLE_NAME, PACKAGE_DECORATOR);
+		this.decoratorPackage = requireNonNull(decoratorPackage);
+		this.dynamicDecoratorMetadata = requireNonNull(dynamicDecoratorMetadata);
+	}
+
+	@Override
+	public void init()
+	{
+		setPackage(decoratorPackage);
+
+		setLabel("Decorator Parameters");
+
+		addAttribute(ID, ROLE_ID).setLabel("Identifier");
+		addAttribute(DECORATOR).setDataType(XREF)
+							   .setRefEntity(dynamicDecoratorMetadata)
+							   .setNillable(false)
+							   .setLabel("Decorator");
+		addAttribute(PARAMETERS).setDataType(TEXT)
+								.setNillable(true)
+								.setLabel("Parameters")
+								.setDescription("Decorator parameters in JSON");
+	}
+}
+

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecorator.java
@@ -64,4 +64,9 @@ public class DynamicDecorator extends StaticEntity
 		set(SCHEMA, schema);
 		return this;
 	}
+
+	public String getSchema()
+	{
+		return getString(SCHEMA);
+	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecorator.java
@@ -58,4 +58,10 @@ public class DynamicDecorator extends StaticEntity
 	{
 		return getString(DESCRIPTION);
 	}
+
+	public DynamicDecorator setSchema(String schema)
+	{
+		set(SCHEMA, schema);
+		return this;
+	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorMetadata.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component;
 
 import static java.util.Objects.requireNonNull;
 import static org.molgenis.data.decorator.meta.DecoratorPackage.PACKAGE_DECORATOR;
+import static org.molgenis.data.meta.AttributeType.TEXT;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_ID;
 import static org.molgenis.data.meta.model.EntityType.AttributeRole.ROLE_LABEL;
 import static org.molgenis.data.meta.model.Package.PACKAGE_SEPARATOR;
@@ -37,6 +38,6 @@ public class DynamicDecoratorMetadata extends SystemEntityType
 		addAttribute(ID, ROLE_ID).setLabel("Identifier");
 		addAttribute(LABEL, ROLE_LABEL).setLabel("Label").setNillable(false).setLookupAttributeIndex(0);
 		addAttribute(DESCRIPTION).setLabel("Description").setNillable(false).setLookupAttributeIndex(1);
-		addAttribute(SCHEMA).setLabel("Schema").setReadOnly(true);
+		addAttribute(SCHEMA).setDataType(TEXT).setLabel("Schema");
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorMetadata.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorMetadata.java
@@ -18,6 +18,7 @@ public class DynamicDecoratorMetadata extends SystemEntityType
 	public static final String ID = "id";
 	public static final String LABEL = "label";
 	public static final String DESCRIPTION = "description";
+	public static final String SCHEMA = "schema";
 
 	private final DecoratorPackage decoratorPackage;
 
@@ -36,5 +37,6 @@ public class DynamicDecoratorMetadata extends SystemEntityType
 		addAttribute(ID, ROLE_ID).setLabel("Identifier");
 		addAttribute(LABEL, ROLE_LABEL).setLabel("Label").setNillable(false).setLookupAttributeIndex(0);
 		addAttribute(DESCRIPTION).setLabel("Description").setNillable(false).setLookupAttributeIndex(1);
+		addAttribute(SCHEMA).setLabel("Schema").setReadOnly(true);
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
@@ -26,7 +26,7 @@ public class DynamicDecoratorPopulator
 	private final DynamicRepositoryDecoratorRegistry registry;
 	private final DynamicDecoratorFactory dynamicDecoratorFactory;
 
-	public DynamicDecoratorPopulator(DataService dataService,
+	DynamicDecoratorPopulator(DataService dataService,
 			DynamicRepositoryDecoratorRegistry dynamicRepositoryDecoratorRegistry,
 			DynamicDecoratorFactory dynamicDecoratorFactory)
 	{

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
@@ -90,9 +90,9 @@ public class DynamicDecoratorPopulator
 	private DynamicDecorator createDecorator(String id)
 	{
 		DynamicRepositoryDecoratorFactory factory = registry.getFactory(id);
-		DynamicDecorator dynamicDecorator = dynamicDecoratorFactory.create(id)
-																   .setLabel(factory.getLabel())
-																   .setDescription(factory.getDescription());
-		return dynamicDecorator;
+		return dynamicDecoratorFactory.create(id)
+									  .setLabel(factory.getLabel())
+									  .setDescription(factory.getDescription())
+									  .setSchema(factory.getSchema());
 	}
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
@@ -1,16 +1,22 @@
 package org.molgenis.data.decorator.meta;
 
 import org.molgenis.data.DataService;
+import org.molgenis.data.Entity;
 import org.molgenis.data.decorator.DynamicRepositoryDecoratorFactory;
 import org.molgenis.data.decorator.DynamicRepositoryDecoratorRegistry;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.StreamSupport.stream;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_CONFIGURATION;
+import static org.molgenis.data.decorator.meta.DecoratorParametersMetadata.DECORATOR_PARAMETERS;
 import static org.molgenis.data.decorator.meta.DynamicDecoratorMetadata.DYNAMIC_DECORATOR;
 
 @Component
@@ -45,8 +51,8 @@ public class DynamicDecoratorPopulator
 	private void removeNonExistingDecorators()
 	{
 		Set<String> nonExistingDecorators = getNonExistingDecorators();
-		updateDecoratorConfigurations(nonExistingDecorators);
-		dataService.deleteAll(DYNAMIC_DECORATOR, (Stream<Object>) (Stream<?>) nonExistingDecorators.stream());
+		updateReferringEntities(nonExistingDecorators);
+		dataService.deleteAll(DYNAMIC_DECORATOR, nonExistingDecorators.stream().map(id -> (Object) id));
 	}
 
 	private Set<String> getNonExistingDecorators()
@@ -59,24 +65,54 @@ public class DynamicDecoratorPopulator
 		return decorators;
 	}
 
-	private void updateDecoratorConfigurations(Set<String> nonExistingDecorators)
+	private void updateReferringEntities(Set<String> nonExistingDecorators)
 	{
-		Stream<DecoratorConfiguration> updatedEntities = dataService.findAll(DECORATOR_CONFIGURATION,
-				DecoratorConfiguration.class).map(config -> removeReferences(nonExistingDecorators, config));
-		dataService.update(DECORATOR_CONFIGURATION, updatedEntities);
+		List<Object> paramsToDelete = getDecoratorParametersToDelete(nonExistingDecorators);
+		Stream<DecoratorConfiguration> updatedConfigs = removeParametersFromConfigurations(paramsToDelete);
+		dataService.update(DECORATOR_CONFIGURATION, updatedConfigs);
+		dataService.deleteAll(DECORATOR_PARAMETERS, paramsToDelete.stream());
 	}
 
-	private DecoratorConfiguration removeReferences(Set<String> nonExistingDecorators,
+	private Stream<DecoratorConfiguration> removeParametersFromConfigurations(List<Object> paramsToDelete)
+	{
+		return dataService.findAll(DECORATOR_CONFIGURATION, DecoratorConfiguration.class)
+						  .map(config -> removeReferencesOrDeleteIfEmpty(paramsToDelete, config))
+						  .filter(Objects::nonNull);
+	}
+
+	private List<Object> getDecoratorParametersToDelete(Set<String> nonExistingDecorators)
+	{
+		return dataService.findAll(DECORATOR_PARAMETERS, DecoratorParameters.class)
+						  .filter(decoratorParameters -> nonExistingDecorators.contains(
+								  decoratorParameters.getDecorator().getId()))
+						  .map(Entity::getIdValue)
+						  .collect(toList());
+	}
+
+	/**
+	 * Removes references to DecoratorParameters that will be deleted. If this results in a DecoratorConfiguration
+	 * without any parameters, then the row is deleted.
+	 *
+	 * @return DecoratorConfiguration without references to DecoratorParameters that will be deleted, null if the row was deleted
+	 */
+	private DecoratorConfiguration removeReferencesOrDeleteIfEmpty(List<Object> decoratorParametersToRemove,
 			DecoratorConfiguration configuration)
 	{
-		//TODO cascade delete
-		//		List<DynamicDecorator> decorators = StreamSupport.stream(
-		//				configuration.getEntities(DYNAMIC_DECORATORS, DynamicDecorator.class).spliterator(), false)
-		//														 .filter(e -> !nonExistingDecorators.contains(e.getId()))
-		//														 .collect(toList());
-		//
-		//		configuration.set(DYNAMIC_DECORATORS, decorators);
-		return configuration;
+		List<DecoratorParameters> decoratorParameters = stream(
+				configuration.getEntities(DecoratorConfigurationMetadata.DECORATOR_PARAMETERS,
+						DecoratorParameters.class).spliterator(), false).filter(
+				parameters -> !decoratorParametersToRemove.contains(parameters.getId())).collect(toList());
+
+		if (decoratorParameters.isEmpty())
+		{
+			dataService.deleteById(DECORATOR_CONFIGURATION, configuration.getIdValue());
+			return null;
+		}
+		else
+		{
+			configuration.set(DecoratorConfigurationMetadata.DECORATOR_PARAMETERS, decoratorParameters);
+			return configuration;
+		}
 	}
 
 	private boolean notPersisted(String id)

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecoratorPopulator.java
@@ -5,16 +5,12 @@ import org.molgenis.data.decorator.DynamicRepositoryDecoratorFactory;
 import org.molgenis.data.decorator.DynamicRepositoryDecoratorRegistry;
 import org.springframework.stereotype.Component;
 
-import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_CONFIGURATION;
-import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DYNAMIC_DECORATORS;
 import static org.molgenis.data.decorator.meta.DynamicDecoratorMetadata.DYNAMIC_DECORATOR;
 
 @Component
@@ -73,12 +69,13 @@ public class DynamicDecoratorPopulator
 	private DecoratorConfiguration removeReferences(Set<String> nonExistingDecorators,
 			DecoratorConfiguration configuration)
 	{
-		List<DynamicDecorator> decorators = StreamSupport.stream(
-				configuration.getEntities(DYNAMIC_DECORATORS, DynamicDecorator.class).spliterator(), false)
-														 .filter(e -> !nonExistingDecorators.contains(e.getId()))
-														 .collect(toList());
-
-		configuration.set(DYNAMIC_DECORATORS, decorators);
+		//TODO cascade delete
+		//		List<DynamicDecorator> decorators = StreamSupport.stream(
+		//				configuration.getEntities(DYNAMIC_DECORATORS, DynamicDecorator.class).spliterator(), false)
+		//														 .filter(e -> !nonExistingDecorators.contains(e.getId()))
+		//														 .collect(toList());
+		//
+		//		configuration.set(DYNAMIC_DECORATORS, decorators);
 		return configuration;
 	}
 

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/DecoratorParametersRepositoryDecoratorTest.java
@@ -1,0 +1,97 @@
+package org.molgenis.data.decorator;
+
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.molgenis.data.Repository;
+import org.molgenis.data.decorator.meta.DecoratorParameters;
+import org.molgenis.test.AbstractMockitoTest;
+import org.molgenis.validation.JsonValidator;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.util.stream.Stream;
+
+import static org.mockito.Mockito.*;
+
+public class DecoratorParametersRepositoryDecoratorTest extends AbstractMockitoTest
+{
+	@Mock
+	private JsonValidator jsonValidator;
+
+	@Mock
+	private Repository delegateRepo;
+
+	@Captor
+	private ArgumentCaptor<Stream<DecoratorParameters>> streamCaptor;
+
+	private DecoratorParametersRepositoryDecorator decorator;
+
+	private static final String SCHEMA = "{some: 'schema'}";
+	private static final String JSON = "{para: 'meters'}";
+
+	@BeforeMethod
+	@SuppressWarnings("unchecked")
+	public void beforeMethod()
+	{
+		decorator = new DecoratorParametersRepositoryDecorator(delegateRepo, jsonValidator);
+	}
+
+	@Test
+	public void testUpdate()
+	{
+		decorator.update(mockParameters());
+		verify(jsonValidator).validate(JSON, SCHEMA);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testUpdateStream()
+	{
+		decorator.update(Stream.of(mockParameters(), mockParameters()));
+
+		verify(delegateRepo).update(streamCaptor.capture());
+		streamCaptor.getValue().forEach(t ->
+		{ // consume stream
+		});
+		verify(jsonValidator, times(2)).validate(JSON, SCHEMA);
+	}
+
+	@Test
+	public void testAdd()
+	{
+		decorator.add(mockParameters());
+		verify(jsonValidator).validate(JSON, SCHEMA);
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void testAddStream()
+	{
+		decorator.add(Stream.of(mockParameters(), mockParameters()));
+
+		verify(delegateRepo).add(streamCaptor.capture());
+		streamCaptor.getValue().forEach(t ->
+		{ // consume stream
+		});
+		verify(jsonValidator, times(2)).validate(JSON, SCHEMA);
+	}
+
+	@Test
+	public void testNoValidationWhenNullParameters()
+	{
+		DecoratorParameters parameters = mock(DecoratorParameters.class, RETURNS_DEEP_STUBS);
+
+		decorator.add(parameters);
+
+		verifyZeroInteractions(jsonValidator);
+	}
+
+	private DecoratorParameters mockParameters()
+	{
+		DecoratorParameters parameters = mock(DecoratorParameters.class, RETURNS_DEEP_STUBS);
+		when(parameters.getParameters()).thenReturn(JSON);
+		when(parameters.getDecorator().getSchema()).thenReturn(SCHEMA);
+		return parameters;
+	}
+}

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
@@ -2,35 +2,47 @@ package org.molgenis.data.decorator;
 
 import com.google.gson.Gson;
 import org.mockito.Mock;
-import org.molgenis.data.*;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+import org.molgenis.data.AbstractMolgenisSpringTest;
+import org.molgenis.data.DataService;
+import org.molgenis.data.Entity;
+import org.molgenis.data.Repository;
 import org.molgenis.data.decorator.meta.*;
 import org.molgenis.data.event.BootstrappingEvent;
 import org.molgenis.data.meta.model.EntityType;
-import org.molgenis.data.support.QueryImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
+import java.util.stream.Stream;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+import static com.google.common.collect.ImmutableMap.of;
+import static com.google.common.collect.Sets.newHashSet;
+import static java.util.Collections.emptyMap;
+import static java.util.stream.Collectors.toSet;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.*;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_CONFIGURATION;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.ENTITY_TYPE_ID;
 import static org.molgenis.data.event.BootstrappingEvent.BootstrappingStatus.FINISHED;
 import static org.testng.Assert.assertEquals;
 
 @ContextConfiguration(classes = { DecoratorConfigurationMetadata.class, DecoratorPackage.class,
-		DynamicDecoratorMetadata.class })
+		DynamicDecoratorMetadata.class, DecoratorParametersMetadata.class })
 public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenisSpringTest
 {
 	@Autowired
 	DecoratorConfigurationMetadata decoratorConfigurationMetadata;
 
+	@Autowired
+	DecoratorParametersMetadata decoratorParametersMetadata;
+
 	@Mock
 	private Repository<Entity> repository;
-	@Mock
+	@Mock(answer = RETURNS_DEEP_STUBS)
 	private DataService dataService;
 	@Mock
 	private EntityType entityType;
@@ -39,39 +51,87 @@ public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenis
 	@Mock
 	private DynamicRepositoryDecoratorFactory<Entity> dynamicRepositoryDecoratorFactory;
 
+	private DynamicRepositoryDecoratorRegistryImpl registry;
+
 	@BeforeMethod
-	public void setUp()
+	public void beforeMethod()
 	{
-		when(entityType.getId()).thenReturn("entityTypeId");
-		when(repository.getEntityType()).thenReturn(entityType);
+		registry = new DynamicRepositoryDecoratorRegistryImpl(dataService, new Gson());
+
+		//fake the bootstrapping event to tell the registry that bootstrapping is finished.
+		registry.onApplicationEvent(new BootstrappingEvent(FINISHED));
 	}
 
 	@Test
+	public void testAddFactory()
+	{
+		DynamicRepositoryDecoratorFactory factory1 = mock(DynamicRepositoryDecoratorFactory.class);
+		when(factory1.getId()).thenReturn("test1");
+		DynamicRepositoryDecoratorFactory factory2 = mock(DynamicRepositoryDecoratorFactory.class);
+		when(factory2.getId()).thenReturn("test2");
+
+		registry.addFactory(factory1);
+		registry.addFactory(factory2);
+
+		assertEquals(registry.getFactoryIds().collect(toSet()), newHashSet("test1", "test2"));
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Duplicate decorator id \\[test\\]")
+	public void testAddDuplicateFactory()
+	{
+		DynamicRepositoryDecoratorFactory factory = mock(DynamicRepositoryDecoratorFactory.class);
+		when(factory.getId()).thenReturn("test");
+
+		registry.addFactory(factory);
+		registry.addFactory(factory);
+	}
+
+	@Test
+	public void testGetFactory()
+	{
+		DynamicRepositoryDecoratorFactory factory = mock(DynamicRepositoryDecoratorFactory.class);
+		when(factory.getId()).thenReturn("test");
+		registry.addFactory(factory);
+
+		DynamicRepositoryDecoratorFactory returnedFactory = registry.getFactory("test");
+
+		assertEquals(returnedFactory, factory);
+	}
+
+	@Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "Decorator \\[test\\] does not exist")
+	public void testGetNonExistingFactory()
+	{
+		registry.getFactory("test");
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
 	public void testDecorate()
 	{
+		when(entityType.getId()).thenReturn("entityTypeId");
+		when(repository.getEntityType()).thenReturn(entityType);
+
 		DynamicDecorator dynamicDecorator = mock(DynamicDecorator.class);
-		@SuppressWarnings("unchecked")
+		DecoratorParameters parameters = mock(DecoratorParameters.class);
+		when(parameters.getDecorator()).thenReturn(dynamicDecorator);
 		Repository<Entity> decoratedRepository = mock(Repository.class);
 
 		when(decoratedRepository.getName()).thenReturn("decoratedRepositoryName");
-		//		when(decoratorConfiguration.getDecoratorParameters()).thenReturn(Stream.of(dynamicDecorator)); //TODO
+		when(decoratorConfiguration.getDecoratorParameters()).thenAnswer(
+				(Answer<Stream>) invocation -> Stream.of(parameters));
+
 		when(dynamicDecorator.getId()).thenReturn("dynamicDecoratorId");
+
 		when(dynamicRepositoryDecoratorFactory.getId()).thenReturn("dynamicDecoratorId");
-		when(dynamicRepositoryDecoratorFactory.createDecoratedRepository(repository, mock(Map.class))).thenReturn(
+		when(dynamicRepositoryDecoratorFactory.createDecoratedRepository(eq(repository), any(Map.class))).thenReturn(
 				decoratedRepository);
-		Query<DecoratorConfiguration> query = new QueryImpl<>();
-		query.eq(ENTITY_TYPE_ID, "entityTypeId");
-		when(dataService.findOne(DECORATOR_CONFIGURATION, query, DecoratorConfiguration.class)).thenReturn(
-				decoratorConfiguration);
+		when(dataService.query(DECORATOR_CONFIGURATION, DecoratorConfiguration.class)
+						.eq(ENTITY_TYPE_ID, "entityTypeId")
+						.findOne()).thenReturn(decoratorConfiguration);
 
-		DynamicRepositoryDecoratorRegistryImpl dynamicRepositoryDecoratorRegistry = new DynamicRepositoryDecoratorRegistryImpl(
-				dataService, mock(Gson.class));
-		//fake the event to tell the registry that bootstrapping is done.
-		dynamicRepositoryDecoratorRegistry.onApplicationEvent(new BootstrappingEvent(FINISHED));
+		registry.addFactory(dynamicRepositoryDecoratorFactory);
 
-		dynamicRepositoryDecoratorRegistry.addFactory(dynamicRepositoryDecoratorFactory);
-
-		assertEquals(dynamicRepositoryDecoratorRegistry.decorate(repository).getName(), "decoratedRepositoryName");
+		assertEquals(registry.decorate(repository).getName(), "decoratedRepositoryName");
 	}
 
 	@Test
@@ -81,11 +141,47 @@ public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenis
 		when(repository.getName()).thenReturn("repositoryName");
 		when(entityType.getId()).thenReturn("entityTypeId");
 
-		DynamicRepositoryDecoratorRegistryImpl dynamicRepositoryDecoratorRegistry = new DynamicRepositoryDecoratorRegistryImpl(
-				dataService, mock(Gson.class));
-		//fake the event to tell the registry that bootstrapping is done.
-		dynamicRepositoryDecoratorRegistry.onApplicationEvent(new BootstrappingEvent(FINISHED));
+		when(dataService.query(DECORATOR_CONFIGURATION, DecoratorConfiguration.class)
+						.eq(ENTITY_TYPE_ID, "entityTypeId")
+						.findOne()).thenReturn(null);
 
-		assertEquals(dynamicRepositoryDecoratorRegistry.decorate(repository).getName(), "repositoryName");
+		assertEquals(registry.decorate(repository).getName(), "repositoryName");
+	}
+
+	@Test
+	public void getParameterMap()
+	{
+		DecoratorConfiguration config = mock(DecoratorConfiguration.class);
+		DecoratorParameters params1 = mock(DecoratorParameters.class, Mockito.RETURNS_DEEP_STUBS);
+		DecoratorParameters params2 = mock(DecoratorParameters.class, Mockito.RETURNS_DEEP_STUBS);
+		when(config.getDecoratorParameters()).thenReturn(Stream.of(params1, params2));
+		when(params1.getParameters()).thenReturn("{attr: 'test'}");
+		when(params2.getParameters()).thenReturn("{column: 'test', value: 'text'}");
+		when(params1.getDecorator().getId()).thenReturn("dec1");
+		when(params2.getDecorator().getId()).thenReturn("dec2");
+		Map<String, Map<String, Object>> expected = of("dec1", of("attr", "test"), "dec2",
+				of("column", "test", "value", "text"));
+
+		Map<String, Map<String, Object>> parameterMap = registry.getParameterMap(config);
+
+		assertEquals(parameterMap, expected);
+	}
+
+	@Test
+	public void getParametersMapWithNullValue()
+	{
+		DecoratorConfiguration config = mock(DecoratorConfiguration.class);
+		DecoratorParameters params1 = mock(DecoratorParameters.class, Mockito.RETURNS_DEEP_STUBS);
+		DecoratorParameters params2 = mock(DecoratorParameters.class, Mockito.RETURNS_DEEP_STUBS);
+		when(config.getDecoratorParameters()).thenReturn(Stream.of(params1, params2));
+		when(params1.getParameters()).thenReturn("{attr: 'test'}");
+		when(params2.getParameters()).thenReturn(null);
+		when(params1.getDecorator().getId()).thenReturn("dec1");
+		when(params2.getDecorator().getId()).thenReturn("dec2");
+		Map<String, Map<String, Object>> expected = of("dec1", of("attr", "test"), "dec2", emptyMap());
+
+		Map<String, Map<String, Object>> parameterMap = registry.getParameterMap(config);
+
+		assertEquals(parameterMap, expected);
 	}
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
@@ -1,5 +1,6 @@
 package org.molgenis.data.decorator;
 
+import com.google.gson.Gson;
 import org.mockito.Mock;
 import org.molgenis.data.*;
 import org.molgenis.data.decorator.meta.*;
@@ -11,6 +12,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
@@ -56,14 +58,15 @@ public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenis
 		when(decoratorConfiguration.getDecorators()).thenReturn(Stream.of(dynamicDecorator));
 		when(dynamicDecorator.getId()).thenReturn("dynamicDecoratorId");
 		when(dynamicRepositoryDecoratorFactory.getId()).thenReturn("dynamicDecoratorId");
-		when(dynamicRepositoryDecoratorFactory.createDecoratedRepository(repository)).thenReturn(decoratedRepository);
+		when(dynamicRepositoryDecoratorFactory.createDecoratedRepository(repository, mock(Map.class))).thenReturn(
+				decoratedRepository);
 		Query<DecoratorConfiguration> query = new QueryImpl<>();
 		query.eq(ENTITY_TYPE_ID, "entityTypeId");
 		when(dataService.findOne(DECORATOR_CONFIGURATION, query, DecoratorConfiguration.class)).thenReturn(
 				decoratorConfiguration);
 
 		DynamicRepositoryDecoratorRegistryImpl dynamicRepositoryDecoratorRegistry = new DynamicRepositoryDecoratorRegistryImpl(
-				dataService);
+				dataService, mock(Gson.class));
 		//fake the event to tell the registry that bootstrapping is done.
 		dynamicRepositoryDecoratorRegistry.onApplicationEvent(new BootstrappingEvent(FINISHED));
 
@@ -80,7 +83,7 @@ public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenis
 		when(entityType.getId()).thenReturn("entityTypeId");
 
 		DynamicRepositoryDecoratorRegistryImpl dynamicRepositoryDecoratorRegistry = new DynamicRepositoryDecoratorRegistryImpl(
-				dataService);
+				dataService, mock(Gson.class));
 		//fake the event to tell the registry that bootstrapping is done.
 		dynamicRepositoryDecoratorRegistry.onApplicationEvent(new BootstrappingEvent(FINISHED));
 

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
@@ -37,7 +37,7 @@ public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenis
 	@Mock
 	private DecoratorConfiguration decoratorConfiguration;
 	@Mock
-	private DynamicRepositoryDecoratorFactory<Entity, EntityType> dynamicRepositoryDecoratorFactory;
+	private DynamicRepositoryDecoratorFactory<Entity> dynamicRepositoryDecoratorFactory;
 
 	@BeforeMethod
 	public void setUp()

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/DynamicRepositoryDecoratorRegistryImplTest.java
@@ -13,7 +13,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Map;
-import java.util.stream.Stream;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -55,7 +54,7 @@ public class DynamicRepositoryDecoratorRegistryImplTest extends AbstractMolgenis
 		Repository<Entity> decoratedRepository = mock(Repository.class);
 
 		when(decoratedRepository.getName()).thenReturn("decoratedRepositoryName");
-		when(decoratorConfiguration.getDecorators()).thenReturn(Stream.of(dynamicDecorator));
+		//		when(decoratorConfiguration.getDecoratorParameters()).thenReturn(Stream.of(dynamicDecorator)); //TODO
 		when(dynamicDecorator.getId()).thenReturn("dynamicDecoratorId");
 		when(dynamicRepositoryDecoratorFactory.getId()).thenReturn("dynamicDecoratorId");
 		when(dynamicRepositoryDecoratorFactory.createDecoratedRepository(repository, mock(Map.class))).thenReturn(

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/config/JsonTestConfig.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/config/JsonTestConfig.java
@@ -1,0 +1,12 @@
+package org.molgenis.integrationtest.config;
+
+import com.google.gson.Gson;
+import org.molgenis.validation.JsonValidator;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+
+@Configuration
+@Import({ Gson.class, JsonValidator.class })
+public class JsonTestConfig
+{
+}

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/AddingRepositoryDecorator.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/AddingRepositoryDecorator.java
@@ -9,7 +9,7 @@ public class AddingRepositoryDecorator extends AbstractRepositoryDecorator<Entit
 {
 	private final String attributeName;
 
-	public AddingRepositoryDecorator(Repository<Entity> delegateRepository, String attributeName)
+	AddingRepositoryDecorator(Repository<Entity> delegateRepository, String attributeName)
 	{
 		super(delegateRepository);
 		this.attributeName = attributeName;

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/AddingRepositoryDecorator.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/AddingRepositoryDecorator.java
@@ -3,23 +3,22 @@ package org.molgenis.integrationtest.data.decorator;
 import org.molgenis.data.AbstractRepositoryDecorator;
 import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 //Decorator specifically for DynamicDecoratorIT
 public class AddingRepositoryDecorator extends AbstractRepositoryDecorator<Entity>
 {
-	private static final Logger LOG = LoggerFactory.getLogger(AddingRepositoryDecorator.class);
+	private final String attributeName;
 
-	public AddingRepositoryDecorator(Repository<Entity> delegateRepository)
+	public AddingRepositoryDecorator(Repository<Entity> delegateRepository, String attributeName)
 	{
 		super(delegateRepository);
+		this.attributeName = attributeName;
 	}
 
 	@Override
 	public void update(Entity entity)
 	{
-		entity.set("int_attr", entity.getInt("int_attr") + 1);
+		entity.set(attributeName, entity.getInt(attributeName) + 1);
 		super.update(entity);
 	}
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/AddingRepositoryDecoratorFactory.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/AddingRepositoryDecoratorFactory.java
@@ -1,19 +1,35 @@
 package org.molgenis.integrationtest.data.decorator;
 
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
 import org.molgenis.data.decorator.DynamicRepositoryDecoratorFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static java.util.Objects.requireNonNull;
+
 @Component
-public class AddingRepositoryDecoratorFactory implements DynamicRepositoryDecoratorFactory
+public class AddingRepositoryDecoratorFactory implements DynamicRepositoryDecoratorFactory<Entity>
 {
+	private static final String PARAM_ATTRIBUTE = "attr";
+
 	private static final String ID = "add";
+	private final Gson gson;
+
+	public AddingRepositoryDecoratorFactory(Gson gson)
+	{
+		this.gson = requireNonNull(gson);
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Repository createDecoratedRepository(Repository repository)
+	public Repository<Entity> createDecoratedRepository(Repository<Entity> repository, Map<String, Object> parameters)
 	{
-		return new AddingRepositoryDecorator(repository);
+		return new AddingRepositoryDecorator(repository, parameters.get(PARAM_ATTRIBUTE).toString());
 	}
 
 	@Override
@@ -31,6 +47,14 @@ public class AddingRepositoryDecoratorFactory implements DynamicRepositoryDecora
 	@Override
 	public String getDescription()
 	{
-		return "This is a test decorator";
+		return "This is a test decorator.";
+	}
+
+	@Override
+	public String getSchema()
+	{
+		return gson.toJson(of("title", "Adding Decorator", "type", "object", "properties",
+				of(PARAM_ATTRIBUTE, of("type", "string", "description", "The attribute to increment")), "required",
+				ImmutableList.of("attr")));
 	}
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/PostFixingRepositoryDecorator.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/PostFixingRepositoryDecorator.java
@@ -10,7 +10,7 @@ public class PostFixingRepositoryDecorator extends AbstractRepositoryDecorator<E
 	private final String attributeName;
 	private final String text;
 
-	public PostFixingRepositoryDecorator(Repository<Entity> delegateRepository, String attributeName, String text)
+	PostFixingRepositoryDecorator(Repository<Entity> delegateRepository, String attributeName, String text)
 	{
 		super(delegateRepository);
 		this.attributeName = attributeName;

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/PostFixingRepositoryDecorator.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/PostFixingRepositoryDecorator.java
@@ -3,23 +3,24 @@ package org.molgenis.integrationtest.data.decorator;
 import org.molgenis.data.AbstractRepositoryDecorator;
 import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 //Decorator specifically for DynamicDecoratorIT
 public class PostFixingRepositoryDecorator extends AbstractRepositoryDecorator<Entity>
 {
-	private static final Logger LOG = LoggerFactory.getLogger(PostFixingRepositoryDecorator.class);
+	private final String attributeName;
+	private final String text;
 
-	public PostFixingRepositoryDecorator(Repository<Entity> delegateRepository)
+	public PostFixingRepositoryDecorator(Repository<Entity> delegateRepository, String attributeName, String text)
 	{
 		super(delegateRepository);
+		this.attributeName = attributeName;
+		this.text = text;
 	}
 
 	@Override
 	public void update(Entity entity)
 	{
-		entity.set("string_attr", entity.getString("string_attr") + "_TEST");
+		entity.set(attributeName, entity.getString(attributeName) + text);
 		super.update(entity);
 	}
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/PostFixingRepositoryDecoratorFactory.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/data/decorator/PostFixingRepositoryDecoratorFactory.java
@@ -1,19 +1,37 @@
 package org.molgenis.integrationtest.data.decorator;
 
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+import org.molgenis.data.Entity;
 import org.molgenis.data.Repository;
 import org.molgenis.data.decorator.DynamicRepositoryDecoratorFactory;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static java.util.Objects.requireNonNull;
+
 @Component
-public class PostFixingRepositoryDecoratorFactory implements DynamicRepositoryDecoratorFactory
+public class PostFixingRepositoryDecoratorFactory implements DynamicRepositoryDecoratorFactory<Entity>
 {
+	private static final String PARAM_ATTRIBUTE = "attr";
+	private static final String PARAM_TEXT = "text";
+
 	private static final String ID = "postfix";
+	private final Gson gson;
+
+	public PostFixingRepositoryDecoratorFactory(Gson gson)
+	{
+		this.gson = requireNonNull(gson);
+	}
 
 	@Override
 	@SuppressWarnings("unchecked")
-	public Repository createDecoratedRepository(Repository repository)
+	public Repository createDecoratedRepository(Repository<Entity> repository, Map<String, Object> parameters)
 	{
-		return new PostFixingRepositoryDecorator(repository);
+		return new PostFixingRepositoryDecorator(repository, parameters.get(PARAM_ATTRIBUTE).toString(),
+				parameters.get(PARAM_TEXT).toString());
 	}
 
 	@Override
@@ -34,4 +52,12 @@ public class PostFixingRepositoryDecoratorFactory implements DynamicRepositoryDe
 		return "This is a test decorator";
 	}
 
+	@Override
+	public String getSchema()
+	{
+		return gson.toJson(of("title", "Postfixing Decorator", "type", "object", "properties",
+				of(PARAM_ATTRIBUTE, of("type", "string", "description", "The attribute to increment"), PARAM_TEXT,
+						of("type", "string", "description", "The text to append")), "required",
+				ImmutableList.of("attr", "text")));
+	}
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/DynamicDecoratorIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/DynamicDecoratorIT.java
@@ -1,6 +1,5 @@
 package org.molgenis.integrationtest.platform;
 
-import com.google.gson.Gson;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityTestHarness;
@@ -10,11 +9,11 @@ import org.molgenis.data.index.job.IndexJobScheduler;
 import org.molgenis.data.meta.MetaDataService;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.security.EntityTypeIdentity;
+import org.molgenis.integrationtest.config.JsonTestConfig;
 import org.molgenis.integrationtest.data.decorator.AddingRepositoryDecoratorFactory;
 import org.molgenis.integrationtest.data.decorator.PostFixingRepositoryDecoratorFactory;
 import org.molgenis.security.core.PermissionService;
 import org.molgenis.security.core.PermissionSet;
-import org.molgenis.validation.JsonValidator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -47,7 +46,7 @@ import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 @ContextConfiguration(classes = { PlatformITConfig.class, AddingRepositoryDecoratorFactory.class,
-		PostFixingRepositoryDecoratorFactory.class, Gson.class, JsonValidator.class })
+		PostFixingRepositoryDecoratorFactory.class, JsonTestConfig.class })
 @TestExecutionListeners(listeners = WithSecurityContextTestExecutionListener.class)
 @Transactional
 public class DynamicDecoratorIT extends AbstractTestNGSpringContextTests

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/PlatformITConfig.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/PlatformITConfig.java
@@ -18,6 +18,7 @@ import org.molgenis.data.security.DataserviceRoleHierarchy;
 import org.molgenis.data.security.SystemEntityTypeRegistryImpl;
 import org.molgenis.data.security.permission.DataPermissionConfig;
 import org.molgenis.data.validation.ExpressionValidator;
+import org.molgenis.integrationtest.config.JsonTestConfig;
 import org.molgenis.integrationtest.config.ScriptTestConfig;
 import org.molgenis.integrationtest.config.SecurityCoreITConfig;
 import org.molgenis.integrationtest.data.TestAppSettings;
@@ -87,7 +88,8 @@ import static org.mockito.Mockito.mock;
 		UserPermissionEvaluatorImpl.class, DataserviceRoleHierarchy.class,
 		SystemRepositoryDecoratorFactoryRegistrar.class, SemanticSearchConfig.class, OntologyConfig.class,
 		JobExecutionConfig.class, JobFactoryRegistrar.class, SystemEntityTypeRegistryImpl.class, ScriptTestConfig.class,
-		AclConfig.class, MutableAclClassServiceImpl.class, PermissionRegistry.class, DataPermissionConfig.class })
+		AclConfig.class, MutableAclClassServiceImpl.class, PermissionRegistry.class, DataPermissionConfig.class,
+		JsonTestConfig.class })
 public class PlatformITConfig implements ApplicationListener<ContextRefreshedEvent>
 {
 	@Autowired


### PR DESCRIPTION
This PR adds the possibility to parameterize your dynamic decorators.

There are two test decorators in `molgenis-platform-integration-tests/src/test/.../data/decorator/`. Copy these two (including the factories) to the `molgenis-data` module. When you start the app, these decorators will be picked up by the registry.

EntitiesTypes:
`DynamicDecorator`: These are entity representations of the decorators in the code
`DecoratorParameters`: Use this to set up a single decorator and its parameters
`DecoratorConfiguration`: Use this to add one or more DecoratorParameters to an entity

Some things to try when testing:
- Is the parameter JSON validated correctly?
- When removing a decorator from the code, are all the references removed correctly when restarting the app?
- Is the file template working (and easy to use)?
- Are the dynamic decorators executing their function?
- Do decorators without parameters still work?
- Does an upgrade from a 7.0 database work?

Documentation will be added later.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [W.I.P.] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [No testplan since no way to use in "vanilla molgenis"] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
