### PR TITLE
Let metrics classes register themselves at the registry

### DIFF
--- a/molgenis-metrics/src/main/java/org/molgenis/metrics/MeterBindersConfiguration.java
+++ b/molgenis-metrics/src/main/java/org/molgenis/metrics/MeterBindersConfiguration.java
@@ -1,16 +1,26 @@
 package org.molgenis.metrics;
 
+import static java.util.Objects.requireNonNull;
+
+import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.jvm.ClassLoaderMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmGcMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmMemoryMetrics;
 import io.micrometer.core.instrument.binder.jvm.JvmThreadMetrics;
 import io.micrometer.core.instrument.binder.logging.LogbackMetrics;
 import io.micrometer.core.instrument.binder.system.ProcessorMetrics;
+import javax.annotation.PostConstruct;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class MeterBindersConfiguration {
+
+  private MeterRegistry meterRegistry;
+
+  public MeterBindersConfiguration(MeterRegistry meterRegistry) {
+    this.meterRegistry = requireNonNull(meterRegistry);
+  }
 
   @Bean
   public ClassLoaderMetrics classLoaderMetrics() {
@@ -40,5 +50,15 @@ public class MeterBindersConfiguration {
   @Bean
   LogbackMetrics logbackMetrics() {
     return new LogbackMetrics();
+  }
+
+  @PostConstruct
+  private void registerBeans() {
+    classLoaderMetrics().bindTo(meterRegistry);
+    jvmMemoryMetrics().bindTo(meterRegistry);
+    jvmGcMetrics().bindTo(meterRegistry);
+    processorMetrics().bindTo(meterRegistry);
+    jvmThreadMetrics().bindTo(meterRegistry);
+    logbackMetrics().bindTo(meterRegistry);
   }
 }

--- a/molgenis-metrics/src/main/java/org/molgenis/metrics/MetricsConfig.java
+++ b/molgenis-metrics/src/main/java/org/molgenis/metrics/MetricsConfig.java
@@ -3,10 +3,7 @@ package org.molgenis.metrics;
 import static io.micrometer.prometheus.PrometheusConfig.DEFAULT;
 
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.MeterBinder;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import java.util.List;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -16,15 +13,6 @@ public class MetricsConfig {
   @Bean
   public MeterRegistry meterRegistry() {
     return new PrometheusMeterRegistry(DEFAULT);
-  }
-
-  @Autowired // setter injection because of https://github.com/molgenis/molgenis/issues/8037
-  public void setBinders(List<MeterBinder> meterBinders) {
-    if (meterBinders == null) {
-      return;
-    }
-    MeterRegistry meterRegistry = meterRegistry();
-    meterBinders.forEach(binder -> binder.bindTo(meterRegistry));
   }
 
   @Bean

--- a/molgenis-security/src/main/java/org/molgenis/security/metrics/SessionMetrics.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/metrics/SessionMetrics.java
@@ -4,22 +4,23 @@ import static java.util.Objects.requireNonNull;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
-import io.micrometer.core.instrument.binder.MeterBinder;
-import javax.annotation.Nonnull;
+import javax.annotation.PostConstruct;
 import org.molgenis.security.permission.SecurityContextRegistryImpl;
 import org.springframework.stereotype.Component;
 
 @Component
-public class SessionMetrics implements MeterBinder {
+public class SessionMetrics {
 
   private final SecurityContextRegistryImpl sessions;
+  private MeterRegistry meterRegistry;
 
-  SessionMetrics(SecurityContextRegistryImpl sessions) {
+  SessionMetrics(SecurityContextRegistryImpl sessions, MeterRegistry meterRegistry) {
     this.sessions = requireNonNull(sessions);
+    this.meterRegistry = requireNonNull(meterRegistry);
   }
 
-  @Override
-  public void bindTo(@Nonnull MeterRegistry meterRegistry) {
+  @PostConstruct
+  public void bindToRegistry() {
     Gauge.builder("spring.sessions", sessions, SessionMetrics::getSessions)
         .description("The number of sessions, including expired sessions")
         .register(meterRegistry);


### PR DESCRIPTION
We still see bootstrapping issues now and again, like described here:
https://github.com/molgenis/molgenis/issues/8037

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
