### PR TITLE
Fix #3154 Error 500 when exceeding the maximum file upload size

### DIFF
--- a/molgenis-web/src/main/java/org/molgenis/web/exception/SpringExceptionHandler.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/exception/SpringExceptionHandler.java
@@ -2,6 +2,7 @@ package org.molgenis.web.exception;
 
 import static org.molgenis.web.exception.ExceptionHandlerUtils.handleException;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.ConstraintViolationException;
@@ -25,6 +26,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 
@@ -35,8 +37,19 @@ public class SpringExceptionHandler {
 
   @SuppressWarnings({"deprecation", "squid:CallToDeprecatedMethod"})
   @ExceptionHandler(NoHandlerFoundException.class)
-  public final Object handleSpringException(Exception ex, HttpServletRequest httpServletRequest) {
+  public final Object handleSpringExceptionNotFound(
+      Exception ex, HttpServletRequest httpServletRequest) {
     return handleException(ex, httpServletRequest, NOT_FOUND, null);
+  }
+
+  @ExceptionHandler(MaxUploadSizeExceededException.class)
+  public final Object handleMaxUploadSizeExceededException(
+      Exception ex, HttpServletRequest httpServletRequest) {
+    Exception cause = ex;
+    while (cause.getCause() instanceof Exception) {
+      cause = (Exception) cause.getCause();
+    }
+    return handleException(cause, httpServletRequest, PAYLOAD_TOO_LARGE, null);
   }
 
   @ExceptionHandler({

--- a/molgenis-web/src/test/java/org/molgenis/web/exception/SpringExceptionHandlerTest.java
+++ b/molgenis-web/src/test/java/org/molgenis/web/exception/SpringExceptionHandlerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.NOT_ACCEPTABLE;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
+import static org.springframework.http.HttpStatus.PAYLOAD_TOO_LARGE;
 import static org.springframework.http.HttpStatus.SERVICE_UNAVAILABLE;
 import static org.springframework.http.HttpStatus.UNSUPPORTED_MEDIA_TYPE;
 import static org.testng.Assert.assertEquals;
@@ -36,6 +37,7 @@ import org.springframework.web.bind.ServletRequestBindingException;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.context.request.async.AsyncRequestTimeoutException;
 import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 import org.springframework.web.servlet.NoHandlerFoundException;
 import org.testng.annotations.BeforeClass;
@@ -49,6 +51,7 @@ public class SpringExceptionHandlerTest extends AbstractMockitoTest {
   @Mock private HandlerMethod handlerMethod;
   @Mock private HttpServletRequest httpServletRequest;
   @Mock private NoHandlerFoundException noHandlerFoundException;
+  @Mock private MaxUploadSizeExceededException maxUploadSizeExceededException;
   @Mock private AsyncRequestTimeoutException asyncRequestTimeoutException;
   @Mock private BindException bindException;
   @Mock private MissingServletRequestPartException missingServletRequestPartException;
@@ -104,10 +107,22 @@ public class SpringExceptionHandlerTest extends AbstractMockitoTest {
     when(noHandlerFoundException.getLocalizedMessage()).thenReturn("localized message");
     when(httpServletRequest.getMethod()).thenReturn("OPTIONS");
     assertEquals(
-        handler.handleSpringException(noHandlerFoundException, httpServletRequest),
+        handler.handleSpringExceptionNotFound(noHandlerFoundException, httpServletRequest),
         new ResponseEntity<>(
             new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
             NOT_FOUND));
+  }
+
+  @Test
+  public void testHandleMaxUploadSizeExceededException() {
+    when(maxUploadSizeExceededException.getLocalizedMessage()).thenReturn("localized message");
+    when(httpServletRequest.getMethod()).thenReturn("OPTIONS");
+    assertEquals(
+        handler.handleMaxUploadSizeExceededException(
+            maxUploadSizeExceededException, httpServletRequest),
+        new ResponseEntity<>(
+            new ErrorMessageResponse(new ErrorMessageResponse.ErrorMessage("localized message")),
+            PAYLOAD_TOO_LARGE));
   }
 
   @Test


### PR DESCRIPTION
This fix requires the following Apache Tomcat configuration change:
- add `maxSwallowSize="536870912"` to all configured connectors

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
