### PR TITLE
[CHORE] Updated jenkinsfile for build pod and pushing docker images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent {
         kubernetes {
-            label 'molgenisv2'
+            label 'molgenis'
         }
     }
     environment {
@@ -57,11 +57,12 @@ pipeline {
                 branch 'master'
             }
             environment {
-                TAG = 'experimental'
+                TAG = 'dev'
+                DOCKER_REPOSITORY = 'registry.hub.docker.com/molgenis/molgenis-app'
             }
             steps {
                 container('maven') {
-                    sh "mvn clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -Ddockerfile.tag=${TAG} -Ddockerfile.skip=false"
+                    sh "mvn clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -Ddockerfile.tag=${TAG} -Ddockerfile.repository=${DOCKER_REPOSITORY} -Ddockerfile.skip=false"
                 }
             }
             post {
@@ -80,10 +81,11 @@ pipeline {
             }
             environment {
                 TAG = 'latest'
+                DOCKER_REPOSITORY = 'registry.hub.docker.com/molgenis/molgenis-app'
             }
             steps {
                 container('maven') {
-                    sh "mvn clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -Ddockerfile.tag=${BRANCH_NAME}-${TAG} -Ddockerfile.skip=false"
+                    sh "mvn clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -Ddockerfile.tag=${BRANCH_NAME}-${TAG} -Ddockerfile.repository=${DOCKER_REPOSITORY} -Ddockerfile.skip=false"
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,13 +52,12 @@ pipeline {
                 }
             }
         }
-
         stage('Build [ master ]') {
             when {
                 branch 'master'
             }
             environment {
-                TAG = 'latest'
+                TAG = 'experimental'
             }
             steps {
                 container('maven') {
@@ -80,7 +79,7 @@ pipeline {
                 expression { BRANCH_NAME ==~ /[0-9]\.[0-9]/ }
             }
             environment {
-                TAG = 'stable'
+                TAG = 'latest'
             }
             steps {
                 container('maven') {
@@ -102,12 +101,13 @@ pipeline {
                 expression { BRANCH_NAME ==~ /[0-9]\.[0-9]/ }
             }
             environment {
-                TAG = 'lts'
+                TAG = 'stable'
                 ORG = 'molgenis'
                 REPO = 'molgenis'
                 MAVEN_ARTIFACT_ID = 'molgenis'
                 MAVEN_GROUP_ID = 'org.molgenis'
                 PGP_SECRETKEY = "keyfile:/home/jenkins/key.asc"
+                DOCKER_REPOSITORY = 'registry.hub.docker.com/molgenis/molgenis-app'
             }
             steps {
                 timeout(time: 40, unit: 'MINUTES') {
@@ -128,7 +128,7 @@ pipeline {
                     sh "git remote set-url origin https://${GITHUB_TOKEN}@github.com/${ORG}/${REPO}.git"
                     sh "git checkout -f ${BRANCH_NAME}"
                     sh ".release/generate_release_properties.bash ${MAVEN_ARTIFACT_ID} ${MAVEN_GROUP_ID} ${RELEASE_SCOPE}"
-                    sh "mvn release:prepare release:perform -Dmaven.test.redirectTestOutputToFile=true -Darguments=\"-DskipITs\" -DskipITs -Ddockerfile.tag=${BRANCH_NAME}-${TAG} -Ddockerfile.skip=false"
+                    sh "mvn release:prepare release:perform -Dmaven.test.redirectTestOutputToFile=true -Darguments=\"-DskipITs -Ddockerfile.tag=${BRANCH_NAME}-${TAG} -Ddockerfile.skip=false -Ddockerfile.repository=${DOCKER_REPOSITORY}\" -DskipITs -Ddockerfile.tag=${BRANCH_NAME}-${TAG} -Ddockerfile.skip=false -Ddockerfile.repository=${DOCKER_REPOSITORY}"
                     sh "git push --tags origin ${BRANCH_NAME}"
                 }
             }

--- a/molgenis-app/pom.xml
+++ b/molgenis-app/pom.xml
@@ -17,6 +17,7 @@
         <dockerfile-maven-version>1.4.0</dockerfile-maven-version>
         <dockerfile.tag>${project.version}</dockerfile.tag>
         <dockerfile.skip>true</dockerfile.skip>
+        <dockerfile.repository>registry.molgenis.org/molgenis/molgenis-app</dockerfile.repository>
     </properties>
 
     <build>
@@ -45,7 +46,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <repository>registry.molgenis.org/molgenis/molgenis-app</repository>
+                    <repository>${dockerfile.repository}</repository>
                     <tag>${dockerfile.tag}</tag>
                     <buildArgs>
                         <WAR_FILE>target/${project.build.finalName}.war</WAR_FILE>


### PR DESCRIPTION
Updated build pod again to "molgenis" - we now always are provisioning the secrets from vault and molgenisv2 was leaning on kubernetes secrets.

We are now pushing the following images:
- master merge: registry.hub.docker.com/molgenis/molgenis-app:dev
- branch merge: registry.hub.docker.com/molgenis/molgenis-app:7.1.0-latest
- branch release: registry.hub.docker.com/molgenis/molgenis-app:7.1.0-stable 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
