### PR TITLE
[FIX] RPM molgenis-server.properties generation is updated

### DIFF
--- a/molgenis-app/pom.xml
+++ b/molgenis-app/pom.xml
@@ -70,7 +70,7 @@
           <mappings>
             <mapping>
               <directory>/usr/local/share/molgenis/war</directory>
-              <filemode>700</filemode>
+              <filemode>755</filemode>
               <username>molgenis</username>
               <groupname>molgenis</groupname>
               <sources>

--- a/molgenis-app/rpm/postinstall.bash
+++ b/molgenis-app/rpm/postinstall.bash
@@ -31,7 +31,7 @@ echo "--------------------------------------------------"
 echo "[INFO] Determine if there is a molgenis-server.properties"
 if [[ -z ${INTERACTIVE} ]]
 then
-  "[WARN] Set interactive mode default to true"
+  echo "[WARN] Set interactive mode default to true"
   INTERACTIVE=true
 fi
 if [[ ! -f ${MOLGENIS_HOME}/molgenis-server.properties ]]

--- a/molgenis-app/rpm/postinstall.bash
+++ b/molgenis-app/rpm/postinstall.bash
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-INTERACTIVE=true
 MOLGENIS_HOME=/home/molgenis/
 
 DB_USER=molgenis
@@ -30,8 +29,15 @@ cp -rp /usr/local/share/molgenis/war/ROOT.war /usr/share/tomcat/webapps/ROOT.war
 
 echo "--------------------------------------------------"
 echo "[INFO] Determine if there is a molgenis-server.properties"
-if [[ ! -f ${MOLGENIS_HOME}/molgenis-server.properties ]]; then
-  if [[ ${INTERACTIVE} -eq "true" ]]; then
+if [[ -z ${INTERACTIVE} ]]
+then
+  "[WARN] Set interactive mode default to true"
+  INTERACTIVE=true
+fi
+if [[ ! -f ${MOLGENIS_HOME}/molgenis-server.properties ]]
+then
+  if [[ ${INTERACTIVE} -eq "true" ]]
+  then
     echo "[INFO] Configure [ molgenis-server.properties ]"
     echo "*****************************************"
     read -p "Enter database user: " DB_USER
@@ -47,7 +53,8 @@ if [[ ! -f ${MOLGENIS_HOME}/molgenis-server.properties ]]; then
   else
     "[INFO] Running in non-interactive mode"
     "[INFO] Generate a [ molgenis-server.properties ] file"
-    sed -e "s|__DB_USER__|${DB_USER}|" \
+  fi
+  sed -e "s|__DB_USER__|${DB_USER}|" \
       -e "s|__DB_PASSWORD__|${DB_PASSWORD}|" \
       -e "s|__ADMIN_PASSWORD__|${ADMIN_PASSWORD}|" \
       -e "s|__MAIL_USER__|${MAIL_USER}|" \
@@ -58,7 +65,6 @@ if [[ ! -f ${MOLGENIS_HOME}/molgenis-server.properties ]]; then
       -e "s|__MINIO_SECRET_KEY__|${MINIO_SECRET_KEY}|" \
       -e "s|__MINIO_REGION__|${MINIO_REGION}|" \
       /usr/local/share/molgenis/templates/molgenis-server.properties > ${MOLGENIS_HOME}/molgenis-server.properties
-  fi
 else
   echo "[INFO] molgenis-server.properties already exists"
 fi

--- a/molgenis-app/rpm/postinstall.bash
+++ b/molgenis-app/rpm/postinstall.bash
@@ -29,31 +29,8 @@ cp -rp /usr/local/share/molgenis/war/ROOT.war /usr/share/tomcat/webapps/ROOT.war
 
 echo "--------------------------------------------------"
 echo "[INFO] Determine if there is a molgenis-server.properties"
-if [[ -z ${INTERACTIVE} ]]
-then
-  echo "[WARN] Set interactive mode default to true"
-  INTERACTIVE=true
-fi
 if [[ ! -f ${MOLGENIS_HOME}/molgenis-server.properties ]]
 then
-  if [[ ${INTERACTIVE} -eq "true" ]]
-  then
-    echo "[INFO] Configure [ molgenis-server.properties ]"
-    echo "*****************************************"
-    read -p "Enter database user: " DB_USER
-    read -p "Enter database password: " DB_PASSWORD
-    read -p "Enter admin password: " ADMIN_PASSWORD
-    read -p "Enter mail username: " MAIL_USER
-    read -p "Enter mail password: " MAIL_PASSWORD
-    read -p "Enter Minio bucket name: " MINIO_BUCKET_NAME
-    read -p "Enter Minio endpoint: " MINIO_ENDPOINT
-    read -p "Enter Minio access key: " MINIO_ACCESS_KEY
-    read -p "Enter Minio secret key: " MINIO_SECRET_KEY
-    read -p "Enter Minio region: " MINIO_REGION
-  else
-    "[INFO] Running in non-interactive mode"
-    "[INFO] Generate a [ molgenis-server.properties ] file"
-  fi
   sed -e "s|__DB_USER__|${DB_USER}|" \
       -e "s|__DB_PASSWORD__|${DB_PASSWORD}|" \
       -e "s|__ADMIN_PASSWORD__|${ADMIN_PASSWORD}|" \

--- a/molgenis-app/rpm/preinstall.bash
+++ b/molgenis-app/rpm/preinstall.bash
@@ -6,11 +6,25 @@ echo "########################################"
 echo "[INFO] Cleanup old packages"
 rm -rf /usr/local/share/molgenis/war/*.war
 echo "[INFO] Add new user molgenis (in group: molgenis)"
-if [[ $(getent passwd molgenis) ]]; then
+if [[ $(getent passwd molgenis) ]]
+then
   echo "[WARN] User 'molgenis' already exists"
 else
-  useradd molgenis:molgenis
+  groupadd molgenis
+  useradd molgenis -g molgenis
 fi
+
+TOMCAT_INSTALLED==$(rpm -qa | grep tomcat)
+if [[ ! -z ${TOMCAT_INSTALLED} ]]
+then
+  echo "[INFO] Tomcat is installed"
+  echo "[INFO] Add tomcat-user to molgenis-group to be able to write in MOLGENIS-homedir"
+  usermod -g molgenis tomcat
+  echo "[INFO] Allow users other than the user molgenis to write in molgenis-homedir"
+  echo "[INFO] If they are part of the molgenis-group"
+  chmod -R 770 /home/molgenis
+fi
+
 echo "----------------------------------------"
 echo "PREINSTALL - MOLGENIS - finished"
 echo "########################################"


### PR DESCRIPTION
- Interactive-mode is deleted, this is not a good practise as RPM's should be non-interactive always
- Added tomcat-user to molgenis group to be able to write to /home/molgenis
- Added chmod 770 (read/write for molgenis group) to /home/molgenis

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
