### PR TITLE
fix(data-row-edit): fix 8356

### DIFF
--- a/molgenis-data-row-edit/src/main/resources/l10n/data-row-edit_en.properties
+++ b/molgenis-data-row-edit/src/main/resources/l10n/data-row-edit_en.properties
@@ -4,3 +4,8 @@ data-row-edit-invalid-fields-msg=Cannot save, this row contains invalid values.
 data-row-edit-cancel-button-label=Cancel
 data-row-edit-default-error-message=An error has occurred.
 
+# Form boolean labels (used to call FormMapper)
+data-row-edit-boolean-true=Yes
+data-row-edit-boolean-false=No
+data-row-edit-boolean-null=Don't know
+

--- a/molgenis-data-row-edit/src/main/resources/l10n/data-row-edit_nl.properties
+++ b/molgenis-data-row-edit/src/main/resources/l10n/data-row-edit_nl.properties
@@ -3,3 +3,8 @@ data-row-edit-save-busy-state-label=Opslaan...
 data-row-edit-invalid-fields-msg=Opslaan niet mogenlijk, deze rij bevat invalide waarden.
 data-row-edit-cancel-button-label=Annuleren
 data-row-edit-default-error-message=Er is een fout opgetreden.
+
+# Form boolean labels (used to call FormMapper)
+data-row-edit-boolean-true=Ja
+data-row-edit-boolean-false=Nee
+data-row-edit-boolean-null=Weet ik niet 


### PR DESCRIPTION
Add boolean label translations for data-row-edit plugin

Fix #8356 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
