### PR TITLE
Fix EntityTypeMapper: Empty values should be null rather than empty String

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/export/mapper/EntityTypeMapper.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/export/mapper/EntityTypeMapper.java
@@ -50,7 +50,7 @@ public class EntityTypeMapper {
           row.add(getTags(entityType));
           break;
         case EMX_ENTITIES_EXTENDS:
-          row.add(entityType.getExtends() != null ? entityType.getExtends().getId() : "");
+          row.add(entityType.getExtends() != null ? entityType.getExtends().getId() : null);
           break;
         case EMX_ENTITIES_PACKAGE:
           row.add(getPackageId(entityType));
@@ -60,7 +60,7 @@ public class EntityTypeMapper {
           break;
         default:
           Object value = entityType.get(entry.getValue());
-          row.add(value != null ? value.toString() : "");
+          row.add(value != null ? value.toString() : null);
           break;
       }
     }

--- a/molgenis-data-import/src/test/java/org/molgenis/data/export/EntityTypeMapperTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/export/EntityTypeMapperTest.java
@@ -56,6 +56,39 @@ public class EntityTypeMapperTest extends AbstractMockitoTest {
   }
 
   @Test
+  public void testMapEntityTypeNotExtending() {
+    EntityType entityType = mock(EntityType.class);
+    Tag tag1 = mock(Tag.class);
+    Tag tag2 = mock(Tag.class);
+    when(tag1.getId()).thenReturn("tag1");
+    when(tag2.getId()).thenReturn("tag2");
+    Package pack = mock(Package.class);
+    when(pack.getId()).thenReturn("packageId");
+
+    when(entityType.getTags()).thenReturn(newArrayList(tag1, tag2));
+    doReturn("Elastic").when(entityType).get(EntityTypeMetadata.BACKEND);
+    doReturn("Human Readable").when(entityType).get(EntityTypeMetadata.LABEL);
+    doReturn("Description").when(entityType).get(EntityTypeMetadata.DESCRIPTION);
+    doReturn(false).when(entityType).get(EntityTypeMetadata.IS_ABSTRACT);
+    when(entityType.getExtends()).thenReturn(null);
+    when(entityType.getPackage()).thenReturn(pack);
+    when(entityType.getId()).thenReturn("packageId_ID");
+
+    List<Object> expected =
+        newArrayList(
+            "ID",
+            "packageId",
+            "Human Readable",
+            "Description",
+            "false",
+            null,
+            "Elastic",
+            "tag1,tag2");
+    List<Object> actual = EntityTypeMapper.map(entityType);
+    assertEquals(actual, expected);
+  }
+
+  @Test
   public void testGet() {
     EntityType entityType = mock(EntityType.class);
     Attribute attr1 = mock(Attribute.class);

--- a/molgenis-data-import/src/test/java/org/molgenis/data/export/EntityTypeMapperTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/export/EntityTypeMapperTest.java
@@ -68,7 +68,7 @@ public class EntityTypeMapperTest extends AbstractMockitoTest {
     when(entityType.getTags()).thenReturn(newArrayList(tag1, tag2));
     doReturn("Elastic").when(entityType).get(EntityTypeMetadata.BACKEND);
     doReturn("Human Readable").when(entityType).get(EntityTypeMetadata.LABEL);
-    doReturn("Description").when(entityType).get(EntityTypeMetadata.DESCRIPTION);
+    doReturn(null).when(entityType).get(EntityTypeMetadata.DESCRIPTION);
     doReturn(false).when(entityType).get(EntityTypeMetadata.IS_ABSTRACT);
     when(entityType.getExtends()).thenReturn(null);
     when(entityType.getPackage()).thenReturn(pack);
@@ -76,14 +76,7 @@ public class EntityTypeMapperTest extends AbstractMockitoTest {
 
     List<Object> expected =
         newArrayList(
-            "ID",
-            "packageId",
-            "Human Readable",
-            "Description",
-            "false",
-            null,
-            "Elastic",
-            "tag1,tag2");
+            "ID", "packageId", "Human Readable", null, "false", null, "Elastic", "tag1,tag2");
     List<Object> actual = EntityTypeMapper.map(entityType);
     assertEquals(actual, expected);
   }

--- a/molgenis-data-import/src/test/java/org/molgenis/data/export/EntityTypeMapperTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/export/EntityTypeMapperTest.java
@@ -76,14 +76,7 @@ public class EntityTypeMapperTest extends AbstractMockitoTest {
 
     List<Object> expected =
         newArrayList(
-            "ID",
-            "packageId",
-            "Human Readable",
-            null,
-            "false",
-            null,
-            "Elastic",
-            "tag1,tag2");
+            "ID", "packageId", "Human Readable", null, "false", null, "Elastic", "tag1,tag2");
     List<Object> actual = EntityTypeMapper.map(entityType);
     assertEquals(actual, expected);
   }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [n.a.] User documentation updated
- [n.a.] (If you have changed REST API interface) view-swagger.ftl updated
- [n.a.] Test plan template updated
- [x] Clean commits
- [n.a.] Added Feature/Fix to release notes
