### PR TITLE
[CHORE] Upgrade project info plugin to a version that supports java module info.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -778,7 +778,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-project-info-reports-plugin</artifactId>
-        <version>2.9</version>
+        <version>3.0.0</version>
         <configuration>
           <!-- improve report generation performance -->
           <dependencyLocationsEnabled>false</dependencyLocationsEnabled>


### PR DESCRIPTION
Fixes messages where the maven report generator doesn't like bcel.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
