### PR TITLE
Fix #5258: An error in an entity report causes the previous one to be shown

### DIFF
--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
@@ -86,9 +86,10 @@
     function onRowInspect(e) {
         var entityId = e.id;
         var entityTypeId = e.name;
-
-        $('#entityReport').load("dataexplorer/details", {entityTypeId: entityTypeId, entityId: entityId}, function () {
-            $('#entityReportModal').modal("show");
+        $('#entityReport').load("dataexplorer/details", {entityTypeId: entityTypeId, entityId: entityId}, function( response, status, xhr ) {
+            if ( status !== "error" ) {
+                $('#entityReportModal').modal("show");
+            }
         });
     }
 


### PR DESCRIPTION
Note: only an if statement checking for errors without an "else" with a error message since it is already shown. (due to the error occuring server-side)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
