### PR TITLE
Bump frontend with new version of frontend packages

### DIFF
--- a/molgenis-frontend/package.json
+++ b/molgenis-frontend/package.json
@@ -4,16 +4,16 @@
   "license": "LGPL-3.0",
   "dependencies": {
     "@molgenis/app-manager": "0.1.1",
-    "@molgenis/core-ui": "^0.2.3",
-    "@molgenis/data-row-edit": "^1.0.1",
-    "@molgenis/menu": "^0.1.3",
-    "@molgenis/metadata-manager": "^0.1.2",
+    "@molgenis/core-ui": "0.2.3",
+    "@molgenis/data-row-edit": "2.0.0",
+    "@molgenis/menu": "0.1.3",
+    "@molgenis/metadata-manager": "0.1.2",
     "@molgenis/navigator": "0.1.1",
-    "@molgenis/one-click-importer": "^0.1.2",
+    "@molgenis/one-click-importer": "0.1.2",
     "@molgenis/questionnaires": "1.0.0",
-    "@molgenis/scripts": "^1.0.1",
+    "@molgenis/scripts": "1.0.1",
     "@molgenis/searchall": "0.1.2",
-    "@molgenis/security": "^0.1.3",
-    "@molgenis/settings": "^1.0.1"
+    "@molgenis/security": "0.1.3",
+    "@molgenis/settings": "1.0.2"
   }
 }


### PR DESCRIPTION
Version bumps:
- @molgenis/data-row-edit: 1.0.1 => 2.0.0
- @molgenis/settings: 1.0.1 => 1.0.2
- @molgenis/scripts: 1.0.1 => 1.0.2

Fix #8464 Cannot add new token without first clearing expiration date
Fix #8469 Double invalid value message when filling out data row
Fix #8470 Nullable expresion test in data row edit results in error

Note data-row-edit is non breaking but due to issue with automagic version schema

Remove caret from version schema to lock down version

Fix #8475 Frontend dependencies are listed using imprecise version

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
