### PR TITLE
Fix GitBook rendering of double curly braces in 'template expression'

### DIFF
--- a/docs/user_documentation/import-data/ref-emx.md
+++ b/docs/user_documentation/import-data/ref-emx.md
@@ -236,9 +236,8 @@ is used to create computed attributes.
 
 In addition to basic 'computed strings' and 'computed' objects a template can be used as expression. The template expression format is:
 {"template":"..."} with the value a [Mustache](http://mustache.github.io/) template. Tags must refer to attribute identifiers 
-(e.g. {{myStringAttribute}}). For attributes referencing another entity type the attribute in the referencing entity type needs to be 
-specified as well (e.g. {{myXrefAttribute.id}}).
-  
+(e.g. {% raw %}{{myStringAttribute}}{% endraw %}). For attributes referencing another entity type the attribute in the referencing entity type needs to be 
+specified as well (e.g. {% raw %}{{myXrefAttribute.id}}{% endraw %}).
 
 *Example:*
 
@@ -247,13 +246,13 @@ specified as well (e.g. {{myXrefAttribute.id}}).
 | id	           | MyEntityType |	string	 |			       |                                                          |
 | xref0	         | MyEntityType |	xref	   | MyReference |                                                          |	
 | xref1	         | MyEntityType |	xref	   | MyReference |                                                          |
-| computedXref	 | MyEntityType |	string	 |             | {"template":"lorum {{xref0.id}} ipsum {{xref1.label}}"}  |
+| computedXref	 | MyEntityType |	string	 |             | {% raw %}{"template":"lorum {{xref0.id}} ipsum {{xref1.label}}"}{% endraw %} |
 | mref0	         | MyEntityType |	mref	   | MyReference |                                                          |
 | mref1	         | MyEntityType |	mref	   | MyReference |                                                          |
-| computedMref	 | MyEntityType |	string   |						 | {"template":"my {{mref0.id}} text {{mref1.label}}"}      |
+| computedMref	 | MyEntityType |	string   |						 | {% raw %}{"template":"my {{mref0.id}} text {{mref1.label}}"}{% endraw %}     |
 | string0	       | MyEntityType |	string	 |						 |                                                          |
 | string1	       | MyEntityType |	string	 |						 |                                                          |
-| computedString | MyEntityType |	string	 |						 | {"template":"{{string0}} and {{string1}}"}               |
+| computedString | MyEntityType |	string	 |						 | {% raw %}{"template":"{{string0}} and {{string1}}"}{% endraw %}              |
 | id	           | MyReference  |	string	 |						 |                                                          |
 | label	         | MyReference  |	string	 |						 |                                                          |
 


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications (confirm after merge)
- [x] Code reviewed
- [NA] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
