### PR TITLE
Fix #8291 Menu manager dataexplorer plugin broken

### DIFF
--- a/molgenis-web/src/main/java/org/molgenis/web/menu/model/MenuItem.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/menu/model/MenuItem.java
@@ -45,7 +45,7 @@ public abstract class MenuItem implements MenuNode {
 
   /** @return the URL of this menu item, which is the combination of its ID and its parameters. */
   public String getUrl() {
-    return Optional.ofNullable(getParams()).map(it -> getId() + "/" + it).orElse(getId());
+    return Optional.ofNullable(getParams()).map(params -> getId() + "?" + params).orElse(getId());
   }
 
   public static MenuItem create(String id, String label) {

--- a/molgenis-web/src/test/java/org/molgenis/web/menu/model/MenuItemTest.java
+++ b/molgenis-web/src/test/java/org/molgenis/web/menu/model/MenuItemTest.java
@@ -1,0 +1,23 @@
+package org.molgenis.web.menu.model;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+import org.testng.annotations.Test;
+
+public class MenuItemTest {
+
+  @Test
+  public void itemWithParams() {
+    MenuItem menuItem = MenuItem.create("id", "label", "params");
+    assertEquals(menuItem.getParams(), "params");
+    assertEquals(menuItem.getUrl(), "id?params");
+  }
+
+  @Test
+  public void itemWithOutParams() {
+    MenuItem menuItem = MenuItem.create("id", "label");
+    assertNull(menuItem.getParams());
+    assertEquals(menuItem.getUrl(), "id");
+  }
+}


### PR DESCRIPTION
Fix #8291 Menu manager dataexplorer plugin broken

- Replace '/' with '?' as start of param list in item uri
- Add test

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
