### PR TITLE
[FIX] Styling of questionnaire

### DIFF
--- a/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
@@ -18,11 +18,6 @@
   .questionnaire-chapter [class^="pl-"] > fieldset > legend {
     padding-top: 1rem;
   }
-
-  .questionnaire-chapter [class^="pl-"] > fieldset .form-group > label,
-  .questionnaire-chapter .pl-4 > fieldset > legend {
-    font-weight: 700;
-  }
 </style>
 
 <script>

--- a/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
@@ -10,7 +10,8 @@
 </template>
 
 <style>
-  .questionnaire-chapter .pl-2 > fieldset > small {
+  .questionnaire-chapter .pl-2 > fieldset > small,
+  .questionnaire-chapter .pl-4 > fieldset > legend {
     font-size: 100%;
   }
 
@@ -18,8 +19,9 @@
     padding-top: 1rem;
   }
 
+  .questionnaire-chapter [class^="pl-"] > fieldset .form-group > label,
   .questionnaire-chapter .pl-4 > fieldset > legend {
-    font-size: 100%;
+    font-weight: 700;
   }
 </style>
 

--- a/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
@@ -10,12 +10,12 @@
 </template>
 
 <style>
-  .questionnaire-chapter .pl-2 > fieldset > small,
-  .questionnaire-chapter .pl-4 > fieldset > legend {
+  .questionnaire-chapter fieldset fieldset fieldset > small,
+  .questionnaire-chapter fieldset fieldset fieldset > legend {
     font-size: 100%;
   }
 
-  .questionnaire-chapter [class^="pl-"] > fieldset > legend {
+  .questionnaire-chapter fieldset fieldset fieldset > legend {
     padding-top: 1rem;
   }
 </style>

--- a/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/components/ChapterForm.vue
@@ -9,6 +9,20 @@
   </form-component>
 </template>
 
+<style>
+  .questionnaire-chapter .pl-2 > fieldset > small {
+    font-size: 100%;
+  }
+
+  .questionnaire-chapter [class^="pl-"] > fieldset > legend {
+    padding-top: 1rem;
+  }
+
+  .questionnaire-chapter .pl-4 > fieldset > legend {
+    font-size: 100%;
+  }
+</style>
+
 <script>
   import { FormComponent } from '@molgenis/molgenis-ui-form'
   import 'flatpickr/dist/flatpickr.css'

--- a/molgenis-questionnaires/src/main/frontend/src/components/QuestionnaireOverviewEntry.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/components/QuestionnaireOverviewEntry.vue
@@ -4,7 +4,8 @@
 
       <template v-if="attribute.fieldType === 'COMPOUND'">
         <div v-if="hasAChildWithData(attribute)">
-          <h4>{{ attribute.label }}</h4>
+          <h4 v-if="level < 5">{{attribute.label }}</h4>
+          <b v-else>{{ attribute.label }}</b>
           <hr>
         </div>
 
@@ -67,7 +68,8 @@
             case 'CATEGORICAL_MREF':
               return value.map(v => v[attribute.refEntity.labelAttribute]).join(', ')
             case 'BOOL':
-              return value ? this.$t('questionnaire_boolean_true') : this.$t('questionnaire_boolean_false')
+              return value ? this.$t('questionnaire_boolean_true') : this.$t(
+                'questionnaire_boolean_false')
             case 'ENUM':
               return value.join(', ')
             case 'XREF':

--- a/molgenis-questionnaires/src/main/frontend/src/pages/QuestionnaireChapter.vue
+++ b/molgenis-questionnaires/src/main/frontend/src/pages/QuestionnaireChapter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="container-fluid">
+  <div class="container-fluid questionnaire-chapter">
     <div class="row my-5">
       <div class="col-12">
 

--- a/molgenis-questionnaires/src/main/frontend/src/services/questionnaireService.js
+++ b/molgenis-questionnaires/src/main/frontend/src/services/questionnaireService.js
@@ -23,7 +23,8 @@ export default {
    * @param translations Objects containing local spesific translations for "True" and "False"
    * @returns OverView
    */
-  buildOverViewObject: function (questionnaireResp: QuestionnaireEntityResponse, translations: Translation): OverView {
+  buildOverViewObject: function (questionnaireResp: QuestionnaireEntityResponse,
+    translations: Translation): OverView {
     const answers = questionnaireResp.items[0]
 
     const buildAnswerLabel = function (attribute: ResponseMetaAttribute): ?string {
@@ -31,7 +32,8 @@ export default {
       if (answers.hasOwnProperty(attribute.name)) {
         const questionId = attribute.name
         const answerType = attribute.fieldType
-        const refLabelAttribute = attribute.refEntity ? attribute.refEntity.labelAttribute : undefined
+        const refLabelAttribute = attribute.refEntity
+          ? attribute.refEntity.labelAttribute : undefined
         const answer = answers[questionId]
         switch (answerType) {
           case 'MREF':
@@ -39,7 +41,8 @@ export default {
             answerLabel = answer.map(a => a[refLabelAttribute]).join(', ')
             break
           case 'BOOL':
-            answerLabel = answer ? translations.trueLabel : translations.falseLabel
+            answerLabel = answer ? translations.trueLabel
+              : translations.falseLabel
             break
           case 'ENUM':
             answerLabel = answer.join(', ')
@@ -60,7 +63,8 @@ export default {
       return answerLabel !== '' ? answerLabel : undefined
     }
 
-    const buildChapterSection = function (sections: Array<OverViewAnswer | OverViewSection>, attribute: ResponseMetaAttribute): OverViewAnswer | OverViewSection {
+    const buildChapterSection = function (sections: Array<OverViewAnswer | OverViewSection>,
+      attribute: ResponseMetaAttribute): OverViewAnswer | OverViewSection {
       if (attribute.fieldType === 'COMPOUND') {
         const subSections = attribute.attributes.reduce(buildChapterSection, [])
         if (subSections.length > 0) {
@@ -83,19 +87,22 @@ export default {
       return sections
     }
 
-    const chapters = questionnaireResp.meta.attributes.reduce((chapters: Array<OverViewChapter>, attribute: ResponseMetaAttribute): OverView => {
-      if (attribute.fieldType === 'COMPOUND') {
-        const chapterSections = attribute.attributes.reduce(buildChapterSection, [])
-        if (chapterSections.length > 0) {
-          chapters.push({
-            id: attribute.name,
-            title: attribute.label,
-            chapterSections: chapterSections
-          })
+    const chapters = questionnaireResp.meta.attributes.reduce(
+      (chapters: Array<OverViewChapter>,
+        attribute: ResponseMetaAttribute): OverView => {
+        if (attribute.fieldType === 'COMPOUND') {
+          const chapterSections = attribute.attributes.reduce(
+            buildChapterSection, [])
+          if (chapterSections.length > 0) {
+            chapters.push({
+              id: attribute.name,
+              title: attribute.label,
+              chapterSections: chapterSections
+            })
+          }
         }
-      }
-      return chapters
-    }, [])
+        return chapters
+      }, [])
 
     return {
       title: questionnaireResp.meta.label,
@@ -103,7 +110,8 @@ export default {
     }
   },
 
-  buildPdfContent: function (questionnaire: OverView, reportHeaderData: ReportHeaderData): Array<PdfSection> {
+  buildPdfContent: function (questionnaire: OverView,
+    reportHeaderData: ReportHeaderData): Array<PdfSection> {
     let content = []
 
     const printQuestionAndAnswer = (question: OverViewAnswer) => {
@@ -167,7 +175,11 @@ export default {
     let docDefinition = {
       pageSize: 'LETTER',
       footer: function (currentPage, pageCount) {
-        return {text: currentPage.toString() + ' / ' + pageCount, alignment: 'right', style: 'pageNumber'}
+        return {
+          text: currentPage.toString() + ' / ' + pageCount,
+          alignment: 'right',
+          style: 'pageNumber'
+        }
       },
       info: {
         title: 'questionnaire-overview'
@@ -196,11 +208,13 @@ export default {
           margin: [0, 20, 0, 10]
         },
         sectionTitle: {
-          fontSize: 14,
+          fontSize: 10,
+          bold: true,
           margin: [0, 10, 0, 5]
         },
         questionLabel: {
           fontSize: 10,
+          bold: true,
           margin: [0, 5]
         },
         answerLabel: {


### PR DESCRIPTION
* Make description of questions bigger, to fix this:
<img width="532" alt="screen shot 2018-10-25 at 14 34 54" src="https://user-images.githubusercontent.com/10075439/47855991-56022d80-dde6-11e8-9c7c-6dd242a019f9.png">

* Make second level compounds smaller to fix this:

![screen shot 2018-11-01 at 15 00 18](https://user-images.githubusercontent.com/10075439/47856232-fb1d0600-dde6-11e8-99f7-ece54663b7ff.png)
* Also fix view in pdf
* Make questions bold

#### Checklist
- [ ] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
