### PR TITLE
Fix #8327 Downloading extending entities fails due to order issues

### DIFF
--- a/molgenis-data-import/src/main/java/org/molgenis/data/export/EmxExportServiceImpl.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/export/EmxExportServiceImpl.java
@@ -11,12 +11,15 @@ import static org.molgenis.data.importer.emx.EmxMetadataParser.EMX_ENTITIES;
 import static org.molgenis.data.importer.emx.EmxMetadataParser.EMX_PACKAGES;
 
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import org.molgenis.data.DataService;
@@ -182,11 +185,19 @@ public class EmxExportServiceImpl implements EmxExportService {
     writer.writeRows(entities.stream().map(DataRowMapper::mapDataRow), entityType.getId());
   }
 
-  private void writeEntityTypes(Iterable<EntityType> entityTypes, XlsxWriter writer) {
+  // package private for test
+  void writeEntityTypes(Collection<EntityType> entityTypes, XlsxWriter writer) {
+    LinkedList<EntityType> sortedEntityTypes = sortEntityTypesAbstractFirst(entityTypes);
     if (!writer.hasSheet(EMX_ENTITIES)) {
       writer.createSheet(EMX_ENTITIES, newArrayList(ENTITIES_ATTRS.keySet()));
     }
-    writer.writeRows(Streams.stream(entityTypes).map(EntityTypeMapper::map), EMX_ENTITIES);
+    writer.writeRows(sortedEntityTypes.stream().map(EntityTypeMapper::map), EMX_ENTITIES);
+  }
+
+  private LinkedList<EntityType> sortEntityTypesAbstractFirst(Collection<EntityType> entityTypes) {
+    LinkedList<EntityType> sortedEntityTypes = Lists.newLinkedList(entityTypes);
+    sortedEntityTypes.sort(Comparator.comparing(EntityType::isAbstract).reversed());
+    return sortedEntityTypes;
   }
 
   private void writeAttributes(Iterable<Attribute> attrs, XlsxWriter writer) {

--- a/molgenis-data-import/src/test/java/org/molgenis/data/export/EmxExportServiceImplTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/export/EmxExportServiceImplTest.java
@@ -8,12 +8,14 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.export.mapper.PackageMapper.PACKAGE_ATTRS;
+import static org.molgenis.data.importer.emx.EmxMetadataParser.EMX_ENTITIES;
 import static org.molgenis.data.importer.emx.EmxMetadataParser.EMX_PACKAGES;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -88,6 +90,34 @@ public class EmxExportServiceImplTest extends AbstractMockitoTest {
 
     assertEquals(packages, expectedPackages);
     assertEquals(entityTypes, expectedEntityTypes);
+  }
+
+  @Test
+  public void writeEntityTypesTest() {
+    EntityType entityType1 = mock(EntityType.class);
+    EntityType entityType2 = mock(EntityType.class);
+    EntityType entityType3 = mock(EntityType.class);
+    EntityType entityType4 = mock(EntityType.class);
+    when(entityType1.isAbstract()).thenReturn(false);
+    when(entityType2.isAbstract()).thenReturn(false);
+    when(entityType3.isAbstract()).thenReturn(true);
+    when(entityType4.isAbstract()).thenReturn(false);
+    when(entityType3.getId()).thenReturn("3");
+
+    LinkedList<EntityType> entityTypes = new LinkedList<>();
+    entityTypes.add(entityType1);
+    entityTypes.add(entityType2);
+    entityTypes.add(entityType3);
+    entityTypes.add(entityType4);
+    XlsxWriter xlsxWriter = mock(XlsxWriter.class);
+    service.writeEntityTypes(entityTypes, xlsxWriter);
+
+    ArgumentCaptor<Stream> argumentCaptor = ArgumentCaptor.forClass(Stream.class);
+    verify(xlsxWriter).writeRows(argumentCaptor.capture(), eq(EMX_ENTITIES));
+    Stream<List> argument = argumentCaptor.getValue();
+    List<Object> actual = argument.collect(Collectors.toList()).get(0);
+    // Check that the abstract entityType comes first in the stream to the writer
+    assertEquals(actual.get(0), "3");
   }
 
   @Test


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
