### PR TITLE
Fix #7850: EMX defaults value section in documentation contains non grammatical sentence + fix typo

### DIFF
--- a/docs/user_documentation/finding-data/guide-search.md
+++ b/docs/user_documentation/finding-data/guide-search.md
@@ -1,6 +1,6 @@
 # Finding data
 
-![Searchall_screen](../../images/searchall/searchAll.png?raw=true, "searchall/screen")
+![Searchall_screen](../../images/searchall/SearchAll.png?raw=true, "searchall/screen")
 
 Via the "Search all data" plugin it is possible to search for all hits in all data rows, and names and labels of metadata.
 

--- a/docs/user_documentation/import-data/ref-emx.md
+++ b/docs/user_documentation/import-data/ref-emx.md
@@ -77,7 +77,7 @@ Attributes:
 | children	  | patients | mref     |          | patients  |             |  children of a patient  |
 | birthdate   | patients | date     |          |           |             |  day of birth           |
 | birthplace  | patients | xref     |          | cities    |             |  place of birth         |
-| disease     | patients |          |          |           |             |  disese description     |
+| disease     | patients |          |          |           |             |  disease description    |
 | userName    | users    |          | FALSE    |           | TRUE        |  unique login name      |
 | active      | users    | bool     |          |           |             |  whether user is active |
 
@@ -199,7 +199,7 @@ Magma JavaScript validation expression that must return a bool. Must return true
 true/false to indicate whether the attribute can be seen by users. Can also contain a Magma JavaScript expression to dynamically decide if the attribute should be shown or not. See the [Expressions](ref-expressions.md) section for a syntax description.
 
 #### defaultValue
-value that will be filled in in the forms when a new entity instance is created. Not yet supported for mref and xref values. For categorical_mref, should be a comma separated list of ids. For xref should be the of the refEntity. For bool should be true or false. For datetime should be a string in the format YYYY-MM-DDTHH:mm:ssZZ. For date should be a string in the format YYYY-MM-DD.
+value that will be filled in in the forms when a new entity instance is created. For mref and categorical_mref, this should be a comma separated list of ids. For categorical and xref this should be the id of the refEntity. For bool should be true or false. For datetime should be a string in the format YYYY-MM-DDTHH:mm:ssZZ. For date should be a string in the format YYYY-MM-DD.
 
 #### partOfAttribute
 is used to group attributes into a compound attribute. Put here the name of the compound attribute.


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- [x] User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
