### PR TITLE
File store error handling improvements

### DIFF
--- a/molgenis-app-manager/src/main/java/org/molgenis/app/manager/controller/AppController.java
+++ b/molgenis-app-manager/src/main/java/org/molgenis/app/manager/controller/AppController.java
@@ -114,7 +114,8 @@ public class AppController extends PluginController {
   private void serveAppResource(
       HttpServletResponse response, String wildCardPath, AppResponse appResponse)
       throws IOException {
-    File requestedResource = fileStore.getFile(appResponse.getResourceFolder() + wildCardPath);
+    File requestedResource =
+        fileStore.getFileUnchecked(appResponse.getResourceFolder() + wildCardPath);
     response.setContentType(guessMimeType(requestedResource.getName()));
     response.setContentLength((int) requestedResource.length());
     response.setHeader(

--- a/molgenis-app-manager/src/main/java/org/molgenis/app/manager/service/impl/AppManagerServiceImpl.java
+++ b/molgenis-app-manager/src/main/java/org/molgenis/app/manager/service/impl/AppManagerServiceImpl.java
@@ -118,7 +118,7 @@ public class AppManagerServiceImpl implements AppManagerService {
       deactivateApp(app);
     }
     try {
-      deleteDirectory(fileStore.getFile(app.getResourceFolder()));
+      deleteDirectory(fileStore.getFileUnchecked(app.getResourceFolder()));
     } catch (IOException err) {
       throw new CouldNotDeleteAppException(id);
     }
@@ -133,7 +133,7 @@ public class AppManagerServiceImpl implements AppManagerService {
     fileStore.createDirectory(tempAppDirectoryName);
 
     try {
-      ZipFileUtil.unzip(zipData, fileStore.getFile(tempAppDirectoryName));
+      ZipFileUtil.unzip(zipData, fileStore.getFileUnchecked(tempAppDirectoryName));
     } catch (UnzipException unzipException) {
       fileStore.delete(tempAppDirectoryName);
       throw new InvalidAppArchiveException(formFieldName, unzipException);
@@ -167,7 +167,7 @@ public class AppManagerServiceImpl implements AppManagerService {
       throw new IllegalAppNameException(appConfig.getName());
     }
 
-    if (fileStore.getFile(APPS_DIR + separator + appConfig.getName()).exists()) {
+    if (fileStore.getFileUnchecked(APPS_DIR + separator + appConfig.getName()).exists()) {
       fileStore.deleteDirectory(APPS_TMP_DIR);
       throw new AppAlreadyExistsException(appConfig.getName());
     }
@@ -206,7 +206,7 @@ public class AppManagerServiceImpl implements AppManagerService {
 
   @Override
   public String extractFileContent(String appDir, String fileName) {
-    File indexFile = fileStore.getFile(appDir + separator + fileName);
+    File indexFile = fileStore.getFileUnchecked(appDir + separator + fileName);
     return utf8Encodedfiletostring(indexFile);
   }
 
@@ -242,12 +242,12 @@ public class AppManagerServiceImpl implements AppManagerService {
   private List<String> buildMissingRequiredFiles(String appDirectoryName) {
     List<String> missingFromArchive = newArrayList();
 
-    File indexFile = fileStore.getFile(appDirectoryName + separator + ZIP_INDEX_FILE);
+    File indexFile = fileStore.getFileUnchecked(appDirectoryName + separator + ZIP_INDEX_FILE);
     if (!indexFile.exists()) {
       missingFromArchive.add(ZIP_INDEX_FILE);
     }
 
-    File configFile = fileStore.getFile(appDirectoryName + separator + ZIP_CONFIG_FILE);
+    File configFile = fileStore.getFileUnchecked(appDirectoryName + separator + ZIP_CONFIG_FILE);
     if (!configFile.exists()) {
       missingFromArchive.add(ZIP_CONFIG_FILE);
     }

--- a/molgenis-app-manager/src/test/java/org/molgenis/app/manager/controller/AppControllerTest.java
+++ b/molgenis-app-manager/src/test/java/org/molgenis/app/manager/controller/AppControllerTest.java
@@ -114,7 +114,7 @@ public class AppControllerTest extends AbstractTestNGSpringContextTests {
     URL resourceUrl = Resources.getResource(AppControllerTest.class, "/index.html");
     File testJs = new File(new URI(resourceUrl.toString()).getPath());
 
-    when(fileStore.getFile("fake-app/js/test.js")).thenReturn(testJs);
+    when(fileStore.getFileUnchecked("fake-app/js/test.js")).thenReturn(testJs);
 
     appResponse = AppResponse.create(app);
     when(appManagerService.getAppByName(appName)).thenReturn(appResponse);

--- a/molgenis-app-manager/src/test/java/org/molgenis/app/manager/service/impl/AppManagerServiceImplTest.java
+++ b/molgenis-app-manager/src/test/java/org/molgenis/app/manager/service/impl/AppManagerServiceImplTest.java
@@ -104,7 +104,7 @@ public class AppManagerServiceImplTest {
     when(app.getResourceFolder()).thenReturn("folder");
 
     File appDir = mock(File.class);
-    when(fileStore.getFile("folder")).thenReturn(appDir);
+    when(fileStore.getFileUnchecked("folder")).thenReturn(appDir);
 
     Gson gson = new Gson();
     appManagerServiceImpl =
@@ -214,10 +214,14 @@ public class AppManagerServiceImplTest {
     String fileName = "valid-app.zip";
 
     String tmpDirName = "apps_tmp" + File.separator + "extracted_valid-app.zip";
-    doReturn(tempDir).when(fileStore).getFile(tmpDirName);
-    doReturn(indexFile).when(fileStore).getFile(tmpDirName + File.separator + "index.html");
+    doReturn(tempDir).when(fileStore).getFileUnchecked(tmpDirName);
+    doReturn(indexFile)
+        .when(fileStore)
+        .getFileUnchecked(tmpDirName + File.separator + "index.html");
     when(indexFile.exists()).thenReturn(true);
-    doReturn(configFile).when(fileStore).getFile(tmpDirName + File.separator + "config.json");
+    doReturn(configFile)
+        .when(fileStore)
+        .getFileUnchecked(tmpDirName + File.separator + "config.json");
     when(configFile.exists()).thenReturn(true);
 
     assertEquals(appManagerServiceImpl.uploadApp(zipData, fileName, "app"), tmpDirName);
@@ -231,7 +235,7 @@ public class AppManagerServiceImplTest {
     String fileName = "flip.zip";
 
     String tmpDirName = "apps_tmp" + File.separator + "extracted_flip.zip";
-    doReturn(tempDir).when(fileStore).getFile(tmpDirName);
+    doReturn(tempDir).when(fileStore).getFileUnchecked(tmpDirName);
 
     appManagerServiceImpl.uploadApp(zipData, fileName, "app");
   }
@@ -244,9 +248,13 @@ public class AppManagerServiceImplTest {
     String fileName = "app.zip";
 
     String tmpDirName = "apps_tmp" + File.separator + "extracted_app.zip";
-    doReturn(tempDir).when(fileStore).getFile(tmpDirName);
-    doReturn(indexFile).when(fileStore).getFile(tmpDirName + File.separator + "index.html");
-    doReturn(configFile).when(fileStore).getFile(tmpDirName + File.separator + "config.json");
+    doReturn(tempDir).when(fileStore).getFileUnchecked(tmpDirName);
+    doReturn(indexFile)
+        .when(fileStore)
+        .getFileUnchecked(tmpDirName + File.separator + "index.html");
+    doReturn(configFile)
+        .when(fileStore)
+        .getFileUnchecked(tmpDirName + File.separator + "config.json");
     when(configFile.exists()).thenReturn(true);
 
     assertEquals(appManagerServiceImpl.uploadApp(zipData, fileName, "app"), tmpDirName);
@@ -262,10 +270,14 @@ public class AppManagerServiceImplTest {
     String fileName = "app.zip";
 
     String tmpDirName = "apps_tmp" + File.separator + "extracted_app.zip";
-    doReturn(tempDir).when(fileStore).getFile(tmpDirName);
-    doReturn(indexFile).when(fileStore).getFile(tmpDirName + File.separator + "index.html");
+    doReturn(tempDir).when(fileStore).getFileUnchecked(tmpDirName);
+    doReturn(indexFile)
+        .when(fileStore)
+        .getFileUnchecked(tmpDirName + File.separator + "index.html");
     when(indexFile.exists()).thenReturn(true);
-    doReturn(configFile).when(fileStore).getFile(tmpDirName + File.separator + "config.json");
+    doReturn(configFile)
+        .when(fileStore)
+        .getFileUnchecked(tmpDirName + File.separator + "config.json");
 
     assertEquals(appManagerServiceImpl.uploadApp(zipData, fileName, "app"), tmpDirName);
 
@@ -280,8 +292,8 @@ public class AppManagerServiceImplTest {
         AppManagerServiceImplTest.class.getResource("/config.json").openStream();
     String configContent = IOUtils.toString(configFile, UTF_8);
     File file = mock(File.class);
-    when(fileStore.getFile(APPS_DIR + separator + appUri)).thenReturn(file);
-    when(fileStore.getFile(APPS_DIR + separator + appUri).exists()).thenReturn(false);
+    when(fileStore.getFileUnchecked(APPS_DIR + separator + appUri)).thenReturn(file);
+    when(fileStore.getFileUnchecked(APPS_DIR + separator + appUri).exists()).thenReturn(false);
 
     appManagerServiceImpl.checkAndObtainConfig(tempDir, configContent);
 
@@ -292,8 +304,8 @@ public class AppManagerServiceImplTest {
   public void testCheckAndObtainConfigInvalidJsonConfigFile() throws IOException {
     String appUri = "";
     File appDir = mock(File.class);
-    when(fileStore.getFile(APPS_DIR + separator + appUri)).thenReturn(appDir);
-    when(fileStore.getFile(APPS_DIR + separator + appUri).exists()).thenReturn(false);
+    when(fileStore.getFileUnchecked(APPS_DIR + separator + appUri)).thenReturn(appDir);
+    when(fileStore.getFileUnchecked(APPS_DIR + separator + appUri).exists()).thenReturn(false);
     appManagerServiceImpl.checkAndObtainConfig("tempDir", "");
   }
 
@@ -313,8 +325,8 @@ public class AppManagerServiceImplTest {
   public void testCheckAndObtainConfigAppAlreadyExists() throws IOException {
     InputStream is = AppManagerServiceImplTest.class.getResourceAsStream("/config.json");
     File appDir = mock(File.class);
-    when(fileStore.getFile(APPS_DIR + separator + "example2")).thenReturn(appDir);
-    when(fileStore.getFile(APPS_DIR + separator + "example2").exists()).thenReturn(true);
+    when(fileStore.getFileUnchecked(APPS_DIR + separator + "example2")).thenReturn(appDir);
+    when(fileStore.getFileUnchecked(APPS_DIR + separator + "example2").exists()).thenReturn(true);
     appManagerServiceImpl.checkAndObtainConfig(
         APPS_DIR + separator + "tempDir", IOUtils.toString(is, UTF_8));
   }
@@ -323,7 +335,7 @@ public class AppManagerServiceImplTest {
   public void testExtractFileContent() throws URISyntaxException {
     URL resourceUrl = Resources.getResource(AppControllerTest.class, "/index.html");
     File testIndexHtml = new File(new URI(resourceUrl.toString()).getPath());
-    when(fileStore.getFile("testDir" + separator + "test")).thenReturn(testIndexHtml);
+    when(fileStore.getFileUnchecked("testDir" + separator + "test")).thenReturn(testIndexHtml);
     appManagerServiceImpl.extractFileContent("testDir", "test");
   }
 

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/LogoController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/LogoController.java
@@ -28,7 +28,7 @@ public class LogoController {
       @PathVariable("extension") String extension,
       HttpServletResponse response)
       throws IOException {
-    File f = fileStore.getFile("/logo/" + name + "." + extension);
+    File f = fileStore.getFileUnchecked("/logo/" + name + "." + extension);
     if (!f.exists()) {
       response.sendError(HttpServletResponse.SC_NOT_FOUND);
       return;

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/file/FileDownloadController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/file/FileDownloadController.java
@@ -39,9 +39,9 @@ public class FileDownloadController {
       response.setStatus(HttpStatus.NOT_FOUND.value());
     } else {
       // Not so nice but keep to serve old legacy files
-      File fileStoreFile = fileStore.getFile(fileMeta.getFilename());
+      File fileStoreFile = fileStore.getFileUnchecked(fileMeta.getFilename());
       if (!fileStoreFile.exists()) {
-        fileStoreFile = fileStore.getFile(id);
+        fileStoreFile = fileStore.getFileUnchecked(id);
       }
       if (!fileStoreFile.exists()) {
         response.setStatus(HttpStatus.NOT_FOUND.value());

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/StyleServiceImpl.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/StyleServiceImpl.java
@@ -7,6 +7,7 @@ import static org.molgenis.core.ui.style.StyleSheetMetadata.STYLE_SHEET;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UncheckedIOException;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -104,7 +105,7 @@ public class StyleServiceImpl implements StyleService {
     FileMeta fileMeta = fileMetaFactory.create(fileId);
     fileMeta.setContentType("css");
     fileMeta.setFilename(fileName);
-    fileMeta.setSize(fileStore.getFile(fileId).length());
+    fileMeta.setSize(fileStore.getFileUnchecked(fileId).length());
     fileMeta.setUrl(buildFileUrl(fileId));
     dataService.add(FileMetaMetaData.FILE_META, fileMeta);
     return fileMeta;
@@ -168,7 +169,12 @@ public class StyleServiceImpl implements StyleService {
       }
     }
 
-    File file = fileStore.getFile(fileMeta.getId());
+    File file;
+    try {
+      file = fileStore.getFile(fileMeta.getId());
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
     return new FileSystemResource(file);
   }
 

--- a/molgenis-data-file/src/main/java/org/molgenis/data/file/FileStore.java
+++ b/molgenis-data-file/src/main/java/org/molgenis/data/file/FileStore.java
@@ -3,6 +3,7 @@ package org.molgenis.data.file;
 import static java.io.File.separator;
 
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,7 +25,7 @@ public class FileStore {
   }
 
   public void deleteDirectory(String dirName) throws IOException {
-    FileUtils.deleteDirectory(getFile(dirName));
+    FileUtils.deleteDirectory(getFileUnchecked(dirName));
   }
 
   public File store(InputStream is, String fileName) throws IOException {
@@ -54,7 +55,32 @@ public class FileStore {
         Paths.get(getStorageDir() + File.separator + targetDir));
   }
 
-  public File getFile(String fileName) {
+  /**
+   * Returns a {@link File} for the given filename in the store.
+   *
+   * @throws FileNotFoundException if no file with the given filename exists
+   * @throws IOException if the given filename does not refer to a file
+   */
+  public File getFile(String fileName) throws IOException {
+    String pathname = storageDir + separator + fileName;
+
+    File file = new File(pathname);
+    if (!file.exists()) {
+      throw new FileNotFoundException(pathname);
+    }
+    if (!file.isFile()) {
+      throw new IOException('\'' + pathname + '\'' + " is not a file");
+    }
+    return file;
+  }
+
+  /**
+   * Returns a {@link File} for the given filename in the store. The filename may denote a
+   * nonexistent file in the store or refer to a directory.
+   *
+   * @see #getFile(String)
+   */
+  public File getFileUnchecked(String fileName) {
     return new File(storageDir + separator + fileName);
   }
 
@@ -68,6 +94,6 @@ public class FileStore {
   }
 
   public void writeToFile(InputStream inputStream, String fileName) throws IOException {
-    FileUtils.copyInputStreamToFile(inputStream, getFile(fileName));
+    FileUtils.copyInputStreamToFile(inputStream, getFileUnchecked(fileName));
   }
 }

--- a/molgenis-data-file/src/test/java/org/molgenis/data/file/FileStoreTest.java
+++ b/molgenis-data-file/src/test/java/org/molgenis/data/file/FileStoreTest.java
@@ -1,10 +1,12 @@
 package org.molgenis.data.file;
 
 import static java.io.File.separator;
+import static org.testng.Assert.assertTrue;
 
 import com.google.common.io.Files;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.testng.Assert;
@@ -28,8 +30,8 @@ public class FileStoreTest {
 
   @Test
   public void testCreateDirectory() {
-    Assert.assertTrue(fileStore.createDirectory("testDir"));
-    Assert.assertTrue(fileStore.getFile("testDir").isDirectory());
+    assertTrue(fileStore.createDirectory("testDir"));
+    assertTrue(fileStore.getFileUnchecked("testDir").isDirectory());
     fileStore.delete("testDir");
   }
 
@@ -41,30 +43,52 @@ public class FileStoreTest {
 
   @Test
   public void testMoveTopLevelDir() throws IOException {
-    Assert.assertTrue(fileStore.createDirectory("testDir1"));
+    assertTrue(fileStore.createDirectory("testDir1"));
     fileStore.store(
         new ByteArrayInputStream(new byte[] {1, 2, 3}), "testDir1" + separator + "bytes.bin");
     fileStore.move("testDir1", "testDir2");
-    File file = fileStore.getFile("testDir2" + separator + "bytes.bin");
+    File file = fileStore.getFileUnchecked("testDir2" + separator + "bytes.bin");
     Assert.assertEquals(FileUtils.readFileToByteArray(file), new byte[] {1, 2, 3});
   }
 
   @Test
   public void testMoveSubLevelDir() throws IOException {
-    Assert.assertTrue(fileStore.createDirectory("testDir1" + separator + "testDir2"));
-    Assert.assertTrue(fileStore.createDirectory("testDir2"));
+    assertTrue(fileStore.createDirectory("testDir1" + separator + "testDir2"));
+    assertTrue(fileStore.createDirectory("testDir2"));
     fileStore.store(
         new ByteArrayInputStream(new byte[] {1, 2, 3}),
         "testDir1" + separator + "testDir2" + separator + "bytes.bin");
     fileStore.move("testDir1" + separator + "testDir2", "testDir2" + separator + "testDir3");
-    File file = fileStore.getFile("testDir2" + separator + "testDir3" + separator + "bytes.bin");
+    File file =
+        fileStore.getFileUnchecked("testDir2" + separator + "testDir3" + separator + "bytes.bin");
     Assert.assertEquals(FileUtils.readFileToByteArray(file), new byte[] {1, 2, 3});
   }
 
   @Test
-  public void testGetFile() throws IOException {
+  public void testGetFileUnchecked() throws IOException {
     String fileName = "bytes.bin";
     File file = fileStore.store(new ByteArrayInputStream(new byte[] {1, 2, 3}), fileName);
-    Assert.assertEquals(fileStore.getFile(fileName).getAbsolutePath(), file.getAbsolutePath());
+    Assert.assertEquals(
+        fileStore.getFileUnchecked(fileName).getAbsolutePath(), file.getAbsolutePath());
+  }
+
+  @Test
+  public void testGetFileExists() throws IOException {
+    String fileName = "bytes.bin";
+    fileStore.store(new ByteArrayInputStream(new byte[] {1, 2, 3}), fileName);
+    assertTrue(fileStore.getFile(fileName).exists());
+  }
+
+  @Test(expectedExceptions = FileNotFoundException.class)
+  public void testGetFileNotExists() throws IOException {
+    String fileName = "unknownFile";
+    fileStore.getFile(fileName);
+  }
+
+  @Test(expectedExceptions = IOException.class)
+  public void testGetFileIsNotFile() throws IOException {
+    String dirName = "directory";
+    fileStore.createDirectory(dirName);
+    fileStore.getFile(dirName);
   }
 }

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/download/job/ResourceDownloadService.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/download/job/ResourceDownloadService.java
@@ -46,7 +46,7 @@ public class ResourceDownloadService {
     FileMeta fileMeta;
     try {
       ResourceCollection resourceCollection = resourceCollector.get(resourceIdentifiers);
-      File emxFile = fileStore.getFile(filename);
+      File emxFile = fileStore.getFileUnchecked(filename);
       fileMeta = createFileMeta(emxFile);
       dataService.add(FileMetaMetaData.FILE_META, fileMeta);
       emxExportService.export(

--- a/molgenis-navigator/src/test/java/org/molgenis/navigator/download/job/DownloadServiceTest.java
+++ b/molgenis-navigator/src/test/java/org/molgenis/navigator/download/job/DownloadServiceTest.java
@@ -64,7 +64,7 @@ public class DownloadServiceTest extends AbstractMolgenisSpringTest {
     when(fileMetaFactory.create(anyString())).thenReturn(fileMeta);
     File file = mock(File.class);
     when(file.getName()).thenReturn("test");
-    when(fileStore.getFile(anyString())).thenReturn(file);
+    when(fileStore.getFileUnchecked(anyString())).thenReturn(file);
 
     ResourceIdentifier id1 = ResourceIdentifier.create(ResourceType.PACKAGE, "it");
     ResourceIdentifier id2 = ResourceIdentifier.create(ResourceType.ENTITY_TYPE, "test_entity");

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/job/OneClickImportJob.java
@@ -54,7 +54,7 @@ public class OneClickImportJob {
   @Transactional
   public List<EntityType> getEntityType(Progress progress, String filename)
       throws UnknownFileTypeException, IOException, InvalidFormatException, EmptySheetException {
-    File file = fileStore.getFile(filename);
+    File file = fileStore.getFileUnchecked(filename);
     String fileExtension =
         findExtensionFromPossibilities(filename, newHashSet("csv", "xlsx", "zip", "xls"));
 

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/job/OneClickImportJobTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/job/OneClickImportJobTest.java
@@ -60,7 +60,7 @@ public class OneClickImportJobTest {
         .thenReturn("simple_valid");
 
     File file = loadFile(OneClickImportJobTest.class, "/" + filename);
-    when(fileStore.getFile(filename)).thenReturn(file);
+    when(fileStore.getFileUnchecked(filename)).thenReturn(file);
 
     List<Sheet> sheets = new ArrayList<>();
     when(excelService.buildExcelSheetsFromFile(file)).thenReturn(sheets);
@@ -102,7 +102,7 @@ public class OneClickImportJobTest {
         .thenReturn("simple_valid");
 
     File file = loadFile(OneClickImportJobTest.class, "/" + filename);
-    when(fileStore.getFile(filename)).thenReturn(file);
+    when(fileStore.getFileUnchecked(filename)).thenReturn(file);
 
     List<String[]> lines = new ArrayList<>();
     lines.add(new String[] {"name,age", "piet,25"});
@@ -145,7 +145,7 @@ public class OneClickImportJobTest {
         .thenReturn("simple_valid");
 
     File file = loadFile(OneClickImportJobTest.class, "/" + filename);
-    when(fileStore.getFile(filename)).thenReturn(file);
+    when(fileStore.getFileUnchecked(filename)).thenReturn(file);
 
     File zipFile1 = loadFile(OneClickImportJobTest.class, "/zip_file_1.csv");
     when(oneClickImporterNamingService.createValidIdFromFileName("zip_file_1.csv"))
@@ -258,7 +258,7 @@ public class OneClickImportJobTest {
     String filename = "unsupported-file-zip.zip";
 
     File file = loadFile(OneClickImportJobTest.class, "/" + filename);
-    when(fileStore.getFile(filename)).thenReturn(file);
+    when(fileStore.getFileUnchecked(filename)).thenReturn(file);
 
     oneClickImporterJob =
         new OneClickImportJob(
@@ -282,7 +282,7 @@ public class OneClickImportJobTest {
     String filename = "unsupported-file-zip2.zip";
 
     File file = loadFile(OneClickImportJobTest.class, "/" + filename);
-    when(fileStore.getFile(filename)).thenReturn(file);
+    when(fileStore.getFileUnchecked(filename)).thenReturn(file);
 
     oneClickImporterJob =
         new OneClickImportJob(
@@ -307,7 +307,7 @@ public class OneClickImportJobTest {
     String filename = "unsupported-file-type.nft";
 
     File file = loadFile(OneClickImportJobTest.class, "/" + filename);
-    when(fileStore.getFile(filename)).thenReturn(file);
+    when(fileStore.getFileUnchecked(filename)).thenReturn(file);
 
     oneClickImporterJob =
         new OneClickImportJob(

--- a/molgenis-scripts/src/main/java/org/molgenis/script/SavedScriptRunner.java
+++ b/molgenis-scripts/src/main/java/org/molgenis/script/SavedScriptRunner.java
@@ -95,7 +95,7 @@ public class SavedScriptRunner {
     FileMeta fileMeta = null;
     if (StringUtils.isNotEmpty(script.getResultFileExtension())) {
       String name = generateRandomString();
-      File file = fileStore.getFile(name + "." + script.getResultFileExtension());
+      File file = fileStore.getFileUnchecked(name + "." + script.getResultFileExtension());
       parameters.put("outputFile", file.getAbsolutePath());
       fileMeta = createFileMeta(name, file);
       dataService.add(FILE_META, fileMeta);


### PR DESCRIPTION
Improved error messages, e.g. for #7925:
- Rename FileStore.getFile -> getFileUnchecked
- Introduce FileStore.getFile that checks whether the file exists and is not a directory

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
