### PR TITLE
Fix #8347: Footer is rendered on top of plugin

### DIFF
--- a/molgenis-core-ui/src/main/resources/css/bootstrap-4/footer/sticky-footer.css
+++ b/molgenis-core-ui/src/main/resources/css/bootstrap-4/footer/sticky-footer.css
@@ -1,14 +1,55 @@
+/**
+ * Uses flexbox to create footer with variable height that stick to the bottom of the page
+ * mg-page is the flex container that flexes in horizontal direction
+ * mg-page-content takes all the space left
+ * footer is put below mg-page-content inside mg-page
+ *
+ *  ------------------------------------------
+ *  | mg-page                                |
+ *  |  ------------------------------------  |
+ *  |  | mg-page-content                  |  |
+ *  |  |                                  |  |
+ *  |  |                                  |  |
+ *  |  |                                  |  |
+ *  |  |                                  |  |
+ *  |  |                                  |  |
+ *  |  |                                  |  |
+ *  |  ------------------------------------  |
+ *  |  ------------------------------------  |
+ *  |  |footer                            |  |
+ *  |  |                                  |  |
+ *  |  |                                  |  |
+ *  |  ------------------------------------  |
+ *  |                                        |
+ *  ------------------------------------------
+ *
+ * 1. Avoid the IE 10-11 `min-height` bug.
+ * 2. Set `flex-shrink` to `0` to prevent some browsers from
+ *    letting these items shrink to smaller than their content's default
+ *    minimum size. See http://bit.ly/1Mn35US for details.
+ * 3. Use `%` instead of `vh` since `vh` is buggy in older mobile Safari.
+ */
 html {
-    position: relative;
-    min-height: 100%;
+    height: 100%;
 }
 
-body {
-    margin-bottom: 60px;
+.mg-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%; /* 1, 3 */
 }
 
 .footer {
-    position: absolute;
-    bottom: 0;
-    width: 100%;
+    flex: none; /* 2 */
+    padding-top: 1rem;
+}
+
+.mg-page-content {
+    flex: 1 0 auto; /* 2 */
+}
+.mg-page-content::after {
+    content: '\00a0'; /* &nbsp; */
+    display: block;
+    height: 0px;
+    visibility: hidden;
 }

--- a/molgenis-core-ui/src/main/resources/templates/molgenis-header.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/molgenis-header.ftl
@@ -88,7 +88,7 @@
     <#include "molgenis-header-tracking.ftl"><#-- before closing </head> tag -->
 </head>
 
-<body>
+<body class="mg-page">
     <#if !(version??) || version == 1>
         <#-- Navbar menu -->
         <#if menu_id??>
@@ -124,7 +124,7 @@
     </#if>
 
 <#-- Start application content -->
-<div class="container-fluid"
+<div class="container-fluid mg-page-content"
      style="padding-top: <#if app_settings.logoTopHref?? && (!version?? ||version == 1)>${app_settings.logoTopMaxHeight + 60}<#else>60</#if>px;">
     <div class="row">
         <div class="col-md-12">


### PR DESCRIPTION
Use flex box to have variable height footer instead of fixed padding height

https://preview-pr-8479-1.dev.molgenis.org/

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
