### PR TITLE
Fix #8402 ScriptJob fails when scheduled, succeeds when started manually

### DIFF
--- a/molgenis-scripts/src/main/java/org/molgenis/script/ScheduledScriptConfig.java
+++ b/molgenis-scripts/src/main/java/org/molgenis/script/ScheduledScriptConfig.java
@@ -46,11 +46,9 @@ public class ScheduledScriptConfig {
       @Override
       public Job<ScriptResult> createJob(ScriptJobExecution scriptJobExecution) {
         final String name = scriptJobExecution.getName();
-        final String parameterString = scriptJobExecution.getParameters();
         return progress -> {
-          Map<String, Object> params = new HashMap<>();
-          params.putAll(gson.fromJson(parameterString, MAP_TOKEN));
-          params.put("scriptJobExecutionId", scriptJobExecution.getIdValue());
+          Map<String, Object> params = getParameterMap(scriptJobExecution);
+
           ScriptResult scriptResult = savedScriptRunner.runScript(name, params);
           if (scriptResult.getOutputFile() != null) {
             scriptJobExecution.setResultUrl(
@@ -61,6 +59,16 @@ public class ScheduledScriptConfig {
         };
       }
     };
+  }
+
+  Map<String, Object> getParameterMap(ScriptJobExecution scriptJobExecution) {
+    Map<String, Object> params = new HashMap<>();
+    final String parameterString = scriptJobExecution.getParameters();
+    if (!parameterString.isEmpty()) {
+      params.putAll(gson.fromJson(parameterString, MAP_TOKEN));
+    }
+    params.put("scriptJobExecutionId", scriptJobExecution.getIdValue());
+    return params;
   }
 
   @Lazy

--- a/molgenis-scripts/src/test/java/org/molgenis/script/ScheduledScriptConfigTest.java
+++ b/molgenis-scripts/src/test/java/org/molgenis/script/ScheduledScriptConfigTest.java
@@ -1,0 +1,58 @@
+package org.molgenis.script;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+import com.google.gson.Gson;
+import java.util.HashMap;
+import java.util.Map;
+import org.mockito.Mock;
+import org.molgenis.jobs.model.ScheduledJobTypeFactory;
+import org.molgenis.test.AbstractMockitoTest;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class ScheduledScriptConfigTest extends AbstractMockitoTest {
+
+  @Mock SavedScriptRunner savedScriptRunner;
+  @Mock ScheduledJobTypeFactory scheduledJobTypeFactory;
+  @Mock ScriptJobExecutionMetadata scriptJobExecutionMetadata;
+
+  private ScheduledScriptConfig scheduledJobConfig;
+
+  @BeforeMethod
+  public void setUp() {
+    this.scheduledJobConfig =
+        new ScheduledScriptConfig(
+            savedScriptRunner, scheduledJobTypeFactory, scriptJobExecutionMetadata, new Gson());
+  }
+
+  @Test
+  public void testGetParameterMap() {
+    ScriptJobExecution scriptJobExecution = mock(ScriptJobExecution.class);
+    when(scriptJobExecution.getParameters()).thenReturn("{param1:test,param2:value}");
+    when(scriptJobExecution.getIdValue()).thenReturn("scriptJobExecutionIdentifier");
+
+    Map<String, Object> actual = scheduledJobConfig.getParameterMap(scriptJobExecution);
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("param1", "test");
+    expected.put("param2", "value");
+    expected.put("scriptJobExecutionId", "scriptJobExecutionIdentifier");
+
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testGetParameterMapEmptyString() {
+    ScriptJobExecution scriptJobExecution = mock(ScriptJobExecution.class);
+    when(scriptJobExecution.getParameters()).thenReturn("");
+    when(scriptJobExecution.getIdValue()).thenReturn("scriptJobExecutionIdentifier");
+
+    Map<String, Object> actual = scheduledJobConfig.getParameterMap(scriptJobExecution);
+    Map<String, Object> expected = new HashMap<>();
+    expected.put("scriptJobExecutionId", "scriptJobExecutionIdentifier");
+
+    assertEquals(actual, expected);
+  }
+}


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
