### PR TITLE
Fix #8243 Docs: remove 'xref as label attr' expression example

### DIFF
--- a/docs/user_documentation/import-data/ref-emx.md
+++ b/docs/user_documentation/import-data/ref-emx.md
@@ -207,16 +207,6 @@ is used to group attributes into a compound attribute. Put here the name of the 
 #### expression
 is used to create computed attributes.
 
-**Computed string example: "xref as label attribute" (config attributes table)**
-  1. Create a new target attribute into the "myEntity" entity, that will become the new computed attribute (in the example: "myLabel")
-  2. Add in the expression column of the new attribute "myLabel": "the name of attribute to convert from" (in example: expression -> "myXref")
-
-| name    | entity	  | label	       | dataType	| idAttribute	| refEntity	  | nillable	| visible	| labelAttribute	| expression |
-|---------|----------|--------------|----------|-------------|-------------|----------|---------|----------------|------------|
-| id      | myEntity | Id	          | int	     | TRUE	       |             |FALSE		   | FALSE	  | FALSE          |            |
-| myXref	 | myEntity | Other Entity	| xref	    | FALSE	      | otherEntity |TRUE      | TRUE    | FALSE	         |            |
-| myLabel | myEntity | Label	       | string	  | FALSE	      |             |TRUE		    | FALSE	  | TRUE           | myXref     |
-
 **Computed object example: "computed myXref" (config attributes table)**
 
   1. Create a two new target attributes (attr1, attr2) in a new entity (newEntity).


### PR DESCRIPTION
- Templates should be used for these use cases

Please add the following breaking change note to the draft release notes when merging:

Drop support for expressions that have 'string' (or similar) as source attribute type and categorical/xref as target attribute type. Existing expressions must be converted to template expressions, e.g. ``` {"template":"{{biobank.name}}"}``` instead of ```biobank```.

#### Checklist
- [x] Functionality works & meets specifications
- Code reviewed
- Code unit/integration/system tested
- [x] User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
