### PR TITLE
Fix #8502: Spring security beans are not using the molgenis roleHierarchy

### DIFF
--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/DataserviceRoleHierarchy.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/DataserviceRoleHierarchy.java
@@ -30,9 +30,7 @@ import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.stereotype.Component;
 
-@Component
 public class DataserviceRoleHierarchy implements RoleHierarchy {
   private static final Logger LOG = LoggerFactory.getLogger(DataserviceRoleHierarchy.class);
   private static final int PAGE_SIZE = 1000;

--- a/molgenis-security/src/main/java/org/springframework/security/acls/jdbc/AclConfig.java
+++ b/molgenis-security/src/main/java/org/springframework/security/acls/jdbc/AclConfig.java
@@ -21,14 +21,17 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.acls.AclPermissionEvaluator;
 import org.springframework.security.acls.domain.AclAuthorizationStrategy;
 import org.springframework.security.acls.domain.AclAuthorizationStrategyImpl;
 import org.springframework.security.acls.domain.AuditLogger;
+import org.springframework.security.acls.domain.SidRetrievalStrategyImpl;
 import org.springframework.security.acls.domain.SpringCacheBasedAclCache;
 import org.springframework.security.acls.model.AclCache;
 import org.springframework.security.acls.model.MutableAclService;
 import org.springframework.security.acls.model.PermissionGrantingStrategy;
+import org.springframework.security.acls.model.SidRetrievalStrategy;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
@@ -37,15 +40,23 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
  * https://github.com/spring-projects/spring-security/issues/4814.
  */
 @Configuration
-@Import(DataSourceConfig.class)
+@Import({DataSourceConfig.class})
 public class AclConfig {
   private final DataSource dataSource;
   private final TransactionManager transactionManager;
+  private final RoleHierarchy roleHierarchy;
   @Autowired JdbcTemplate jdbcTemplate;
 
-  public AclConfig(DataSource dataSource, TransactionManager transactionManager) {
+  public AclConfig(
+      DataSource dataSource, TransactionManager transactionManager, RoleHierarchy roleHierarchy) {
     this.dataSource = requireNonNull(dataSource);
     this.transactionManager = requireNonNull(transactionManager);
+    this.roleHierarchy = requireNonNull(roleHierarchy);
+  }
+
+  @Bean
+  public SidRetrievalStrategy sidRetrievalStrategy() {
+    return new SidRetrievalStrategyImpl(roleHierarchy);
   }
 
   @Bean
@@ -66,7 +77,10 @@ public class AclConfig {
         new SimpleGrantedAuthority(SecurityUtils.ROLE_ACL_MODIFY_AUDITING);
     GrantedAuthority gaGeneralChanges =
         new SimpleGrantedAuthority(SecurityUtils.ROLE_ACL_GENERAL_CHANGES);
-    return new AclAuthorizationStrategyImpl(gaTakeOwnership, gaModifyAuditing, gaGeneralChanges);
+    AclAuthorizationStrategyImpl aclAuthorizationStrategy =
+        new AclAuthorizationStrategyImpl(gaTakeOwnership, gaModifyAuditing, gaGeneralChanges);
+    aclAuthorizationStrategy.setSidRetrievalStrategy(sidRetrievalStrategy());
+    return aclAuthorizationStrategy;
   }
 
   @Bean
@@ -127,6 +141,8 @@ public class AclConfig {
 
   @Bean
   public AclPermissionEvaluator aclPermissionEvaluator() {
-    return new AclPermissionEvaluator(aclService());
+    AclPermissionEvaluator permissionEvaluator = new AclPermissionEvaluator(aclService());
+    permissionEvaluator.setSidRetrievalStrategy(sidRetrievalStrategy());
+    return permissionEvaluator;
   }
 }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [n.a.] Code unit/integration/system tested
- [n.a.] Migration step added in case of breaking change
- [n.a.] User documentation updated
- [n.a.] (If you have changed REST API interface) view-swagger.ftl updated
- [n.a.] Test plan template updated
- [x] Clean commits
- [n.a.] Added Feature/Fix to release notes
