### PR TITLE
Navigator controls: add entity type deduplication when copying

### DIFF
--- a/molgenis-navigator/src/test/java/org/molgenis/navigator/copy/service/EntityTypeCopierTest.java
+++ b/molgenis-navigator/src/test/java/org/molgenis/navigator/copy/service/EntityTypeCopierTest.java
@@ -183,6 +183,30 @@ public class EntityTypeCopierTest extends AbstractMockitoTest {
     verify(refAttrCopy).setDefaultValue("row1,row2,row3");
   }
 
+  @Test
+  public void copyDoubleEntityType() {
+    setupPredictableIdGeneratorMock(idGenerator);
+    EntityType entityTypeA = mock(EntityType.class);
+    when(entityTypeA.getId()).thenReturn("A");
+    EntityType entityTypeACopy = mock(EntityType.class);
+    Package targetPackage = mock(Package.class);
+    Progress progress = mock(Progress.class);
+    CopyState state = CopyState.create(targetPackage, progress);
+    setupMetadataCopierAnswers(ImmutableMap.of(entityTypeA, entityTypeACopy));
+    when(entityTypeDependencyResolver.resolve(singletonList(entityTypeACopy)))
+        .thenReturn(singletonList(entityTypeACopy));
+    state.entityTypesInPackages().add(entityTypeA);
+
+    copier.copy(singletonList(entityTypeA), state);
+
+    verify(entityTypeACopy).setId("id1");
+    assertEquals(state.copiedEntityTypes(), ImmutableMap.of("A", entityTypeACopy));
+    assertEquals(state.originalEntityTypeIds(), ImmutableMap.of("id1", "A"));
+    assertEquals(state.referenceDefaultValues(), emptyMap());
+    verify(dataService.getMeta()).addEntityType(entityTypeACopy);
+    verify(progress, times(1)).increment(1);
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void copyData() {


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
