### PR TITLE
Fix #7676 Metadata manager undo-all-changes option

### DIFF
--- a/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerContainer.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerContainer.vue
@@ -76,7 +76,6 @@
 
         // The route change changed the EntityType we are looking at
         if (toEntityTypeId && fromEntityTypeId !== toEntityTypeId) {
-          this.$store.commit(SET_SELECTED_ATTRIBUTE_ID, null)
           this.$store.dispatch(GET_EDITOR_ENTITY_TYPE, toEntityTypeId)
         }
       }

--- a/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerEntityEditForm.vue
+++ b/molgenis-metadata-manager/src/main/frontend/src/components/MetadataManagerEntityEditForm.vue
@@ -23,6 +23,10 @@
           <save-button :onClick="saveEntityType" :disabled="!isEntityTypeEdited">
             {{ 'save-changes-button' | i18n }}
           </save-button>
+          <button @click="resetEntityType(editorEntityType.id)" class="btn btn-warning"
+                  :disabled="!isEntityTypeEdited">
+            {{ 'undo-changes-button' | i18n }}
+          </button>
           <button @click="deleteEntityType(editorEntityType.id)" class="btn btn-danger"
                   :disabled="editorEntityType.isNew">
             {{ 'delete-entity-button' | i18n }}
@@ -119,7 +123,7 @@
 <script>
   import { mapState, mapGetters } from 'vuex'
   import { UPDATE_EDITOR_ENTITY_TYPE } from '../store/mutations'
-  import { SAVE_EDITOR_ENTITY_TYPE, DELETE_ENTITY_TYPE } from '../store/actions'
+  import { SAVE_EDITOR_ENTITY_TYPE, RESET_EDITOR_ENTITY_TYPE, DELETE_ENTITY_TYPE } from '../store/actions'
   import { getConfirmBeforeDeletingProperties } from '../store/getters'
 
   import Multiselect from 'vue-multiselect'
@@ -130,6 +134,9 @@
     methods: {
       saveEntityType () {
         this.$store.dispatch(SAVE_EDITOR_ENTITY_TYPE, this.$t)
+      },
+      resetEntityType () {
+        this.$store.dispatch(RESET_EDITOR_ENTITY_TYPE)
       },
       deleteEntityType (selectedEntityTypeId) {
         this.$swal(getConfirmBeforeDeletingProperties(selectedEntityTypeId, this.$t)).then(() => {

--- a/molgenis-metadata-manager/src/main/frontend/src/store/actions.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/actions.js
@@ -18,6 +18,7 @@ import type {EditorAttribute, EditorEntityType, State} from '../flow.types'
 
 export const GET_PACKAGES: string = '__GET_PACKAGES__'
 export const GET_ENTITY_TYPES: string = '__GET_ENTITY_TYPES__'
+export const RESET_EDITOR_ENTITY_TYPE: string = '__RESET_EDITOR_ENTITY_TYPE__'
 export const GET_EDITOR_ENTITY_TYPE: string = '__GET_EDITOR_ENTITY_TYPE__'
 export const CREATE_ENTITY_TYPE: string = '__CREATE_ENTITY_TYPE__'
 export const DELETE_ENTITY_TYPE: string = '__DELETE_ENTITY_TYPE__'
@@ -36,7 +37,8 @@ export const toEntityType = (editorEntityType: Object): EditorEntityType => {
     'backend': editorEntityType.backend,
     'package0': editorEntityType.package0,
     'entityTypeParent': editorEntityType.entityTypeParent,
-    'attributes': editorEntityType.attributes.map(attribute => toAttribute(attribute)),
+    'attributes': editorEntityType.attributes.map(
+      attribute => toAttribute(attribute)),
     'referringAttributes': editorEntityType.referringAttributes,
     'tags': editorEntityType.tags,
     'idAttribute': editorEntityType.idAttribute,
@@ -86,107 +88,140 @@ const withSpinner = (commit, promise) => {
   }).then(() => commit(SET_LOADING, false), 1000)
 }
 
+function getEditorEntityType(commit: Function, entityTypeId: string) {
+  withSpinner(commit,
+    api.get('/plugin/metadata-manager/entityType/' + entityTypeId).then(
+      response => {
+        commit(SET_EDITOR_ENTITY_TYPE, toEntityType(response.entityType))
+      }))
+}
+
 export default {
   /**
    * Retrieve all Packages and filter on non-system Packages
    */
-  [GET_PACKAGES] ({commit}: { commit: Function }) {
-    withSpinner(commit, api.get('/plugin/metadata-manager/editorPackages').then(response => {
-      commit(SET_PACKAGES, response)
-    }))
+  [GET_PACKAGES]({commit}: { commit: Function }) {
+    withSpinner(commit,
+      api.get('/plugin/metadata-manager/editorPackages').then(response => {
+        commit(SET_PACKAGES, response)
+      }))
   },
   /**
    * Retrieve all EntityTypes and filter on non-system EntityTypes
    */
-  [GET_ENTITY_TYPES] ({commit}: { commit: Function }) {
-    withSpinner(commit, api.get('/api/v2/sys_md_EntityType?num=10000').then(response => {
-      commit(SET_ENTITY_TYPES, response.items)
-    }))
+  [GET_ENTITY_TYPES]({commit}: { commit: Function }) {
+    withSpinner(commit,
+      api.get('/api/v2/sys_md_EntityType?num=10000').then(response => {
+        commit(SET_ENTITY_TYPES, response.items)
+      }))
   },
   /**
    * Retrieve all Attribute types
    */
-  [GET_ATTRIBUTE_TYPES] ({commit}: { commit: Function }) {
-    withSpinner(commit, api.get('/api/v2/sys_md_Attribute/meta/type').then(response => {
-      commit(SET_ATTRIBUTE_TYPES, response.enumOptions)
-    }))
+  [GET_ATTRIBUTE_TYPES]({commit}: { commit: Function }) {
+    withSpinner(commit,
+      api.get('/api/v2/sys_md_Attribute/meta/type').then(response => {
+        commit(SET_ATTRIBUTE_TYPES, response.enumOptions)
+      }))
+  },
+  /**
+   * Resets the current EditorEntityType
+   */
+  [RESET_EDITOR_ENTITY_TYPE]({commit, state}: { commit: Function, state: State }) {
+    getEditorEntityType(commit, state.selectedEntityTypeId)
   },
   /**
    * Retrieve EditorEntityType based on EntityType ID
    *
    * @param entityTypeId The selected EntityType identifier
    */
-  [GET_EDITOR_ENTITY_TYPE] ({commit}: { commit: Function }, entityTypeId: string) {
-    withSpinner(commit, api.get('/plugin/metadata-manager/entityType/' + entityTypeId).then(response => {
-      commit(SET_EDITOR_ENTITY_TYPE, toEntityType(response.entityType))
-    }))
+  [GET_EDITOR_ENTITY_TYPE]({commit}: { commit: Function },
+    entityTypeId: string) {
+    getEditorEntityType(commit, entityTypeId)
   },
   /**
    * Create a new EntityType
    * Response returns a blank EditorEntityType
    * EditorEntityType is added to the list of entityTypes in the state
    */
-  [CREATE_ENTITY_TYPE] ({commit}: { commit: Function }) {
-    withSpinner(commit, api.get('/plugin/metadata-manager/create/entityType').then(response => {
-      const newEditorEntityType = toEntityType(response.entityType)
-      newEditorEntityType.isNew = true
-      commit(SET_EDITOR_ENTITY_TYPE, newEditorEntityType)
-      commit(SET_SELECTED_ENTITY_TYPE_ID, newEditorEntityType.id)
-    }))
+  [CREATE_ENTITY_TYPE]({commit}: { commit: Function }) {
+    withSpinner(commit,
+      api.get('/plugin/metadata-manager/create/entityType').then(response => {
+        const newEditorEntityType = toEntityType(response.entityType)
+        newEditorEntityType.isNew = true
+        commit(SET_EDITOR_ENTITY_TYPE, newEditorEntityType)
+        commit(SET_SELECTED_ENTITY_TYPE_ID, newEditorEntityType.id)
+      }))
   },
   /**
    * Deletes an EntityType and reloads the EntityTypes present in the state
    *
    * @param selectedEntityTypeId the ID of the EntityType to be deleted
    */
-  [DELETE_ENTITY_TYPE] ({commit, state}: { commit: Function, state: State }, selectedEntityTypeId: string) {
-    withSpinner(commit, api.delete_('/api/v1/' + selectedEntityTypeId + '/meta').then(response => {
-      commit(SET_ENTITY_TYPES, state.entityTypes.filter(entityType => entityType.id !== selectedEntityTypeId))
-      commit(SET_SELECTED_ENTITY_TYPE_ID, null)
-      commit(SET_SELECTED_ATTRIBUTE_ID, null)
-      commit(SET_EDITOR_ENTITY_TYPE, null)
-      commit(CREATE_ALERT, {type: 'info', message: 'Delete was successful: ' + response.statusText})
-    }))
+  [DELETE_ENTITY_TYPE]({commit, state}: { commit: Function, state: State },
+    selectedEntityTypeId: string) {
+    withSpinner(commit,
+      api.delete_('/api/v1/' + selectedEntityTypeId + '/meta').then(
+        response => {
+          commit(SET_ENTITY_TYPES, state.entityTypes.filter(
+            entityType => entityType.id !== selectedEntityTypeId))
+          commit(SET_SELECTED_ENTITY_TYPE_ID, null)
+          commit(SET_SELECTED_ATTRIBUTE_ID, null)
+          commit(SET_EDITOR_ENTITY_TYPE, null)
+          commit(CREATE_ALERT, {
+            type: 'info',
+            message: 'Delete was successful: ' + response.statusText
+          })
+        }))
   },
   /**
    * Create a new Attribute
    * Response returns a blank Attribute
    * Attribute is added to the list of attributes in the existing editorEntityType
    */
-  [CREATE_ATTRIBUTE] ({commit, state}: { commit: Function, state: State }) {
-    withSpinner(commit, api.get('/plugin/metadata-manager/create/attribute').then(response => {
-      const attribute = toAttribute(response.attribute)
-      attribute.isNew = true
-      commit(UPDATE_EDITOR_ENTITY_TYPE, {key: 'attributes', value: [...state.editorEntityType.attributes, attribute]})
-      commit(SET_SELECTED_ATTRIBUTE_ID, attribute.id)
-    }))
+  [CREATE_ATTRIBUTE]({commit, state}: { commit: Function, state: State }) {
+    withSpinner(commit,
+      api.get('/plugin/metadata-manager/create/attribute').then(response => {
+        const attribute = toAttribute(response.attribute)
+        attribute.isNew = true
+        commit(UPDATE_EDITOR_ENTITY_TYPE, {
+          key: 'attributes',
+          value: [...state.editorEntityType.attributes, attribute]
+        })
+        commit(SET_SELECTED_ATTRIBUTE_ID, attribute.id)
+      }))
   },
   /**
    * Persist metadata changes to the database
    */
-  [SAVE_EDITOR_ENTITY_TYPE] ({commit, state}: { commit: Function, state: State }, t: Function) {
+  [SAVE_EDITOR_ENTITY_TYPE]({commit, state}: { commit: Function, state: State },
+    t: Function) {
     const options = {
       body: JSON.stringify(state.editorEntityType)
     }
-    withSpinner(commit, api.post('/plugin/metadata-manager/entityType', options).then(response => {
-      commit(CREATE_ALERT, {
-        type: 'success',
-        message: response.statusText + ': ' + t('save-succes-message') + ': ' + state.editorEntityType.label
-      })
+    withSpinner(commit,
+      api.post('/plugin/metadata-manager/entityType', options).then(
+        response => {
+          commit(CREATE_ALERT, {
+            type: 'success',
+            message: response.statusText + ': ' + t('save-succes-message')
+              + ': ' + state.editorEntityType.label
+          })
 
-      if (state.editorEntityType.isNew) {
-        const editorEntityType = JSON.parse(JSON.stringify(state.editorEntityType))
+          if (state.editorEntityType.isNew) {
+            const editorEntityType = JSON.parse(
+              JSON.stringify(state.editorEntityType))
 
-        editorEntityType.isNew = false
-        editorEntityType.attributes.forEach(attribute => {
-          attribute.isNew = false
-        })
+            editorEntityType.isNew = false
+            editorEntityType.attributes.forEach(attribute => {
+              attribute.isNew = false
+            })
 
-        commit(SET_SELECTED_ENTITY_TYPE_ID, editorEntityType.id)
-        commit(SET_ENTITY_TYPES, [...state.entityTypes, editorEntityType])
-      } else {
-        commit(SET_EDITOR_ENTITY_TYPE, state.editorEntityType)
-      }
-    }))
+            commit(SET_SELECTED_ENTITY_TYPE_ID, editorEntityType.id)
+            commit(SET_ENTITY_TYPES, [...state.entityTypes, editorEntityType])
+          } else {
+            commit(SET_EDITOR_ENTITY_TYPE, state.editorEntityType)
+          }
+        }))
   }
 }

--- a/molgenis-metadata-manager/src/main/frontend/src/store/mutations.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/mutations.js
@@ -8,7 +8,7 @@ import type {
   Update,
   UpdateOrder
 } from '../flow.types'
-import { INITIAL_STATE } from './state'
+import {INITIAL_STATE} from './state'
 
 export const SET_PACKAGES: string = '__SET_PACKAGES__'
 export const SET_ENTITY_TYPES: string = '__SET_ENTITY_TYPES__'
@@ -90,6 +90,7 @@ export default {
   [SET_EDITOR_ENTITY_TYPE] (state: State, editorEntityType: EditorEntityType) {
     state.editorEntityType = editorEntityType
     state.initialEditorEntityType = JSON.parse(JSON.stringify(editorEntityType))
+    state.selectedAttributeId = null
   },
   /**
    * Update currently selected EditorEntityType

--- a/molgenis-metadata-manager/src/main/frontend/test/unit/specs/actions.spec.js
+++ b/molgenis-metadata-manager/src/main/frontend/test/unit/specs/actions.spec.js
@@ -15,7 +15,8 @@ import {
   UPDATE_EDITOR_ENTITY_TYPE
 } from 'store/mutations'
 
-import actions, { toAttribute, toEntityType } from 'store/actions'
+import actions, {toAttribute, toEntityType} from 'store/actions'
+import {RESET_EDITOR_ENTITY_TYPE} from "../../../src/store/actions";
 
 const i18n = {
   'save-succes-message': 'Successfully updated metadata for EntityType'
@@ -147,6 +148,35 @@ describe('actions', () => {
       }
 
       utils.testAction(actions.__GET_ATTRIBUTE_TYPES__, options, done)
+    })
+  })
+
+  describe('RESET_EDITOR_ENTITY_TYPE', () => {
+    const entityTypeId = '1'
+
+    it('should retrieve the currently selected EditorEntityType and store it in the state via a mutation', done => {
+      const response = {
+        entityType: {
+          id: '1',
+          attributes: []
+        }
+      }
+
+      const get = td.function('api.get')
+      td.when(get('/plugin/metadata-manager/entityType/' + entityTypeId)).thenResolve(response)
+      td.replace(api, 'get', get)
+
+      const payload = toEntityType(response.entityType)
+
+      const options = {
+        state: {selectedEntityTypeId: entityTypeId},
+        expectedMutations: [
+          {type: SET_LOADING, payload: true},
+          {type: SET_EDITOR_ENTITY_TYPE, payload: payload}
+        ]
+      }
+
+      utils.testAction(actions.__RESET_EDITOR_ENTITY_TYPE__, options, done)
     })
   })
 

--- a/molgenis-metadata-manager/src/main/frontend/test/unit/specs/mutations.spec.js
+++ b/molgenis-metadata-manager/src/main/frontend/test/unit/specs/mutations.spec.js
@@ -105,7 +105,8 @@ describe('mutations', () => {
     it('Sets selected entity type to edit', () => {
       const state = {
         editorEntityType: {},
-        initialEditorEntityType: {}
+        initialEditorEntityType: {},
+        selectedAttributeId: null
       }
       const editorEntityType = {
         id: 'root_gender',
@@ -158,6 +159,7 @@ describe('mutations', () => {
       mutations.__SET_EDITOR_ENTITY_TYPE__(state, editorEntityType)
       expect(state.editorEntityType).to.deep.equal(editorEntityType)
       expect(state.initialEditorEntityType).to.deep.equal(JSON.parse(JSON.stringify(editorEntityType)))
+      expect(state.selectedAttributeId).to.deep.equal(null)
     })
   })
 

--- a/molgenis-metadata-manager/src/main/resources/l10n/metadata-manager_en.properties
+++ b/molgenis-metadata-manager/src/main/resources/l10n/metadata-manager_en.properties
@@ -1,6 +1,7 @@
 # Buttons
 back-to-home-button=Back to home
 save-changes-button=Save all changes
+undo-changes-button=Undo all changes
 delete-entity-button=Delete entity
 # Application
 application-title=Metadata manager

--- a/molgenis-metadata-manager/src/main/resources/l10n/metadata-manager_nl.properties
+++ b/molgenis-metadata-manager/src/main/resources/l10n/metadata-manager_nl.properties
@@ -1,6 +1,7 @@
 # Buttons
 back-to-home-button=Ga terug naar het menu
 save-changes-button=Sla alles op
+undo-changes-button=Wijzigingen ongedaan maken
 delete-entity-button=Verwijder Entiteit
 # Application
 application-title=Metadata manager


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
