### PR TITLE
chore: Let parent pom manage micrometer version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,6 @@
     <fmt-maven-plugin.version>2.5.1</fmt-maven-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <checkstyle.version>8.12</checkstyle.version>
-    <micrometer.version>1.0.6</micrometer.version>
     <sonar-maven-plugin.version>3.5.0.1254</sonar-maven-plugin.version>
   </properties>
 
@@ -994,16 +993,6 @@
         <groupId>org.zeroturnaround</groupId>
         <artifactId>zt-zip</artifactId>
         <version>${zt-zip.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-core</artifactId>
-        <version>${micrometer.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>io.micrometer</groupId>
-        <artifactId>micrometer-spring-legacy</artifactId>
-        <version>${micrometer.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.jknack</groupId>


### PR DESCRIPTION
Micrometer dependency management is included in spring-boot which is a parent pom of ours.
Let them manage the version of micrometer.
N.B. This effectively upgrades micrometer from 1.0.6 to [1.0.7](https://github.com/micrometer-metrics/micrometer/releases/tag/v1.0.7)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
