### PR TITLE
Fix #8511: Index manager is still present in default menu

### DIFF
--- a/molgenis-app/src/main/resources/molgenis_ui.json
+++ b/molgenis-app/src/main/resources/molgenis_ui.json
@@ -111,11 +111,6 @@
       "items": [
         {
           "type": "plugin",
-          "id": "indexmanager",
-          "label": "Index manager"
-        },
-        {
-          "type": "plugin",
           "id": "logmanager",
           "label": "Log manager"
         },


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
