### PR TITLE
Fix 7809 Disable vuex strict node in production

### DIFF
--- a/molgenis-app-manager/src/main/frontend/src/store/index.js
+++ b/molgenis-app-manager/src/main/frontend/src/store/index.js
@@ -30,5 +30,6 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   actions,
   mutations,
-  state
+  state,
+  strict: process.env.NODE_ENV !== 'production'
 })

--- a/molgenis-metadata-manager/src/main/frontend/src/store/index.js
+++ b/molgenis-metadata-manager/src/main/frontend/src/store/index.js
@@ -13,5 +13,5 @@ export default new Vuex.Store({
   mutations,
   actions,
   getters,
-  strict: true
+  strict: process.env.NODE_ENV !== 'production'
 })

--- a/molgenis-navigator/src/main/frontend/src/store/index.js
+++ b/molgenis-navigator/src/main/frontend/src/store/index.js
@@ -13,5 +13,5 @@ export default new Vuex.Store({
   mutations,
   actions,
   getters,
-  strict: true
+  strict: process.env.NODE_ENV !== 'production'
 })

--- a/molgenis-one-click-importer/src/main/frontend/src/store/index.js
+++ b/molgenis-one-click-importer/src/main/frontend/src/store/index.js
@@ -10,5 +10,6 @@ Vue.use(Vuex)
 export default new Vuex.Store({
   state,
   mutations,
-  actions
+  actions,
+  strict: process.env.NODE_ENV !== 'production'
 })

--- a/molgenis-questionnaires/src/main/frontend/src/store/index.js
+++ b/molgenis-questionnaires/src/main/frontend/src/store/index.js
@@ -82,5 +82,5 @@ export default new Vuex.Store({
   getters,
   mutations,
   state,
-  strict: true
+  strict: process.env.NODE_ENV !== 'production'
 })

--- a/molgenis-security-ui/src/main/frontend/src/store/index.js
+++ b/molgenis-security-ui/src/main/frontend/src/store/index.js
@@ -23,5 +23,5 @@ export default new Vuex.Store({
   getters,
   mutations,
   state,
-  strict: true
+  strict: process.env.NODE_ENV !== 'production'
 })


### PR DESCRIPTION
Use node env to toggle use of strict mode, as suggested by vuex docs
- strict mode gives more warnings but is slower due to deep-equals ( see vuex docs for details)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
