### PR TITLE
 Fix #7886 JobExecution entity delete allowed for running job

### DIFF
--- a/molgenis-data-platform/src/test/java/org/molgenis/data/platform/decorators/SystemRepositoryDecoratorRegistryImplTest.java
+++ b/molgenis-data-platform/src/test/java/org/molgenis/data/platform/decorators/SystemRepositoryDecoratorRegistryImplTest.java
@@ -1,0 +1,76 @@
+package org.molgenis.data.platform.decorators;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import org.molgenis.data.Entity;
+import org.molgenis.data.Repository;
+import org.molgenis.data.SystemRepositoryDecoratorFactory;
+import org.molgenis.data.meta.SystemEntityType;
+import org.molgenis.test.AbstractMockitoTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class SystemRepositoryDecoratorRegistryImplTest extends AbstractMockitoTest {
+
+  private SystemRepositoryDecoratorRegistryImpl systemRepositoryDecoratorRegistryImpl;
+
+  @BeforeMethod
+  public void setUpBeforeMethod() {
+    systemRepositoryDecoratorRegistryImpl = new SystemRepositoryDecoratorRegistryImpl();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testDecorate() {
+    String grandparentEntityTypeId = "grandparentEntityTypeId";
+    SystemEntityType grandparentEntityType = mock(SystemEntityType.class);
+    when(grandparentEntityType.getId()).thenReturn(grandparentEntityTypeId);
+
+    String parentEntityTypeId = "parentEntityTypeId";
+    SystemEntityType parentEntityType = mock(SystemEntityType.class);
+    when(parentEntityType.getId()).thenReturn(parentEntityTypeId);
+    when(parentEntityType.getExtends()).thenReturn(grandparentEntityType);
+
+    String entityTypeId = "entityTypeId";
+    SystemEntityType entityType = mock(SystemEntityType.class);
+    when(entityType.getId()).thenReturn(entityTypeId);
+    when(entityType.getExtends()).thenReturn(parentEntityType);
+
+    Repository<Entity> repository = mock(Repository.class);
+    when(repository.getEntityType()).thenReturn(entityType);
+
+    SystemRepositoryDecoratorFactory entityTypeFactory =
+        mock(SystemRepositoryDecoratorFactory.class);
+    when(entityTypeFactory.getEntityType()).thenReturn(entityType);
+    systemRepositoryDecoratorRegistryImpl.addFactory(entityTypeFactory);
+
+    SystemRepositoryDecoratorFactory grandparentEntityTypeFactory =
+        mock(SystemRepositoryDecoratorFactory.class);
+    when(grandparentEntityTypeFactory.getEntityType()).thenReturn(grandparentEntityType);
+    systemRepositoryDecoratorRegistryImpl.addFactory(grandparentEntityTypeFactory);
+
+    Repository<Entity> decoratedRepository = mock(Repository.class);
+    when(grandparentEntityTypeFactory.createDecoratedRepository(repository))
+        .thenReturn(decoratedRepository);
+
+    Repository decoratedDecoratedRepository = mock(Repository.class);
+    when(entityTypeFactory.createDecoratedRepository(decoratedRepository))
+        .thenReturn(decoratedDecoratedRepository);
+    assertEquals(
+        systemRepositoryDecoratorRegistryImpl.decorate(repository), decoratedDecoratedRepository);
+  }
+
+  @Test
+  public void testDecorateNoFactory() {
+    String entityTypeId = "entityTypeId";
+    SystemEntityType entityType = mock(SystemEntityType.class);
+    when(entityType.getId()).thenReturn(entityTypeId);
+
+    @SuppressWarnings("unchecked")
+    Repository<Entity> repository = mock(Repository.class);
+    when(repository.getEntityType()).thenReturn(entityType);
+    assertEquals(systemRepositoryDecoratorRegistryImpl.decorate(repository), repository);
+  }
+}

--- a/molgenis-jobs/pom.xml
+++ b/molgenis-jobs/pom.xml
@@ -34,6 +34,11 @@
     </dependency>
     <dependency>
       <groupId>org.molgenis</groupId>
+      <artifactId>molgenis-i18n</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.molgenis</groupId>
       <artifactId>molgenis-security</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -68,6 +73,13 @@
     <dependency>
       <groupId>org.molgenis</groupId>
       <artifactId>molgenis-data</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.molgenis</groupId>
+      <artifactId>molgenis-i18n</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>
       <scope>test</scope>

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/ActiveJobExecutionDeleteForbiddenException.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/ActiveJobExecutionDeleteForbiddenException.java
@@ -1,0 +1,32 @@
+package org.molgenis.jobs;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+
+import org.molgenis.i18n.CodedRuntimeException;
+import org.molgenis.jobs.model.JobExecution;
+import org.molgenis.jobs.model.JobExecution.Status;
+
+public class ActiveJobExecutionDeleteForbiddenException extends CodedRuntimeException {
+  private static final String ERROR_CODE = "JOB01";
+
+  private final String jobExecutionId;
+  private final Status jobExecutionStatus;
+
+  public ActiveJobExecutionDeleteForbiddenException(JobExecution jobExecution) {
+    super(ERROR_CODE);
+    requireNonNull(jobExecution);
+    this.jobExecutionId = jobExecution.getIdentifier();
+    this.jobExecutionStatus = jobExecution.getStatus();
+  }
+
+  @Override
+  public String getMessage() {
+    return format("id:%s status:%s", jobExecutionId, jobExecutionStatus);
+  }
+
+  @Override
+  protected Object[] getLocalizedMessageArguments() {
+    return new Object[0];
+  }
+}

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/JobsL10nConfig.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/JobsL10nConfig.java
@@ -1,0 +1,15 @@
+package org.molgenis.jobs;
+
+import org.molgenis.i18n.PropertiesMessageSource;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JobsL10nConfig {
+  public static final String NAMESPACE = "jobs";
+
+  @Bean
+  public PropertiesMessageSource dataMessageSource() {
+    return new PropertiesMessageSource(NAMESPACE);
+  }
+}

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/model/JobExecutionRepositoryDecorator.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/model/JobExecutionRepositoryDecorator.java
@@ -1,0 +1,82 @@
+package org.molgenis.jobs.model;
+
+import java.util.stream.Stream;
+import org.molgenis.data.AbstractRepositoryDecorator;
+import org.molgenis.data.Repository;
+import org.molgenis.data.UnknownEntityException;
+import org.molgenis.jobs.ActiveJobExecutionDeleteForbiddenException;
+import org.molgenis.jobs.model.JobExecution.Status;
+import org.molgenis.util.UnexpectedEnumException;
+
+class JobExecutionRepositoryDecorator extends AbstractRepositoryDecorator<JobExecution> {
+  private static final int BATCH_SIZE = 1000;
+
+  JobExecutionRepositoryDecorator(Repository<JobExecution> delegateRepository) {
+    super(delegateRepository);
+  }
+
+  @Override
+  public void delete(JobExecution jobExecution) {
+    validateDeleteAllowed(jobExecution);
+    super.delete(jobExecution);
+  }
+
+  @Override
+  public void deleteById(Object id) {
+    validateDeleteAllowedById(id);
+    super.deleteById(id);
+  }
+
+  @Override
+  public void deleteAll() {
+    forEachBatched(
+        jobExecutionBatch -> jobExecutionBatch.forEach(this::validateDeleteAllowed), BATCH_SIZE);
+    super.deleteAll();
+  }
+
+  @Override
+  public void delete(Stream<JobExecution> jobExecutionStream) {
+    super.delete(jobExecutionStream.filter(this::validateDeleteAllowed));
+  }
+
+  @Override
+  public void deleteAll(Stream<Object> ids) {
+    super.deleteAll(ids.filter(this::validateDeleteAllowedById));
+  }
+
+  private boolean validateDeleteAllowedById(Object jobExecutionId) {
+    JobExecution jobExecution = findOneById(jobExecutionId);
+    if (jobExecution == null) {
+      throw new UnknownEntityException(getEntityType(), jobExecutionId);
+    }
+    return validateDeleteAllowed(jobExecution);
+  }
+
+  private boolean validateDeleteAllowed(JobExecution jobExecution) {
+    if (isActiveJobExecution(jobExecution)) {
+      throw new ActiveJobExecutionDeleteForbiddenException(jobExecution);
+    }
+    return true;
+  }
+
+  private boolean isActiveJobExecution(JobExecution jobExecution) {
+    boolean isActive;
+
+    Status status = jobExecution.getStatus();
+    switch (status) {
+      case PENDING:
+      case RUNNING:
+        isActive = true;
+        break;
+      case SUCCESS:
+      case FAILED:
+      case CANCELED:
+        isActive = false;
+        break;
+      default:
+        throw new UnexpectedEnumException(status);
+    }
+
+    return isActive;
+  }
+}

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/model/JobExecutionRepositoryDecoratorFactory.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/model/JobExecutionRepositoryDecoratorFactory.java
@@ -1,0 +1,19 @@
+package org.molgenis.jobs.model;
+
+import org.molgenis.data.AbstractSystemRepositoryDecoratorFactory;
+import org.molgenis.data.Repository;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JobExecutionRepositoryDecoratorFactory
+    extends AbstractSystemRepositoryDecoratorFactory<JobExecution, JobExecutionMetaData> {
+
+  public JobExecutionRepositoryDecoratorFactory(JobExecutionMetaData jobExecutionMetaData) {
+    super(jobExecutionMetaData);
+  }
+
+  @Override
+  public Repository<JobExecution> createDecoratedRepository(Repository<JobExecution> repository) {
+    return new JobExecutionRepositoryDecorator(repository);
+  }
+}

--- a/molgenis-jobs/src/main/resources/l10n/jobs_en.properties
+++ b/molgenis-jobs/src/main/resources/l10n/jobs_en.properties
@@ -1,0 +1,1 @@
+JOB01=Deleting an active job is not allowed.

--- a/molgenis-jobs/src/main/resources/l10n/jobs_nl.properties
+++ b/molgenis-jobs/src/main/resources/l10n/jobs_nl.properties
@@ -1,0 +1,1 @@
+JOB01=Verwijderen van een actieve job is niet toegestaan.

--- a/molgenis-jobs/src/test/java/org/molgenis/jobs/ActiveJobExecutionDeleteForbiddenExceptionTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/jobs/ActiveJobExecutionDeleteForbiddenExceptionTest.java
@@ -1,0 +1,35 @@
+package org.molgenis.jobs;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.*;
+
+import org.molgenis.i18n.test.exception.ExceptionMessageTest;
+import org.molgenis.jobs.model.JobExecution;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class ActiveJobExecutionDeleteForbiddenExceptionTest extends ExceptionMessageTest {
+
+  @BeforeMethod
+  public void setUp() {
+    messageSource.addMolgenisNamespaces("jobs");
+  }
+
+  @Test(dataProvider = "languageMessageProvider")
+  @Override
+  public void testGetLocalizedMessage(String lang, String message) {
+    JobExecution jobExecution = mock(JobExecution.class);
+    assertExceptionMessageEquals(
+        new ActiveJobExecutionDeleteForbiddenException(jobExecution), lang, message);
+  }
+
+  @DataProvider(name = "languageMessageProvider")
+  @Override
+  public Object[][] languageMessageProvider() {
+    return new Object[][] {
+      new Object[] {"en", "Deleting an active job is not allowed."},
+      {"nl", "Verwijderen van een actieve job is niet toegestaan."}
+    };
+  }
+}

--- a/molgenis-jobs/src/test/java/org/molgenis/jobs/model/JobExecutionRepositoryDecoratorTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/jobs/model/JobExecutionRepositoryDecoratorTest.java
@@ -1,0 +1,179 @@
+package org.molgenis.jobs.model;
+
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.molgenis.data.Entity;
+import org.molgenis.data.Repository;
+import org.molgenis.data.UnknownEntityException;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.jobs.ActiveJobExecutionDeleteForbiddenException;
+import org.molgenis.jobs.model.JobExecution.Status;
+import org.molgenis.test.AbstractMockitoTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class JobExecutionRepositoryDecoratorTest extends AbstractMockitoTest {
+  @Mock private Repository<JobExecution> delegateRepository;
+
+  private JobExecutionRepositoryDecorator jobExecutionRepositoryDecorator;
+
+  @BeforeMethod
+  public void setUpBeforeMethod() {
+    jobExecutionRepositoryDecorator = new JobExecutionRepositoryDecorator(delegateRepository);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void testJobExecutionRepositoryDecorator() {
+    new JobExecutionRepositoryDecorator(null);
+  }
+
+  @Test
+  public void testDeleteAllowed() {
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.CANCELED).getMock();
+    jobExecutionRepositoryDecorator.delete(jobExecution);
+    verify(delegateRepository).delete(jobExecution);
+  }
+
+  @Test(expectedExceptions = ActiveJobExecutionDeleteForbiddenException.class)
+  public void testDeleteForbidden() {
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.PENDING).getMock();
+    jobExecutionRepositoryDecorator.delete(jobExecution);
+  }
+
+  @Test
+  public void testDeleteByIdAllowed() {
+    Object jobExecutionId = "myJobExecutionId";
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.FAILED).getMock();
+    when(delegateRepository.findOneById(jobExecutionId)).thenReturn(jobExecution);
+
+    jobExecutionRepositoryDecorator.deleteById(jobExecutionId);
+    verify(delegateRepository).deleteById(jobExecutionId);
+  }
+
+  @Test(expectedExceptions = ActiveJobExecutionDeleteForbiddenException.class)
+  public void testDeleteByIdForbidden() {
+    Object jobExecutionId = "myJobExecutionId";
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.RUNNING).getMock();
+    when(delegateRepository.findOneById(jobExecutionId)).thenReturn(jobExecution);
+
+    jobExecutionRepositoryDecorator.deleteById(jobExecutionId);
+    verify(delegateRepository).deleteById(jobExecutionId);
+  }
+
+  @Test(expectedExceptions = UnknownEntityException.class)
+  public void testDeleteByIdUnknownJobExecution() {
+    EntityType entityType = mock(EntityType.class);
+    when(delegateRepository.getEntityType()).thenReturn(entityType);
+    Object jobExecutionId = "unknownJobExecutionId";
+    jobExecutionRepositoryDecorator.deleteById(jobExecutionId);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testDeleteAllAllowed() {
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.SUCCESS).getMock();
+    doAnswer(
+            invocation -> {
+              ((Consumer<List<Entity>>) invocation.getArgument(1))
+                  .accept(singletonList(jobExecution));
+              return null;
+            })
+        .when(delegateRepository)
+        .forEachBatched(any(), any(), eq(1000));
+
+    jobExecutionRepositoryDecorator.deleteAll();
+    verify(delegateRepository).deleteAll();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test(expectedExceptions = ActiveJobExecutionDeleteForbiddenException.class)
+  public void testDeleteAllForbidden() {
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.PENDING).getMock();
+    doAnswer(
+            invocation -> {
+              ((Consumer<List<Entity>>) invocation.getArgument(1))
+                  .accept(singletonList(jobExecution));
+              return null;
+            })
+        .when(delegateRepository)
+        .forEachBatched(any(), any(), eq(1000));
+
+    jobExecutionRepositoryDecorator.deleteAll();
+    verify(delegateRepository).deleteAll();
+  }
+
+  @Test
+  public void testDeleteStreamAllowed() {
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.SUCCESS).getMock();
+    jobExecutionRepositoryDecorator.delete(Stream.of(jobExecution));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Stream<JobExecution>> entityStreamCaptor = ArgumentCaptor.forClass(Stream.class);
+    verify(delegateRepository).delete(entityStreamCaptor.capture());
+    assertEquals(entityStreamCaptor.getValue().collect(toList()), singletonList(jobExecution));
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test(expectedExceptions = ActiveJobExecutionDeleteForbiddenException.class)
+  public void testDeleteStreamForbidden() {
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.RUNNING).getMock();
+    jobExecutionRepositoryDecorator.delete(Stream.of(jobExecution));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Stream<JobExecution>> entityStreamCaptor = ArgumentCaptor.forClass(Stream.class);
+    verify(delegateRepository).delete(entityStreamCaptor.capture());
+    entityStreamCaptor.getValue().collect(toList());
+  }
+
+  @Test
+  public void testDeleteAllStreamAllowed() {
+    Object jobExecutionId = "myJobExecutionId";
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.SUCCESS).getMock();
+    when(delegateRepository.findOneById(jobExecutionId)).thenReturn(jobExecution);
+
+    jobExecutionRepositoryDecorator.deleteAll(Stream.of(jobExecutionId));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Stream<Object>> entityIdStreamCaptor = ArgumentCaptor.forClass(Stream.class);
+    verify(delegateRepository).deleteAll(entityIdStreamCaptor.capture());
+    assertEquals(entityIdStreamCaptor.getValue().collect(toList()), singletonList(jobExecutionId));
+  }
+
+  @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test(expectedExceptions = ActiveJobExecutionDeleteForbiddenException.class)
+  public void testDeleteAllStreamForbidden() {
+    Object jobExecutionId = "myJobExecutionId";
+    JobExecution jobExecution = mock(JobExecution.class);
+    when(jobExecution.getStatus()).thenReturn(Status.RUNNING).getMock();
+    when(delegateRepository.findOneById(jobExecutionId)).thenReturn(jobExecution);
+
+    jobExecutionRepositoryDecorator.deleteAll(Stream.of(jobExecutionId));
+
+    @SuppressWarnings("unchecked")
+    ArgumentCaptor<Stream<Object>> entityIdStreamCaptor = ArgumentCaptor.forClass(Stream.class);
+    verify(delegateRepository).deleteAll(entityIdStreamCaptor.capture());
+    entityIdStreamCaptor.getValue().collect(toList());
+  }
+}


### PR DESCRIPTION
Dev feature: Support abstract entity type repository decorators

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
