### PR TITLE
[CHORE] Update MOLGENIS top-layer image to own tomcat-9.0-jre11

### DIFF
--- a/molgenis-app/Dockerfile
+++ b/molgenis-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:9.0-jre11
+FROM molgenis/tomcat:tomcat-release-2019-03-11_12-31-59
 
 # MOLGENIS war-file
 ARG WAR_FILE


### PR DESCRIPTION
This needs to be done when we want control of updates of the tomcat image that we are using. 

You can update the image by releasing: molgenis-ops-docker with another build of the tomcat image. That pulls the latest 9.0-jre11 iamge from the dockerhub, which includes the latest fixes.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
