### PR TITLE
[FEAT] Update OpenCPU setting to can make use of cloud instance

### DIFF
--- a/molgenis-r/src/main/java/org/molgenis/r/OpenCpuSettings.java
+++ b/molgenis-r/src/main/java/org/molgenis/r/OpenCpuSettings.java
@@ -5,7 +5,7 @@ public interface OpenCpuSettings {
 
   String getHost();
 
-  int getPort();
+  Integer getPort();
 
   String getRootPath();
 }

--- a/molgenis-r/src/main/java/org/molgenis/r/OpenCpuSettingsImpl.java
+++ b/molgenis-r/src/main/java/org/molgenis/r/OpenCpuSettingsImpl.java
@@ -63,7 +63,7 @@ public class OpenCpuSettingsImpl extends DefaultSettingsEntity implements OpenCp
       addAttribute(PORT)
           .setDataType(INT)
           .setDefaultValue(defaultPort)
-          .setNillable(false)
+          .setNillable(true)
           .setLabel("URI port")
           .setDescription("Open CPU URI port (e.g. 8004).");
       addAttribute(ROOT_PATH)
@@ -86,7 +86,7 @@ public class OpenCpuSettingsImpl extends DefaultSettingsEntity implements OpenCp
   }
 
   @Override
-  public int getPort() {
+  public Integer getPort() {
     return getInt(PORT);
   }
 

--- a/molgenis-r/src/main/java/org/molgenis/r/RScriptExecutor.java
+++ b/molgenis-r/src/main/java/org/molgenis/r/RScriptExecutor.java
@@ -207,19 +207,21 @@ public class RScriptExecutor {
   private URI getOpenCpuUri() {
     try {
       URI uri;
-      if(openCpuSettings.getPort() == null) {
-        uri = new URIBuilder()
-            .setScheme(openCpuSettings.getScheme())
-            .setHost(openCpuSettings.getHost())
-            .setPath(openCpuSettings.getRootPath())
-            .build();
+      if (openCpuSettings.getPort() == null) {
+        uri =
+            new URIBuilder()
+                .setScheme(openCpuSettings.getScheme())
+                .setHost(openCpuSettings.getHost())
+                .setPath(openCpuSettings.getRootPath())
+                .build();
       } else {
-        uri = new URIBuilder()
-            .setScheme(openCpuSettings.getScheme())
-            .setHost(openCpuSettings.getHost())
-            .setPort(openCpuSettings.getPort())
-            .setPath(openCpuSettings.getRootPath())
-            .build();
+        uri =
+            new URIBuilder()
+                .setScheme(openCpuSettings.getScheme())
+                .setHost(openCpuSettings.getHost())
+                .setPort(openCpuSettings.getPort())
+                .setPath(openCpuSettings.getRootPath())
+                .build();
       }
       return uri;
     } catch (URISyntaxException e) {

--- a/molgenis-r/src/main/java/org/molgenis/r/RScriptExecutor.java
+++ b/molgenis-r/src/main/java/org/molgenis/r/RScriptExecutor.java
@@ -206,12 +206,22 @@ public class RScriptExecutor {
 
   private URI getOpenCpuUri() {
     try {
-      return new URIBuilder()
-          .setScheme(openCpuSettings.getScheme())
-          .setHost(openCpuSettings.getHost())
-          .setPort(openCpuSettings.getPort())
-          .setPath(openCpuSettings.getRootPath())
-          .build();
+      URI uri;
+      if(openCpuSettings.getPort() == null) {
+        uri = new URIBuilder()
+            .setScheme(openCpuSettings.getScheme())
+            .setHost(openCpuSettings.getHost())
+            .setPath(openCpuSettings.getRootPath())
+            .build();
+      } else {
+        uri = new URIBuilder()
+            .setScheme(openCpuSettings.getScheme())
+            .setHost(openCpuSettings.getHost())
+            .setPort(openCpuSettings.getPort())
+            .setPath(openCpuSettings.getRootPath())
+            .build();
+      }
+      return uri;
     } catch (URISyntaxException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
When you target a cloud instance, there will be indirection between servers such as loadbalancers and stuff. When you add a port number in the URL these services will not accept it.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
