### PR TITLE
Fix #6516 Mail settings username/password are required

### DIFF
--- a/molgenis-util/src/main/java/org/molgenis/util/mail/JavaMailSenderFactory.java
+++ b/molgenis-util/src/main/java/org/molgenis/util/mail/JavaMailSenderFactory.java
@@ -27,11 +27,6 @@ public class JavaMailSenderFactory implements MailSenderFactory {
   @Override
   public JavaMailSenderImpl createMailSender(MailSettings mailSettings) {
     LOG.trace("createMailSender");
-    if (mailSettings.getUsername() == null || mailSettings.getPassword() == null) {
-      throw new IllegalStateException(
-          "Cannot create mail sender. Username or password of the mail account not specified in the system mail settings.");
-    }
-
     JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
     mailSender.setHost(mailSettings.getHost());
     mailSender.setPort(mailSettings.getPort());

--- a/molgenis-util/src/test/java/org/molgenis/util/mail/JavaMailSenderFactoryTest.java
+++ b/molgenis-util/src/test/java/org/molgenis/util/mail/JavaMailSenderFactoryTest.java
@@ -41,6 +41,20 @@ public class JavaMailSenderFactoryTest extends AbstractMockitoTest {
     assertEquals(actualProperties.getProperty("mail.smtp.auth"), "true");
   }
 
+  // regression test for https://github.com/molgenis/molgenis/issues/6516
+  @Test
+  public void testCreateMailSenderWithoutUsernamePassword() {
+    JavaMailSenderImpl actual = javaMailSenderFactory.createMailSender(mailSettings);
+
+    assertEquals(actual.getHost(), "host");
+    assertEquals(actual.getPort(), 1234);
+    assertEquals(actual.getDefaultEncoding(), "UTF-8");
+    final Properties actualProperties = actual.getJavaMailProperties();
+    assertEquals(actualProperties.getProperty("mail.smtp.starttls.enable"), "true");
+    assertEquals(actualProperties.getProperty("mail.smtp.quitwait"), "false");
+    assertEquals(actualProperties.getProperty("mail.smtp.auth"), "true");
+  }
+
   @Test
   public void testCreateMailSenderWithSpecifiedProperties() {
     final Properties javaMailProps = new Properties();


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
