### PR TITLE
Fix #7412 Data explorer entered-data lost on click outside of modal

### DIFF
--- a/molgenis-core-ui/src/main/javascript/modules/react-components/Modal.js
+++ b/molgenis-core-ui/src/main/javascript/modules/react-components/Modal.js
@@ -46,7 +46,7 @@ var Modal = React.createClass({
         });
         var id = 'modal-title-' + new Date().getTime();
         return (
-            div({className: 'modal', tabIndex: -1, role: 'dialog', 'aria-labelledby': id, ref: 'modal'},
+            div({className: 'modal', tabIndex: -1, role: 'dialog', 'aria-labelledby': id, 'data-backdrop': 'static', ref: 'modal'},
                 div({className: modalDialogClasses},
                     div({className: 'modal-content'},
                         div({className: 'modal-header'},


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [NA] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
