### PR TITLE
Fix #8474: R script cannot use token to connect to molgenis API

### DIFF
--- a/molgenis-r/pom.xml
+++ b/molgenis-r/pom.xml
@@ -46,5 +46,10 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.jayway.jsonpath</groupId>
+      <artifactId>json-path</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/molgenis-r/src/main/java/org/molgenis/r/MolgenisRController.java
+++ b/molgenis-r/src/main/java/org/molgenis/r/MolgenisRController.java
@@ -20,7 +20,8 @@ public class MolgenisRController {
     }
 
     model.addAttribute(
-        "api_url", ServletUriComponentsBuilder.fromCurrentRequest().path(API_URI).toUriString());
+        "api_url",
+        ServletUriComponentsBuilder.fromCurrentContextPath().path(API_URI).toUriString());
 
     return "molgenis.R";
   }

--- a/molgenis-r/src/test/java/org/molgenis/r/MolgenisRControllerTest.java
+++ b/molgenis-r/src/test/java/org/molgenis/r/MolgenisRControllerTest.java
@@ -1,0 +1,52 @@
+package org.molgenis.r;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+
+import org.molgenis.security.token.TokenExtractor;
+import org.molgenis.test.AbstractMockitoTest;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.servlet.view.json.MappingJackson2JsonView;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MolgenisRControllerTest extends AbstractMockitoTest {
+
+  private MockMvc mockMvc;
+
+  @BeforeMethod
+  public void beforeTest() {
+    MolgenisRController controller = new MolgenisRController();
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            // use a json view to easily test the model values that get set
+            .setSingleView(new MappingJackson2JsonView())
+            .setCustomArgumentResolvers(new TokenExtractor())
+            .build();
+  }
+
+  @Test
+  public void testShowMolgenisRApiClientWithTokenParam() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/molgenis.R?molgenis-token=abcde"))
+        .andExpect(jsonPath("$.api_url").value("http://localhost/api/"))
+        .andExpect(jsonPath("$.token").value("abcde"));
+  }
+
+  @Test
+  public void testShowMolgenisRApiClientWithTokenHeader() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/molgenis.R").header("X-Molgenis-Token", "abcde"))
+        .andExpect(jsonPath("$.api_url").value("http://localhost/api/"))
+        .andExpect(jsonPath("$.token").value("abcde"));
+  }
+
+  @Test
+  public void testShowMolgenisRApiClientWithoutToken() throws Exception {
+    mockMvc
+        .perform(MockMvcRequestBuilders.get("/molgenis.R"))
+        .andExpect(jsonPath("$.api_url").value("http://localhost/api/"))
+        .andExpect(jsonPath("$.token").doesNotExist());
+  }
+}


### PR DESCRIPTION
Fixes #8474

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
