### PR TITLE
Fix #8170 Sign up failure displays wrong error

### DIFF
--- a/molgenis-security/src/main/java/org/molgenis/security/account/AccountServiceImpl.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/AccountServiceImpl.java
@@ -108,9 +108,6 @@ public class AccountServiceImpl implements AccountService {
       mailSender.send(mailMessage);
     } catch (MailException mce) {
       LOG.error("Could not send signup mail", mce);
-
-      dataService.delete(USER, user);
-
       throw new MolgenisUserException(
           "An error occurred. Please contact the administrator. You are not signed up!");
     }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
