### PR TITLE
doc: fix relative link from quickstart to upload guide

### DIFF
--- a/docs/quickstart/guide-quickstart.md
+++ b/docs/quickstart/guide-quickstart.md
@@ -47,7 +47,7 @@ Go to the Upload menu. You now should see something like this:
 
 ![Importer first screen](../images/importer_first_screen.png?raw=true, "importer")
 
-To keep it simple, all you need to do is click the 'select a file' button, select your newly made EMX file, and press the next button until it starts importing. Don't worry about all the options you are skipping, we will handle those in the [upload guide](../user_documentation/import-data/guide-upload). After your import is done, you can view your data in the data explorer. Go there by clicking the 'Data Explorer' link in the menu.
+To keep it simple, all you need to do is click the 'select a file' button, select your newly made EMX file, and press the next button until it starts importing. Don't worry about all the options you are skipping, we will handle those in the [upload guide](../user_documentation/import-data/guide-upload.md). After your import is done, you can view your data in the data explorer. Go there by clicking the 'Data Explorer' link in the menu.
 
 Congratulations! You have now deployed MOLGENIS either locally or on a server, and you have made the first steps on getting your data into the MOLGENIS database. Play around a bit with the different data explorer filters to get a feel on how MOLGENIS works.
 


### PR DESCRIPTION
It is not possible to create a link that works both on github and in the docbook.
I've picked the one that works in docbook.
See https://seadude.gitbooks.io/learn-gitbook/content/ for the syntax.

See #8194

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
