### PR TITLE
M6042: As DM / Chr6 we need a feature to assign existing questionnaires to the users

### DIFF
--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/OwnershipDecorator.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/OwnershipDecorator.java
@@ -1,0 +1,75 @@
+package org.molgenis.data.security.owned;
+
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
+import static org.molgenis.security.core.PermissionSet.WRITE;
+import static org.molgenis.security.core.SidUtils.createUserSid;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.molgenis.data.AbstractRepositoryDecorator;
+import org.molgenis.data.Entity;
+import org.molgenis.data.Repository;
+import org.molgenis.data.security.EntityIdentity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.acls.model.MutableAcl;
+import org.springframework.security.acls.model.MutableAclService;
+import org.springframework.security.acls.model.Sid;
+
+/**
+ * Decorator that assigns ownership based on the owner attribute.
+ *
+ * <p>Only newly added entities get their ownership updated. User needs to have permission to update
+ * ownership.
+ */
+public class OwnershipDecorator extends AbstractRepositoryDecorator<Entity> {
+
+  private final MutableAclService mutableAclService;
+  private final String ownerAttributeName;
+
+  private static final Logger LOG = LoggerFactory.getLogger(OwnershipDecorator.class);
+
+  OwnershipDecorator(
+      Repository<Entity> delegateRepository,
+      MutableAclService mutableAclService,
+      String ownerAttributeName) {
+    super(delegateRepository);
+    this.mutableAclService = requireNonNull(mutableAclService);
+    this.ownerAttributeName = requireNonNull(ownerAttributeName);
+  }
+
+  @Override
+  public Integer add(Stream<Entity> entities) {
+    List<Entity> batch = entities.collect(toList());
+    Integer result = super.add(batch.stream());
+    batch.forEach(this::assignToOwner);
+    return result;
+  }
+
+  @Override
+  public void add(Entity entity) {
+    super.add(entity);
+    assignToOwner(entity);
+  }
+
+  private void assignToOwner(Entity entity) {
+    EntityIdentity entityIdentity = new EntityIdentity(entity);
+    String ownerName = entity.getString(ownerAttributeName);
+    LOG.debug("Assigning entity {} to owner {}...", entityIdentity, ownerName);
+    Sid ownerSid = createUserSid(ownerName);
+    MutableAcl acl = (MutableAcl) mutableAclService.readAclById(entityIdentity);
+    acl.setOwner(ownerSid);
+    removeAllEntries(acl);
+    acl.insertAce(0, WRITE, ownerSid, true);
+
+    mutableAclService.updateAcl(acl);
+    LOG.info("Assigned entity {} to owner {}.", entityIdentity, ownerName);
+  }
+
+  private void removeAllEntries(MutableAcl acl) {
+    while (!acl.getEntries().isEmpty()) {
+      acl.deleteAce(0);
+    }
+  }
+}

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/OwnershipDecoratorFactory.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/owned/OwnershipDecoratorFactory.java
@@ -1,0 +1,64 @@
+package org.molgenis.data.security.owned;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static java.util.Collections.singleton;
+import static java.util.Objects.requireNonNull;
+
+import com.google.gson.Gson;
+import java.util.Map;
+import org.molgenis.data.Entity;
+import org.molgenis.data.Repository;
+import org.molgenis.data.decorator.DynamicRepositoryDecoratorFactory;
+import org.springframework.security.acls.model.MutableAclService;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OwnershipDecoratorFactory implements DynamicRepositoryDecoratorFactory<Entity> {
+
+  private static final String ID = "ownership";
+  private static final String OWNER_ATTRIBUTE = "ownerAttribute";
+  private final Gson gson;
+  private final MutableAclService mutableAclService;
+
+  public OwnershipDecoratorFactory(Gson gson, MutableAclService mutableAclService) {
+    this.gson = requireNonNull(gson);
+    this.mutableAclService = requireNonNull(mutableAclService);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Repository createDecoratedRepository(
+      Repository<Entity> repository, Map<String, Object> parameters) {
+    String ownerAttribute = parameters.get(OWNER_ATTRIBUTE).toString();
+    return new OwnershipDecorator(repository, mutableAclService, ownerAttribute);
+  }
+
+  @Override
+  public String getId() {
+    return ID;
+  }
+
+  @Override
+  public String getLabel() {
+    return "Ownership decorator";
+  }
+
+  @Override
+  public String getDescription() {
+    return "When entities are added to the decorated repository, their owner is set to the value of the ownerAttribute.";
+  }
+
+  @Override
+  public String getSchema() {
+    return gson.toJson(
+        of(
+            "title",
+            "Questionnaire",
+            "type",
+            "object",
+            "properties",
+            of(OWNER_ATTRIBUTE, of("type", "string", "description", "Name of the owner attribute")),
+            "required",
+            singleton(OWNER_ATTRIBUTE)));
+  }
+}

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/owned/OwnershipDecoratorTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/owned/OwnershipDecoratorTest.java
@@ -1,0 +1,144 @@
+package org.molgenis.data.security.owned;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.molgenis.security.core.PermissionSet.WRITE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import java.util.stream.Stream;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.molgenis.data.Entity;
+import org.molgenis.data.Repository;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.security.EntityIdentity;
+import org.molgenis.security.core.PermissionSet;
+import org.molgenis.test.AbstractMockitoTest;
+import org.molgenis.validation.JsonValidationException;
+import org.molgenis.validation.JsonValidator;
+import org.springframework.security.acls.domain.AclAuthorizationStrategy;
+import org.springframework.security.acls.domain.AclImpl;
+import org.springframework.security.acls.domain.AuditLogger;
+import org.springframework.security.acls.domain.PrincipalSid;
+import org.springframework.security.acls.model.AccessControlEntry;
+import org.springframework.security.acls.model.MutableAclService;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class OwnershipDecoratorTest extends AbstractMockitoTest {
+
+  private OwnershipDecoratorFactory ownershipDecoratorFactory;
+
+  @Mock private Entity entity;
+  @Mock private EntityType entityType;
+  @Mock private Repository<Entity> delegate;
+  @Mock private MutableAclService mutableAclService;
+  @Mock private AclAuthorizationStrategy authorizationStrategy;
+  @Mock private AuditLogger auditLogger;
+  @Captor private ArgumentCaptor<Stream<Entity>> streamCaptor;
+
+  private OwnershipDecorator ownershipDecorator;
+  private JsonValidator validator = new JsonValidator();
+
+  @BeforeMethod
+  public void beforeMethod() {
+    ownershipDecoratorFactory = new OwnershipDecoratorFactory(new Gson(), mutableAclService);
+    ownershipDecorator =
+        (OwnershipDecorator)
+            ownershipDecoratorFactory.createDecoratedRepository(
+                delegate, ImmutableMap.of("ownerAttribute", "owner"));
+  }
+
+  @Test
+  public void testAdd() {
+    EntityIdentity entityIdentity = new EntityIdentity("MyQuestionnaire", "id");
+    when(entity.getString("owner")).thenReturn("username");
+    when(entity.getIdValue()).thenReturn("id");
+    when(entity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("MyQuestionnaire");
+    AclImpl acl = new AclImpl(entityIdentity, 1, authorizationStrategy, auditLogger);
+    acl.insertAce(0, PermissionSet.WRITE, new PrincipalSid("otheruser"), true);
+    when(mutableAclService.readAclById(entityIdentity)).thenReturn(acl);
+
+    ownershipDecorator.add(entity);
+
+    verify(delegate).add(entity);
+    verify(mutableAclService).updateAcl(acl);
+    PrincipalSid ownerSid = new PrincipalSid("username");
+    assertEquals(acl.getOwner(), ownerSid);
+    assertEquals(acl.getEntries().size(), 1);
+    AccessControlEntry ace = acl.getEntries().get(0);
+    assertEquals(ace.getSid(), ownerSid);
+    assertEquals(ace.getPermission(), WRITE);
+    assertTrue(ace.isGranting());
+  }
+
+  @Test
+  public void testAddStream() {
+    EntityIdentity entityIdentity = new EntityIdentity("MyQuestionnaire", "id");
+    when(entity.getString("owner")).thenReturn("username");
+    when(entity.getIdValue()).thenReturn("id");
+    when(entity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("MyQuestionnaire");
+    AclImpl acl = new AclImpl(entityIdentity, 1, authorizationStrategy, auditLogger);
+    acl.insertAce(0, PermissionSet.WRITE, new PrincipalSid("otheruser"), true);
+    when(mutableAclService.readAclById(entityIdentity)).thenReturn(acl);
+
+    ownershipDecorator.add(Stream.of(entity));
+
+    verify(delegate).add(streamCaptor.capture());
+    assertEquals(streamCaptor.getValue().collect(toList()), singletonList(entity));
+    verify(mutableAclService).updateAcl(acl);
+    PrincipalSid ownerSid = new PrincipalSid("username");
+    assertEquals(acl.getOwner(), ownerSid);
+    assertEquals(acl.getEntries().size(), 1);
+    AccessControlEntry ace = acl.getEntries().get(0);
+    assertEquals(ace.getSid(), ownerSid);
+    assertEquals(ace.getPermission(), WRITE);
+    assertTrue(ace.isGranting());
+  }
+
+  @Test
+  public void testGetFactorySchema() {
+    validator.validate("{ownerAttribute: 'owner'}", ownershipDecoratorFactory.getSchema());
+  }
+
+  @Test(
+      expectedExceptions = JsonValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "violations: #: required key \\[ownerAttribute\\] not found")
+  public void testFactorySchemaChecksForOwnerAttribute() {
+    validator.validate("{}", ownershipDecoratorFactory.getSchema());
+  }
+
+  @Test(
+      expectedExceptions = JsonValidationException.class,
+      expectedExceptionsMessageRegExp =
+          "violations: #/ownerAttribute: expected type: String, found: Integer")
+  public void testFactorySchemaChecksOwnerAttributeType() {
+    validator.validate("{ownerAttribute: 1}", ownershipDecoratorFactory.getSchema());
+  }
+
+  @Test
+  public void testGetFactoryDescription() {
+    assertEquals(
+        ownershipDecoratorFactory.getDescription(),
+        "When entities are added to the decorated repository, their owner is set to the value of the ownerAttribute.");
+  }
+
+  @Test
+  public void testGetFactoryLabel() {
+    assertEquals(ownershipDecoratorFactory.getLabel(), "Ownership decorator");
+  }
+
+  @Test
+  public void testGetFactoryId() {
+    assertEquals(ownershipDecoratorFactory.getId(), "ownership");
+  }
+}


### PR DESCRIPTION
Adds a dynamic OwnershipDecorator that can be used at import time to wrap the questionnaire repository.

To see it in action:

* Create user pietje
* Create Questionnaires group and make pietje editor in the group
* Give USER role read permission on sys_dec package
* Import test questionnaire metadata [emx-questionnaire.xls](
https://github.com/molgenis/molgenis/raw/master/molgenis-questionnaires/src/test/resources/emx-questionnaire.xls)
* Make questionnaires_TestQuestionnaire row-level secured
* Create decorator parameters:

id  | decorator | parameters 
-- | -- | -- 
owned | Ownership decorator | {ownerAttribute: owner} 

* Create decorator configuration:

entityTypeId |  parameters 
-- | -- 
questionnaires_TestQuestionnaire | owned

* Import pietje's questionnaire data (rename to questionnaires_TestQuestionnaire.tsv and upload)
[questionnaires_TestQuestionnaire.rename-to-tsv.txt](https://github.com/molgenis/molgenis/files/2373945/questionnaires_TestQuestionnaire.rename-to-tsv.txt)
* Remove the dynamic decorator config, it is no longer needed
* Log in as pietje and open the questionnaire

#### Checklist
- [x] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes