### PR TITLE
chore(Jenkinsfile): Run sonar analysis on release branches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,6 +118,7 @@ pipeline {
                         container('maven') {
                             sh "mvn -q -B clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -T4"
                             sh "curl -s https://codecov.io/bash | bash -s - -c -F unit -K  -C ${GIT_COMMIT}"
+                            sh "mvn -q -B sonar:sonar -Dsonar.login=${SONAR_TOKEN} -Dsonar.branch.name=${BRANCH_NAME} -Dsonar.ws.timeout=120"
                             dir('molgenis-app'){
                                 sh "mvn -q -B dockerfile:build dockerfile:tag dockerfile:push -Ddockerfile.tag=${BRANCH_NAME}-latest"
                                 sh "mvn -q -B dockerfile:tag dockerfile:push -Ddockerfile.tag=latest"


### PR DESCRIPTION
Merge AFTER @tommydeboer or @sidohaakma configures long-lived branch regex on sonarcloud.
See https://sonarcloud.io/documentation/branches/long-lived-branches/

#### Checklist
- Functionality works & meets specifications
- Code reviewed
- Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
