### PR TITLE
Fix #7915 range bug in questionnaire

### DIFF
--- a/molgenis-questionnaires/src/main/frontend/src/store/getters.js
+++ b/molgenis-questionnaires/src/main/frontend/src/store/getters.js
@@ -36,7 +36,7 @@ const isChapterComplete = (chapter: Object, formData: Object): boolean => {
     const valid = child.validate(formData)
 
     if (filledInValue) {
-      const inRange = child.range ? value => child.range.min && value <= child.range.max : true
+      const inRange = child.range ? value >= child.range.min && value <= child.range.max : true
       return valid && inRange
     } else {
       return valid && !required

--- a/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/getters.spec.js
+++ b/molgenis-questionnaires/src/main/frontend/test/unit/specs/store/getters.spec.js
@@ -1,6 +1,6 @@
 import getters from 'src/store/getters'
 
-describe('getters', () => {
+describe.only('getters', () => {
   const state = {
     chapters: [
       {
@@ -21,7 +21,11 @@ describe('getters', () => {
             type: 'number',
             visible: (data) => true,
             required: () => true,
-            validate: () => true
+            validate: () => true,
+            range: {
+              min: 3,
+              max: 6
+            }
           },
           {
             id: 'chapter-1-field-3',
@@ -123,7 +127,7 @@ describe('getters', () => {
     ],
     formData: {
       'chapter-1-field-1': 'value',
-      'chapter-1-field-2': 'value',
+      'chapter-1-field-2': 5,
       'chapter-1-field-3': undefined,
       'chapter-2-field-1': undefined,
       'chapter-3-field-2': undefined,


### PR DESCRIPTION
When I fill in an out of range number in questionnaire, I can proceed and submit

Use equal-or-larger instead of function definition

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
