### PR TITLE
Fix #7789 EntityUtils.equals doesn't compare i18n labels/descriptions

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/util/EntityUtils.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/util/EntityUtils.java
@@ -29,6 +29,7 @@ import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.meta.model.Tag;
+import org.molgenis.i18n.LanguageService;
 import org.molgenis.util.ListEscapeUtils;
 import org.molgenis.util.Pair;
 import org.molgenis.util.UnexpectedEnumException;
@@ -200,8 +201,23 @@ public class EntityUtils {
     if (entityType != null && otherEntityType == null) return false;
     if (!(entityType != null && entityType.getId().equals(otherEntityType.getId()))) return false;
     if (!Objects.equals(entityType.getLabel(), otherEntityType.getLabel())) return false;
+    if (!LanguageService.getLanguageCodes()
+        .allMatch(
+            languageCode ->
+                Objects.equals(
+                    entityType.getLabel(languageCode), otherEntityType.getLabel(languageCode)))) {
+      return false;
+    }
     if (!Objects.equals(entityType.getDescription(), otherEntityType.getDescription()))
       return false;
+    if (!LanguageService.getLanguageCodes()
+        .allMatch(
+            languageCode ->
+                Objects.equals(
+                    entityType.getDescription(languageCode),
+                    otherEntityType.getDescription(languageCode)))) {
+      return false;
+    }
     if (entityType.isAbstract() != otherEntityType.isAbstract()) return false;
 
     // NB This is at such a low level that we do not know the default backend
@@ -366,7 +382,20 @@ public class EntityUtils {
     if (!Objects.equals(attr.getLabel(), otherAttr.getLabel())) {
       return false;
     }
+    if (!LanguageService.getLanguageCodes()
+        .allMatch(
+            languageCode ->
+                Objects.equals(attr.getLabel(languageCode), otherAttr.getLabel(languageCode)))) {
+      return false;
+    }
     if (!Objects.equals(attr.getDescription(), otherAttr.getDescription())) {
+      return false;
+    }
+    if (!LanguageService.getLanguageCodes()
+        .allMatch(
+            languageCode ->
+                Objects.equals(
+                    attr.getDescription(languageCode), otherAttr.getDescription(languageCode)))) {
       return false;
     }
     if (!Objects.equals(attr.getDataType(), otherAttr.getDataType())) {

--- a/molgenis-data/src/test/java/org/molgenis/data/util/EntityUtilsTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/util/EntityUtilsTest.java
@@ -65,6 +65,10 @@ public class EntityUtilsTest {
     when(otherLabelEntityType.getLabel()).thenReturn("otherLabel");
     dataList.add(new Object[] {entityType, otherLabelEntityType, false});
 
+    EntityType otherI18nLabelEntityType = createEqualsEntityType();
+    when(otherI18nLabelEntityType.getLabel("en")).thenReturn("otherLabelEn");
+    dataList.add(new Object[] {entityType, otherI18nLabelEntityType, false});
+
     EntityType otherAbstractEntityType = createEqualsEntityType();
     when(otherAbstractEntityType.isAbstract()).thenReturn(false);
     dataList.add(new Object[] {entityType, otherAbstractEntityType, false});
@@ -80,6 +84,10 @@ public class EntityUtilsTest {
     EntityType otherDescriptionEntityType = createEqualsEntityType();
     when(otherDescriptionEntityType.getDescription()).thenReturn("otherDescription");
     dataList.add(new Object[] {entityType, otherDescriptionEntityType, false});
+
+    EntityType otherI18nDescriptionEntityType = createEqualsEntityType();
+    when(otherI18nDescriptionEntityType.getLabel("en")).thenReturn("otherDescriptionEn");
+    dataList.add(new Object[] {entityType, otherI18nDescriptionEntityType, false});
 
     EntityType otherAttributesEntityType = createEqualsEntityType();
     when(otherAttributesEntityType.getOwnAllAttributes())
@@ -106,10 +114,12 @@ public class EntityUtilsTest {
     when(entityType.toString()).thenReturn("entity");
     when(entityType.getId()).thenReturn("id");
     when(entityType.getLabel()).thenReturn("label");
+    when(entityType.getLabel("en")).thenReturn("labelEn");
     when(entityType.isAbstract()).thenReturn(true);
     when(entityType.getBackend()).thenReturn("backend");
     when(entityType.getPackage()).thenReturn(null);
     when(entityType.getDescription()).thenReturn(null);
+    when(entityType.getDescription("en")).thenReturn("descriptionEn");
     when(entityType.getOwnAllAttributes()).thenReturn(emptyList());
     when(entityType.getOwnLookupAttributes()).thenReturn(emptyList());
     when(entityType.getTags()).thenReturn(emptyList());
@@ -120,7 +130,7 @@ public class EntityUtilsTest {
 
   @Test(dataProvider = "testEqualsEntityTypeProvider")
   public void testEqualsEntityType(
-      EntityType entityType, EntityType otherEntityType, boolean equals) throws Exception {
+      EntityType entityType, EntityType otherEntityType, boolean equals) {
     assertEquals(EntityUtils.equals(entityType, otherEntityType), equals);
   }
 
@@ -319,11 +329,29 @@ public class EntityUtilsTest {
       testCases.add(new Object[] {attr, otherAttr, false});
     }
 
+    { // i18n label not equals
+      Attribute attr = getMockAttr("labelA");
+      Attribute otherAttr = getMockAttr("labelB");
+      when(attr.getLabel("en")).thenReturn("A");
+      when(otherAttr.getLabel("en")).thenReturn("B");
+
+      testCases.add(new Object[] {attr, otherAttr, false});
+    }
+
     { // description not equals
       Attribute attr = getMockAttr("descriptionA");
       Attribute otherAttr = getMockAttr("descriptionB");
       when(attr.getDescription()).thenReturn("A");
       when(otherAttr.getDescription()).thenReturn("B");
+
+      testCases.add(new Object[] {attr, otherAttr, false});
+    }
+
+    { // i18n description not equals
+      Attribute attr = getMockAttr("descriptionA");
+      Attribute otherAttr = getMockAttr("descriptionB");
+      when(attr.getDescription("en")).thenReturn("A");
+      when(otherAttr.getDescription("en")).thenReturn("B");
 
       testCases.add(new Object[] {attr, otherAttr, false});
     }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
