### PR TITLE
[FIX] Add the skeleton configuration files to home of molgenis

### DIFF
--- a/molgenis-app/rpm/preinstall.bash
+++ b/molgenis-app/rpm/preinstall.bash
@@ -11,7 +11,7 @@ then
   echo "[WARN] User 'molgenis' already exists"
 else
   groupadd molgenis
-  useradd molgenis -g molgenis
+  adduser molgenis -g molgenis --create-home
 fi
 
 TOMCAT_INSTALLED==$(rpm -qa | grep tomcat)


### PR DESCRIPTION
When you create a user the home directory of that user should be populated based upon the /etc/skel configuration. 

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
