### PR TITLE
Migration step for adding the new settings plugin to the menu

### DIFF
--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/bootstrap/MolgenisUpgradeBootstrapper.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/bootstrap/MolgenisUpgradeBootstrapper.java
@@ -9,6 +9,7 @@ import org.molgenis.data.migrate.version.Step33UpdateForeignKeyDeferred;
 import org.molgenis.data.migrate.version.Step34AddRoleMetrics;
 import org.molgenis.data.migrate.version.Step35UpdateAclSystemSid;
 import org.molgenis.data.migrate.version.Step36EnableDataRowEdit;
+import org.molgenis.data.migrate.version.Step37AddSettingsPluginToMenu;
 import org.springframework.stereotype.Component;
 
 /** Registers and executes {@link MolgenisUpgrade upgrades} during application bootstrapping. */
@@ -27,6 +28,7 @@ public class MolgenisUpgradeBootstrapper {
     upgradeService.addUpgrade(new Step34AddRoleMetrics(dataSource));
     upgradeService.addUpgrade(new Step35UpdateAclSystemSid(dataSource));
     upgradeService.addUpgrade(new Step36EnableDataRowEdit(dataSource));
+    upgradeService.addUpgrade(new Step37AddSettingsPluginToMenu(dataSource));
 
     upgradeService.upgrade();
   }

--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/MolgenisVersionService.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/MolgenisVersionService.java
@@ -17,11 +17,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class MolgenisVersionService {
   /** package-private for testability */
-  static final int VERSION = 36;
+  static final int VERSION = 37;
 
   private final DataSource dataSource;
 
-  public MolgenisVersionService(DataSource dataSource) {
+  MolgenisVersionService(DataSource dataSource) {
     this.dataSource = requireNonNull(dataSource);
   }
 

--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/Step37AddSettingsPluginToMenu.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/Step37AddSettingsPluginToMenu.java
@@ -1,0 +1,65 @@
+package org.molgenis.data.migrate.version;
+
+import static java.util.Objects.requireNonNull;
+
+import javax.sql.DataSource;
+import org.molgenis.data.migrate.framework.MolgenisUpgrade;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class Step37AddSettingsPluginToMenu extends MolgenisUpgrade {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Step37AddSettingsPluginToMenu.class);
+
+  private final DataSource dataSource;
+
+  public Step37AddSettingsPluginToMenu(DataSource dataSource) {
+    super(36, 37);
+    this.dataSource = requireNonNull(dataSource);
+  }
+
+  @Override
+  public void upgrade() {
+    LOG.debug("Adding the settings plugin to the menu ...");
+    addSettingsPluginToMenu();
+  }
+
+  private void addSettingsPluginToMenu() {
+    JdbcTemplate jdbcTemplate = new JdbcTemplate(dataSource);
+    String menuString = getMenuString(jdbcTemplate);
+
+    if (hasSettingsPlugin(menuString)) {
+      LOG.info("Settings plugin already in the menu. No further action required.");
+    } else {
+      String newMenu = replaceOldPlugin(menuString);
+      updateMenuInDatabase(jdbcTemplate, newMenu);
+      LOG.info("Added settings plugin to the menu.");
+    }
+  }
+
+  private static boolean hasSettingsPlugin(String menuString) {
+    return menuString.contains("\"type\":\"plugin\",\"id\":\"settings\"");
+  }
+
+  /**
+   * Replaces the old settings plugin with the new settings plugin. Doing it this way makes sure the
+   * position of the plugin stays consistent. If the menu doesn't contain a settings plugin, the new
+   * plugin won't be added.
+   */
+  private static String replaceOldPlugin(String menuString) {
+    return menuString.replace(
+        "\"type\":\"plugin\",\"id\":\"settingsmanager\"",
+        "\"type\":\"plugin\",\"id\":\"settings\"");
+  }
+
+  private String getMenuString(JdbcTemplate jdbcTemplate) {
+    return jdbcTemplate.queryForObject(
+        "SELECT molgenis_menu FROM public.\"sys_set_app#4f91996f\"", String.class);
+  }
+
+  private static void updateMenuInDatabase(JdbcTemplate jdbcTemplate, String menuString) {
+    jdbcTemplate.update(
+        "UPDATE public.\"sys_set_app#4f91996f\" SET \"molgenis_menu\" = ?", menuString);
+  }
+}


### PR DESCRIPTION
If the new settings plugin was already in the menu -> nothing happens
If the old settings plugin was in the menu -> it is replaced with the new one
If there was no settings plugin in the menu -> nothing happens

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
