### PR TITLE
fix (app): Use correct war file name to include in the docker image.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -135,8 +135,8 @@ pipeline {
                             script {
                                 env.TAG = sh(script: "grep project.rel release.properties | cut -d'=' -f2", returnStdout: true)
                             }
-                            dir('molgenis-app'){
-                                sh "mvn -q -B dockerfile:build dockerfile:tag dockerfile:push -Ddockerfile.tag=${TAG} -Ddockerfile.repository=${LOCAL_REPOSITORY}"
+                            dir('molgenis-app') {
+                                sh "mvn -q -B dockerfile:build dockerfile:tag dockerfile:push -Ddockerfile.tag=${TAG} -Ddockerfile.repository=${LOCAL_REPOSITORY} -Ddockerfile.warfile.version=${TAG}-SNAPSHOT"
                             }
                         }
                     }

--- a/molgenis-app/pom.xml
+++ b/molgenis-app/pom.xml
@@ -16,6 +16,8 @@
     <dockerfile-maven-version>1.4.0</dockerfile-maven-version>
     <dockerfile.tag>${project.version}</dockerfile.tag>
     <dockerfile.repository>registry.hub.docker.com/molgenis/molgenis-app</dockerfile.repository>
+    <dockerfile.warfile.version>${project.version}</dockerfile.warfile.version>
+    <dockerfile.warfile>target/${project.artifactId}-${dockerfile.warfile.version}.war</dockerfile.warfile>
   </properties>
 
   <build>
@@ -36,7 +38,7 @@
           <repository>${dockerfile.repository}</repository>
           <tag>${dockerfile.tag}</tag>
           <buildArgs>
-            <WAR_FILE>target/${project.build.finalName}.war</WAR_FILE>
+            <WAR_FILE>${dockerfile.warfile}</WAR_FILE>
           </buildArgs>
           <useMavenSettingsForAuth>true</useMavenSettingsForAuth>
         </configuration>


### PR DESCRIPTION
The release:prepare updates the pom version number after building the image.
When building the docker image you need to point at the war file built using the old snapshot version.

#### Checklist
- Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
