### PR TITLE
Fix docs: nillable default in EMX should be true

### DIFF
--- a/docs/user_documentation/import-data/ref-emx.md
+++ b/docs/user_documentation/import-data/ref-emx.md
@@ -147,7 +147,7 @@ Defines the data type (default: string)
 Used in combination with xref, mref, categorical, categorical_mref or one_to_many. Should refer to an entity.
 
 #### nillable 
-Whether the column may be left empty. Default: false
+Whether the column may be left empty. Default: true
 
 #### idAttribute 
 Whether this field is the unique key for the entity. Default: false. Use 'AUTO' for auto generated (string) identifiers.


### PR DESCRIPTION
#### Checklist
- Functionality works & meets specifications
- Code reviewed
- Code unit/integration/system tested
- [x] User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
