### PR TITLE
Add app version to app card

### DIFF
--- a/molgenis-app-manager/src/main/frontend/src/components/AppCard.vue
+++ b/molgenis-app-manager/src/main/frontend/src/components/AppCard.vue
@@ -1,30 +1,48 @@
 <template>
-    <div class="card app-card-component mb-3">
-        <div class="card-header">
-            <button :disabled="app.isActive" class="btn btn-danger btn-sm mx-1 float-right" @click="deleteApp(app)"
-                    title="delete">
-                <i class="fa fa-trash"></i>
-            </button>
-
+    <div class="card app-card-component">
+      <div class="card-header">
+        <div class="row">
+          <div class="col">
             <h5>{{ app.label }}</h5>
-            <span>
-                <toggle-button
-                        :labels="{checked: ' Active', unchecked: ' Inactive'}"
-                        :width="72" :value="app.isActive"
-                        @change="toggleAppActiveState(app)" :sync="true"
-                        title="toggle active status"></toggle-button>
-            </span>
+          </div>
         </div>
+        <div class="row">
+          <div class="col">
+              <span>
+                <toggle-button
+                  :labels="{checked: ' Active', unchecked: ' Inactive'}"
+                  :width="72" :value="app.isActive"
+                  @change="toggleAppActiveState(app)" :sync="true"
+                  title="toggle active status"></toggle-button>
+            </span>
+            <button :disabled="app.isActive" class="btn btn-danger btn-sm mx-1 float-right"
+                    @click="deleteApp(app)"
+                    title="delete">
+              <i class="fa fa-trash"></i>
+            </button>
+          </div>
+        </div>
+      </div>
 
         <div class="card-body app-card-body">
-            <p class="lead"> {{ app.description }} </p>
+              <dl>
+                <dt>Version</dt>
+                <dd class="text-muted">{{ app.version }}</dd>
+                <dt>Description</dt>
+                <dd class="text-muted">{{ app.description }}</dd>
+            </dl>
         </div>
     </div>
 </template>
 
 <style scoped>
+    .app-card-component {
+      height: 15rem;
+      margin-bottom: 1rem;
+    }
+
     .app-card-component .card-body {
-        height: 150px;
+      overflow-y: auto;
     }
 </style>
 

--- a/molgenis-app-manager/src/main/frontend/src/components/AppCardGallery.vue
+++ b/molgenis-app-manager/src/main/frontend/src/components/AppCardGallery.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="app-card-carousel">
         <div class="app-card-container row">
-            <div v-for="app in apps" :key="app.id" class="col-4">
+            <div v-for="app in apps" :key="app.id" class="col-md-6 col-lg-4">
                 <app-card :app="app"></app-card>
             </div>
         </div>


### PR DESCRIPTION
+ Make styling more dynamic to cope with extra content and different screen sizes

Part one of:
 #6062 as App-deployer on 7.x I want to see the version of an app in the app manager and in the app itself

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
