### PR TITLE
Fix #7985 EntityType.newInstance doesn't copy indexing depth

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/EntityType.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/EntityType.java
@@ -139,6 +139,7 @@ public class EntityType extends StaticEntity implements Labeled {
     entityTypeCopy.setExtends(entityType.getExtends()); // do not deep-copy
     entityTypeCopy.setTags(newArrayList(entityType.getTags())); // do not deep-copy
     entityTypeCopy.setBackend(entityType.getBackend());
+    entityTypeCopy.setIndexingDepth(entityType.getIndexingDepth());
 
     return entityTypeCopy;
   }

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/EntityTypeTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/EntityTypeTest.java
@@ -146,6 +146,7 @@ public class EntityTypeTest {
     when(entityType.getExtends()).thenReturn(extendsEntityType);
     when(entityType.getTags()).thenReturn(asList(tag0, tag1));
     when(entityType.getBackend()).thenReturn("backend");
+    when(entityType.getIndexingDepth()).thenReturn(3);
 
     EntityType entityTypeCopy = EntityType.newInstance(entityType);
     assertSame(entityTypeCopy.getEntityType(), entityTypeMeta);
@@ -177,6 +178,7 @@ public class EntityTypeTest {
     assertSame(tagsCopy.get(0), tag0);
     assertSame(tagsCopy.get(1), tag1);
     assertEquals(entityTypeCopy.getBackend(), "backend");
+    assertEquals(entityTypeCopy.getIndexingDepth(), 3);
   }
 
   @Test(


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [n.a.] User documentation updated
- [n.a.] (If you have changed REST API interface) view-swagger.ftl updated
- [n.a.] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
