### PR TITLE
[Fix] Make request body optional when updating entity.attribute via rest api

### DIFF
--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerV1APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerV1APIIT.java
@@ -614,7 +614,7 @@ public class RestControllerV1APIIT {
         .log()
         .all()
         .statusCode(OKE)
-        .body("label", nullValue());
+        .body("xstringnillable", nullValue());
   }
 
   @Test

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerV1APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerV1APIIT.java
@@ -5,6 +5,7 @@ import static com.google.common.collect.Maps.newHashMap;
 import static com.google.common.io.Resources.getResource;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.nullValue;
 import static org.molgenis.api.tests.utils.RestTestUtils.APPLICATION_JSON;
 import static org.molgenis.api.tests.utils.RestTestUtils.CREATED;
 import static org.molgenis.api.tests.utils.RestTestUtils.NO_CONTENT;
@@ -589,6 +590,31 @@ public class RestControllerV1APIIT {
         .log()
         .all()
         .statusCode(OKE);
+  }
+
+  @Test
+  public void testUpdateAttributePutWithEmptyValue() {
+    given()
+        .log()
+        .all()
+        .contentType(APPLICATION_JSON)
+        .header(X_MOLGENIS_TOKEN, testUserToken)
+        .put(API_V1 + "V1_API_TypeTestAPIV1/1/xstringnillable")
+        .then()
+        .log()
+        .all()
+        .statusCode(OKE);
+
+    given()
+        .log()
+        .all()
+        .header(X_MOLGENIS_TOKEN, testUserToken)
+        .get(API_V1 + "V1_API_TypeTestAPIV1/1/xstringnillable")
+        .then()
+        .log()
+        .all()
+        .statusCode(OKE)
+        .body("label", nullValue());
   }
 
   @Test

--- a/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
+++ b/molgenis-data-rest/src/main/java/org/molgenis/data/rest/RestController.java
@@ -596,7 +596,7 @@ public class RestController {
       @PathVariable("entityTypeId") String entityTypeId,
       @PathVariable("attributeName") String attributeName,
       @PathVariable("id") String untypedId,
-      @RequestBody Object paramValue) {
+      @RequestBody(required = false) Object paramValue) {
     updateAttribute(entityTypeId, attributeName, untypedId, paramValue);
   }
 
@@ -608,7 +608,7 @@ public class RestController {
       @PathVariable("entityTypeId") String entityTypeId,
       @PathVariable("attributeName") String attributeName,
       @PathVariable("id") String untypedId,
-      @RequestBody Object paramValue) {
+      @RequestBody(required = false) Object paramValue) {
     EntityType entityType = dataService.getEntityType(entityTypeId);
     if (entityType == null) {
       throw new UnknownEntityTypeException(entityTypeId);

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
@@ -773,8 +773,10 @@ public class RestControllerTest extends AbstractTestNGSpringContextTests {
                 .content("\"Klaas\"")
                 .contentType(APPLICATION_JSON))
         .andExpect(status().isOk());
-    verify(dataService).update(ArgumentMatchers.eq(ENTITY_NAME),
-        ArgumentMatchers.<Entity>argThat(x -> "Klaas".equals(x.getString("name"))));
+    verify(dataService)
+        .update(
+            ArgumentMatchers.eq(ENTITY_NAME),
+            ArgumentMatchers.<Entity>argThat(x -> "Klaas".equals(x.getString("name"))));
   }
 
   @Test
@@ -786,8 +788,10 @@ public class RestControllerTest extends AbstractTestNGSpringContextTests {
                 .content("null")
                 .contentType(APPLICATION_JSON))
         .andExpect(status().isOk());
-    verify(dataService).update(ArgumentMatchers.eq(ENTITY_NAME),
-        ArgumentMatchers.<Entity>argThat(x -> x.getString("name") == null));
+    verify(dataService)
+        .update(
+            ArgumentMatchers.eq(ENTITY_NAME),
+            ArgumentMatchers.<Entity>argThat(x -> x.getString("name") == null));
   }
 
   @Test

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
@@ -777,6 +777,15 @@ public class RestControllerTest extends AbstractTestNGSpringContextTests {
   }
 
   @Test
+  public void updateAttributeWithEmptyValue() throws Exception {
+    mockMvc
+        .perform(
+            post(HREF_ENTITY_ID + "/name").param("_method", "PUT").contentType(APPLICATION_JSON))
+        .andExpect(status().isOk());
+    verify(dataService).update(ArgumentMatchers.eq(ENTITY_NAME), any(Entity.class));
+  }
+
+  @Test
   public void updateAttribute_unknownEntity() throws Exception {
     mockMvc
         .perform(

--- a/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
+++ b/molgenis-data-rest/src/test/java/org/molgenis/data/rest/RestControllerTest.java
@@ -770,10 +770,24 @@ public class RestControllerTest extends AbstractTestNGSpringContextTests {
         .perform(
             post(HREF_ENTITY_ID + "/name")
                 .param("_method", "PUT")
-                .content("Klaas")
+                .content("\"Klaas\"")
                 .contentType(APPLICATION_JSON))
         .andExpect(status().isOk());
-    verify(dataService).update(ArgumentMatchers.eq(ENTITY_NAME), any(Entity.class));
+    verify(dataService).update(ArgumentMatchers.eq(ENTITY_NAME),
+        ArgumentMatchers.<Entity>argThat(x -> "Klaas".equals(x.getString("name"))));
+  }
+
+  @Test
+  public void updateAttributeNull() throws Exception {
+    mockMvc
+        .perform(
+            post(HREF_ENTITY_ID + "/name")
+                .param("_method", "PUT")
+                .content("null")
+                .contentType(APPLICATION_JSON))
+        .andExpect(status().isOk());
+    verify(dataService).update(ArgumentMatchers.eq(ENTITY_NAME),
+        ArgumentMatchers.<Entity>argThat(x -> x.getString("name") == null));
   }
 
   @Test


### PR DESCRIPTION
This allows clearing the attribute value

Fix #7942 

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
