### PR TITLE
Bump frontend menu 1.0.4 to 1.0.5; Fix #8481 Header is not sticky in new pages

### DIFF
--- a/molgenis-frontend/package.json
+++ b/molgenis-frontend/package.json
@@ -6,7 +6,7 @@
     "@molgenis/app-manager": "0.1.1",
     "@molgenis/core-ui": "0.2.3",
     "@molgenis/data-row-edit": "2.0.0",
-    "@molgenis/menu": "0.1.4",
+    "@molgenis/menu": "0.1.5",
     "@molgenis/metadata-manager": "0.1.2",
     "@molgenis/navigator": "0.1.1",
     "@molgenis/one-click-importer": "0.1.2",


### PR DESCRIPTION
Version bumps:
- @molgenis/menu: 1.0.4 => 1.0.5

Fix #8481 Header is not sticky in new pages

preview: https://preview-pr-8496-1.dev.molgenis.org/

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
