### PR TITLE
Fix #8177 Navigator download writes abstract attributes of existing types

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/export/EmxExportServiceImpl.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/export/EmxExportServiceImpl.java
@@ -121,7 +121,7 @@ public class EmxExportServiceImpl implements EmxExportService {
         progress.status(progressMessage);
         progress.increment(1);
       }
-      writeAttributes(entityType.getAllAttributes(), writer);
+      writeAttributes(entityType.getOwnAllAttributes(), writer);
       if (!entityType.isAbstract()) {
         downloadData(entityType, writer);
       }


### PR DESCRIPTION
After applying this fix the import of the downloaded EMX fails due to #6020

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
