### PR TITLE
Fix #8190: Default logo does not match default style

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/settings/AppDbSettings.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/settings/AppDbSettings.java
@@ -52,7 +52,7 @@ public class AppDbSettings extends DefaultSettingsEntity implements AppSettings 
     private static final String AGGREGATE_THRESHOLD = "aggregate_threshold";
 
     private static final String DEFAULT_TITLE = "MOLGENIS";
-    private static final String DEFAULT_LOGO_NAVBAR_HREF = "/img/Logo_Black_Small.png";
+    private static final String DEFAULT_LOGO_NAVBAR_HREF = "/img/Logo_Blue_Small.png";
     private static final Integer DEFAULT_LOGO_TOP_MAX_HEIGHT = 150;
     private static final String DEFAULT_LANGUAGE_CODE = "en";
     private static final String DEFAULT_BOOTSTRAP_THEME = "bootstrap-molgenis-blue.min.css";


### PR DESCRIPTION
Fixes #8190: Default logo does not match default style

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
