### PR TITLE
[DOC] Fix instructions for running in docker on windows

### DIFF
--- a/molgenis-app/DOCKER.md
+++ b/molgenis-app/DOCKER.md
@@ -51,5 +51,11 @@ $env:TAG="PR-7492-3"; docker-compose up
 In normal (IntelliJ or Windows `cmd`) prompt:
 
 ```bash
-SET TAG=PR-7492-3 && docker-compose up
+SET TAG=PR-7492-3&& docker-compose up
 ```
+
+> Beware of spaces, if you put a space between the tag and the `&&` you'll get an error!
+```
+SET TAG=PR-7817 && docker-compose up
+ERROR: no such image: registry.molgenis.org/molgenis/molgenis-app:PR-7817 : invalid reference format
+``` 


### PR DESCRIPTION
The docs had a space between the tag name and the && which causes hard to catch errors

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
