### PR TITLE
Wait for index work to finish in CopyServiceIT

### DIFF
--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/CopyServiceIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/CopyServiceIT.java
@@ -253,6 +253,8 @@ public class CopyServiceIT extends AbstractTestNGSpringContextTests {
     testPermissionService.grant(
         ImmutableMap.of(new PackageIdentity(id), PermissionSet.WRITEMETA),
         createUserSid(requireNonNull(getCurrentUsername())));
+
+    waitForWorkToBeFinished(indexService, LOG);
   }
 
   private void cleanupTargetPackage(String id) {
@@ -269,6 +271,8 @@ public class CopyServiceIT extends AbstractTestNGSpringContextTests {
 
     metadataService.addPackage(packageA);
     metadataService.addPackage(packageB);
+
+    waitForWorkToBeFinished(indexService, LOG);
   }
 
   @AfterClass


### PR DESCRIPTION
This is a possible fix for the failing reports build

#### Checklist
- [NA] Functionality works & meets specifications
- [NA] Code reviewed
- [NA] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [NA] Clean commits
- [NA] Added Feature/Fix to release notes
