### PR TITLE
M6176 As datamanager I would like txt to be imported as tsv file using one-click importer

### DIFF
--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/oneclickimporter/OneClickImporterControllerAPIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/oneclickimporter/OneClickImporterControllerAPIIT.java
@@ -65,6 +65,7 @@ public class OneClickImporterControllerAPIIT {
 
   private static final String ONE_CLICK_IMPORT_EXCEL_FILE = "/OneClickImport_complex-valid.xlsx";
   private static final String ONE_CLICK_IMPORT_CSV_FILE = "/OneClickImport_complex-valid.csv";
+  private static final String ONE_CLICK_IMPORT_TXT_FILE = "/OneClickImport_complex-valid.txt";
 
   private String testUserToken;
   private String adminToken;
@@ -125,6 +126,11 @@ public class OneClickImporterControllerAPIIT {
   @Test
   public void testOneClickImportCsvFile() throws IOException, URISyntaxException {
     oneClickImportTest(ONE_CLICK_IMPORT_CSV_FILE);
+  }
+
+  @Test
+  public void testOneClickImportTxtAsCsvFile() throws IOException, URISyntaxException {
+    oneClickImportTest(ONE_CLICK_IMPORT_TXT_FILE);
   }
 
   private void oneClickImportTest(String fileToImport) throws URISyntaxException, IOException {

--- a/molgenis-api-tests/src/test/resources/OneClickImport_complex-valid.txt
+++ b/molgenis-api-tests/src/test/resources/OneClickImport_complex-valid.txt
@@ -1,0 +1,11 @@
+first name	last name	full name	UMCG employee	Age
+Mark	de Haan	Mark de Haan	TRUE	26
+Fleur	Kelpin	Fleur Kelpin	TRUE	
+Dennis	Hendriksen	Dennis Hendriksen	TRUE	
+Bart	Charbon	Bart Charbon	TRUE	
+Sido	Haakma	Sido Haakma	TRUE	
+Mariska	Slofstra	Mariska Slofstra	TRUE	22
+Tommy	de Boer	Tommy de Boer	TRUE	27
+Connor	Stroomberg	Connor Stroomberg	TRUE	
+Piet	Klaassen	Piet Klaassen	FALSE	53
+Jan			FALSE	32

--- a/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
+++ b/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
@@ -10,7 +10,7 @@
               class="form-control"
               ref="fileInput"
               type="file"
-              accept=".csv, .tsv, .zip, .xls, .xlsx, text/csv, application/zip, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+              accept=".txt, .csv, .tsv, .zip, .xls, .xlsx, text/csv, application/zip, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
               @change="importFile"/>
             <div class="supported-types">
               <span class="text-muted"><em>{{ 'file-types' | i18n }}: XLSX, XLS, CSV, TSV</em></span>

--- a/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
+++ b/molgenis-one-click-importer/src/main/frontend/src/components/OneClickImporter.vue
@@ -10,10 +10,10 @@
               class="form-control"
               ref="fileInput"
               type="file"
-              accept=".csv, .zip, .xls, .xlsx, text/csv, application/zip, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+              accept=".csv, .tsv, .zip, .xls, .xlsx, text/csv, application/zip, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
               @change="importFile"/>
             <div class="supported-types">
-              <span class="text-muted"><em>{{ 'file-types' | i18n }}: XLSX, XLS, CSV</em></span>
+              <span class="text-muted"><em>{{ 'file-types' | i18n }}: XLSX, XLS, CSV, TSV</em></span>
             </div>
           </div>
         </form>

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
@@ -56,7 +56,7 @@ public class OneClickImportJob {
       throws UnknownFileTypeException, IOException, InvalidFormatException, EmptySheetException {
     File file = fileStore.getFile(filename);
     String fileExtension =
-        findExtensionFromPossibilities(filename, newHashSet("csv", "xlsx", "zip", "xls"));
+        findExtensionFromPossibilities(filename, newHashSet("csv", "tsv", "xlsx", "zip", "xls"));
 
     progress.status("Preparing import");
     List<DataCollection> dataCollections = newArrayList();
@@ -68,7 +68,7 @@ public class OneClickImportJob {
     } else if (fileExtension.equals("xls") || fileExtension.equals("xlsx")) {
       List<Sheet> sheets = excelService.buildExcelSheetsFromFile(file);
       dataCollections.addAll(oneClickImporterService.buildDataCollectionsFromExcel(sheets));
-    } else if (fileExtension.equals("csv")) {
+    } else if (fileExtension.equals("csv") || fileExtension.equals("tsv")) {
       List<String[]> lines = csvService.buildLinesFromFile(file);
       dataCollections.add(
           oneClickImporterService.buildDataCollectionFromCsv(

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
@@ -56,7 +56,7 @@ public class OneClickImportJob {
       throws UnknownFileTypeException, IOException, InvalidFormatException, EmptySheetException {
     File file = fileStore.getFile(filename);
     String fileExtension =
-        findExtensionFromPossibilities(filename, newHashSet("csv", "tsv", "xlsx", "zip", "xls"));
+        findExtensionFromPossibilities(filename, newHashSet("csv", "tsv", "xlsx", "zip", "xls", "txt"));
 
     progress.status("Preparing import");
     List<DataCollection> dataCollections = newArrayList();
@@ -68,7 +68,7 @@ public class OneClickImportJob {
     } else if (fileExtension.equals("xls") || fileExtension.equals("xlsx")) {
       List<Sheet> sheets = excelService.buildExcelSheetsFromFile(file);
       dataCollections.addAll(oneClickImporterService.buildDataCollectionsFromExcel(sheets));
-    } else if (fileExtension.equals("csv") || fileExtension.equals("tsv")) {
+    } else if (fileExtension.equals("csv") || fileExtension.equals("tsv") || fileExtension.equals("txt")) {
       List<String[]> lines = csvService.buildLinesFromFile(file);
       dataCollections.add(
           oneClickImporterService.buildDataCollectionFromCsv(

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
@@ -56,7 +56,8 @@ public class OneClickImportJob {
       throws UnknownFileTypeException, IOException, InvalidFormatException, EmptySheetException {
     File file = fileStore.getFile(filename);
     String fileExtension =
-        findExtensionFromPossibilities(filename, newHashSet("csv", "tsv", "xlsx", "zip", "xls", "txt"));
+        findExtensionFromPossibilities(
+            filename, newHashSet("csv", "tsv", "xlsx", "zip", "xls", "txt"));
 
     progress.status("Preparing import");
     List<DataCollection> dataCollections = newArrayList();
@@ -68,7 +69,9 @@ public class OneClickImportJob {
     } else if (fileExtension.equals("xls") || fileExtension.equals("xlsx")) {
       List<Sheet> sheets = excelService.buildExcelSheetsFromFile(file);
       dataCollections.addAll(oneClickImporterService.buildDataCollectionsFromExcel(sheets));
-    } else if (fileExtension.equals("csv") || fileExtension.equals("tsv") || fileExtension.equals("txt")) {
+    } else if (fileExtension.equals("csv")
+        || fileExtension.equals("tsv")
+        || fileExtension.equals("txt")) {
       List<String[]> lines = csvService.buildLinesFromFile(file);
       dataCollections.add(
           oneClickImporterService.buildDataCollectionFromCsv(

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/service/impl/CsvServiceImpl.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/service/impl/CsvServiceImpl.java
@@ -42,12 +42,12 @@ public class CsvServiceImpl implements CsvService {
   private CSVReader createCsvReader(String fileName, InputStream in) {
     Reader reader = new InputStreamReader(in, UTF_8);
 
-    if (fileName.toLowerCase().endsWith('.' + CsvFileExtensions.CSV.toString())
-        || fileName.toLowerCase().endsWith('.' + CsvFileExtensions.TXT.toString())) {
+    if (fileName.toLowerCase().endsWith('.' + CsvFileExtensions.CSV.toString())) {
       return new CSVReader(reader);
     }
 
-    if (fileName.toLowerCase().endsWith('.' + CsvFileExtensions.TSV.toString())) {
+    if (fileName.toLowerCase().endsWith('.' + CsvFileExtensions.TSV.toString())
+        || fileName.toLowerCase().endsWith('.' + CsvFileExtensions.TXT.toString())) {
       return new CSVReader(reader, '\t');
     }
 

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/CsvServiceTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/CsvServiceTest.java
@@ -27,9 +27,9 @@ public class CsvServiceTest {
 
   @Test
   public void buildLinesFromTsvFileTestWithTxtExtention()
-          throws InvalidFormatException, IOException, URISyntaxException, MolgenisDataException {
+      throws InvalidFormatException, IOException, URISyntaxException, MolgenisDataException {
     List<String[]> actual =
-            csvService.buildLinesFromFile(loadFile(CsvServiceTest.class, "/simple-valid.txt"));
+        csvService.buildLinesFromFile(loadFile(CsvServiceTest.class, "/simple-valid.txt"));
     List<String[]> expected = expectedLines();
 
     assertEquals(actual, expected);
@@ -52,14 +52,13 @@ public class CsvServiceTest {
     csvService.buildLinesFromFile(loadFile(CsvServiceTest.class, "/header-without-data.csv"));
   }
 
-  private List<String[]> expectedLines()
-  {
+  private List<String[]> expectedLines() {
     List<String[]> expected = new ArrayList<>();
-    expected.add(new String[] { "name", "superpower" });
-    expected.add(new String[] { "Mark", "arrow functions" });
-    expected.add(new String[] { "Connor", "Oldschool syntax" });
-    expected.add(new String[] { "Fleur", "Lambda Magician" });
-    expected.add(new String[] { "Dennis", "Root access" });
+    expected.add(new String[] {"name", "superpower"});
+    expected.add(new String[] {"Mark", "arrow functions"});
+    expected.add(new String[] {"Connor", "Oldschool syntax"});
+    expected.add(new String[] {"Fleur", "Lambda Magician"});
+    expected.add(new String[] {"Dennis", "Root access"});
     return expected;
   }
 }

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/CsvServiceTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/CsvServiceTest.java
@@ -20,12 +20,17 @@ public class CsvServiceTest {
       throws InvalidFormatException, IOException, URISyntaxException, MolgenisDataException {
     List<String[]> actual =
         csvService.buildLinesFromFile(loadFile(CsvServiceTest.class, "/simple-valid.csv"));
-    List<String[]> expected = new ArrayList<>();
-    expected.add(new String[] {"name", "superpower"});
-    expected.add(new String[] {"Mark", "arrow functions"});
-    expected.add(new String[] {"Connor", "Oldschool syntax"});
-    expected.add(new String[] {"Fleur", "Lambda Magician"});
-    expected.add(new String[] {"Dennis", "Root access"});
+    List<String[]> expected = expectedLines();
+
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void buildLinesFromTsvFileTestWithTxtExtention()
+          throws InvalidFormatException, IOException, URISyntaxException, MolgenisDataException {
+    List<String[]> actual =
+            csvService.buildLinesFromFile(loadFile(CsvServiceTest.class, "/simple-valid.txt"));
+    List<String[]> expected = expectedLines();
 
     assertEquals(actual, expected);
   }
@@ -45,5 +50,16 @@ public class CsvServiceTest {
   public void buildLinesWithHeaderOnly()
       throws InvalidFormatException, IOException, URISyntaxException, MolgenisDataException {
     csvService.buildLinesFromFile(loadFile(CsvServiceTest.class, "/header-without-data.csv"));
+  }
+
+  private List<String[]> expectedLines()
+  {
+    List<String[]> expected = new ArrayList<>();
+    expected.add(new String[] { "name", "superpower" });
+    expected.add(new String[] { "Mark", "arrow functions" });
+    expected.add(new String[] { "Connor", "Oldschool syntax" });
+    expected.add(new String[] { "Fleur", "Lambda Magician" });
+    expected.add(new String[] { "Dennis", "Root access" });
+    return expected;
   }
 }

--- a/molgenis-one-click-importer/src/test/resources/simple-valid.txt
+++ b/molgenis-one-click-importer/src/test/resources/simple-valid.txt
@@ -1,0 +1,5 @@
+name	superpower
+Mark	arrow functions
+Connor	Oldschool syntax
+Fleur	Lambda Magician
+Dennis	Root access


### PR DESCRIPTION
Demo:
- Load one click imported example into exel, save as tsv ( exel stores as .txt) (...molgenis/molgenis-api-tests/src/test/resources/OneClickImport_complex-valid.xlsx)
- Upload example using the one-click-imported

Acceptance criteria:
- The importer now always states there is no suitable importer found when uploading a txt file, it should try to upload these files as tsv
if one-click importer doesn't have TSV capability then don't

related story: [M5316 As datamanager I would like txt to be imported as tsv file using advanced and one-click importer ](http://wiki.gcc.rug.nl/ticket/5316)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
