### PR TITLE
fix(header): Add polyfill to all pages.

### DIFF
--- a/docs/developer_documentation/app-development.md
+++ b/docs/developer_documentation/app-development.md
@@ -77,7 +77,8 @@ It contains the following parameters
 | version | string |yes |The version of your app. Used to manage app version, updating etc etc.. |
 | apiDependency | string |yes | The version of the MOLGENIS REST api you used in your app. Can be used to give warnings about possible incompatibility with a specific version of MOLGENIS |
 | name | string |yes | The name of the app. May not contain '/'
-| includeMenuAndFooter | boolean |yes | If you want to use the MOLGENIS menu, you can this value to __true__ |
+| includeMenuAndFooter | boolean |yes | 
+  If you want MOLGENIS to serve your app with the standard header (with menu and polyfill), and footer, set this value to __true__ |
 | runtimeOptions | object |no | A map containing initial parameters you might want to give to your app on init |
 
 ### Example

--- a/molgenis-core-ui/src/main/resources/templates/molgenis-header.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/molgenis-header.ftl
@@ -16,6 +16,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="icon" href="<@resource_href "/img/favicon.ico"/>" type="image/x-icon">
 
+    <#-- Include browser polyfills before any script tags are inserted -->
+    <@polyfill/>
     <#if !version?? || version == 1>
         <link rel="stylesheet" href="<@resource_href "/css/bootstrap.min.css"/>" type="text/css">
         <link rel="stylesheet" href="<@theme_href "/css/bootstrap-3/${app_settings.bootstrapTheme?html}"/>" type="text/css" id="bootstrap-theme">
@@ -23,9 +25,6 @@
         <#if app_settings.logoTopHref?has_content><link rel="stylesheet" href="<@resource_href "/css/molgenis-top-logo.css"/>" type="text/css"></#if>
 
         <#if app_settings.cssHref?has_content><link rel="stylesheet" href="<@resource_href "/css/${app_settings.cssHref?html}"/>" type="text/css"></#if>
-
-        <#-- Include browser polyfills before any script tags are inserted -->
-        <@polyfill/>
 
         <#-- Bundle of third party JavaScript resources used by MOLGENIS: see minify-maven-plugin in molgenis-core-ui/pom.xml for bundle contents -->
         <script src="<@resource_href "/js/dist/molgenis-vendor-bundle.js"/>"></script>


### PR DESCRIPTION
Some apps don't render properly on old browsers. Add the complete babel polyfill to all pages.

N.B. This has as a consequence that apps cannot also import the polyfill, themselves.
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
