### PR TITLE
M6401 Replace bootstrap 3 with bootstrap 4 in static content pages

### DIFF
--- a/molgenis-core-ui/src/main/resources/templates/view-staticcontent-edit.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/view-staticcontent-edit.ftl
@@ -1,40 +1,42 @@
+<#include "resource-macros.ftl">
 <#include "molgenis-header.ftl">
 <#include "molgenis-footer.ftl">
-<#assign css=[]>
-<#assign js=["ckeditor/ckeditor.js"]>
-<@header css js/>
-<div class="row">
-    <div class="col-md-12">
-        <form id="contentForm" method="post" role="form">
 
-            <div class="form-group">
-                <div class="col-md-8 col-md-offset-2">
+<script src="<@resource_href "/js/ckeditor/ckeditor.js"/>"></script>
+<@header css=[] js=[] version=2/>
+
+<div class="row">
+  <div class="col-12">
+    <form id="contentForm" method="post" role="form">
+
+      <div class="form-group">
+        <div class="col-8 offset-md-2">
                 <#if content?has_content>
-                    <textarea id="elm1" name="content" form="contentForm"
-                              rows="15">${content} <#if succes?has_content>${succes?html}</#if></textarea>
+                  <textarea id="elm1" name="content" form="contentForm"
+                            rows="15">${content} <#if succes?has_content>${succes?html}</#if></textarea>
                 <#else>
                     <textarea id="elm1" name="content" form="contentForm" rows="15"></textarea>
                 </#if>
-                </div>
-            </div>
+        </div>
+      </div>
 
-            <div class="form-group">
-                <div class="col-md-8 col-md-offset-2">
-                    <div class="btn-group pull-right">
-                        <a id="cancelBtn" href="${context_url?html}" class="btn btn-default">Close</a>
-                        <button id="submitBtn" type="submit" class="btn btn-default">Save</button>
-                    </div>
-                </div>
-            </div>
+      <div class="form-group">
+        <div class="col-8 offset-md-2">
+          <div class="btn-group float-right">
+            <a id="cancelBtn" href="${context_url?html}" class="btn btn-secondary">Close</a>
+            <button id="submitBtn" type="submit" class="btn btn-secondary">Save</button>
+          </div>
+        </div>
+      </div>
 
-        </form>
-    </div>
+    </form>
+  </div>
 </div>
 
 <script>
-    CKEDITOR.replace('elm1');
-    CKEDITOR.dtd.$removeEmpty['i'] = false;
-    CKEDITOR.dtd.$removeEmpty['span'] = false;
-    CKEDITOR.dtd.$removeEmpty['button'] = false;
+  CKEDITOR.replace('elm1')
+  CKEDITOR.dtd.$removeEmpty['i'] = false
+  CKEDITOR.dtd.$removeEmpty['span'] = false
+  CKEDITOR.dtd.$removeEmpty['button'] = false
 </script>
-<@footer/>
+<@footer version=2/>

--- a/molgenis-core-ui/src/main/resources/templates/view-staticcontent-edit.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/view-staticcontent-edit.ftl
@@ -22,9 +22,9 @@
 
       <div class="form-group">
         <div class="col-8 offset-md-2">
-          <div class="btn-group float-right">
+          <div class="float-right">
             <a id="cancelBtn" href="${context_url?html}" class="btn btn-secondary">Close</a>
-            <button id="submitBtn" type="submit" class="btn btn-secondary">Save</button>
+            <button id="submitBtn" type="submit" class="btn btn-primary">Save</button>
           </div>
         </div>
       </div>

--- a/molgenis-core-ui/src/main/resources/templates/view-staticcontent.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/view-staticcontent.ftl
@@ -1,23 +1,24 @@
 <#include "molgenis-header.ftl">
 <#include "molgenis-footer.ftl">
-<@header/>
+
+<@header css=[] js=[] version=2/>
 
 <#if content?has_content>
 <div class="row">
-    <div class="col-md-12">
-    <#-- Do *not* HTML escape content else text formatting won't work -->
-			${content}
-    </div>
+  <div class="col-12">
+  <#-- Do *not* HTML escape content else text formatting won't work -->
+    ${content}
+  </div>
 </div>
 </#if>
 
 <#if isCurrentUserCanEdit?has_content && isCurrentUserCanEdit>
 <div class="row">
-    <div class="col-md-12">
-        <hr></hr>
-        <a href="${context_url?html}/edit" class="btn btn-default pull-left">Edit page</a>
-    </div>
+  <div class="col-12">
+    <hr></hr>
+    <a href="${context_url?html}/edit" class="btn btn-secondary float-left">Edit page</a>
+  </div>
 </div>
 </#if>
 
-<@footer/>
+<@footer version=2/>


### PR DESCRIPTION
M6401 As content page owner I want to use bootstrap 4 so my pages will have identical styling with the other bootstrap 4.

Test html code:
[test.txt](https://github.com/molgenis/molgenis/files/2984070/test.txt)

Before merge, add this to the breaking changes section of the release notes:

- The bootstrap version of the static content pages (home, news, background, contact and references) is upgraded to bootstrap 4. This means if you used bootstrap 3 in your pages, you have to migrate the classes to classes that are bootstrap 4 compatible. For more information about migrating bootstrap 3 to bootstrap 4, please read the [bootstrap 4 migration page](https://getbootstrap.com/docs/4.0/migration/).

(added to draft by @connoratrug 20-03-2019)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
