### PR TITLE
Fix #8548: Redirect plugin can redirect to URLs that are not present in the menu

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/RedirectController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/RedirectController.java
@@ -1,6 +1,16 @@
 package org.molgenis.core.ui.controller;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.message.BasicNameValuePair;
 import org.molgenis.web.PluginController;
+import org.molgenis.web.menu.MenuReaderService;
+import org.molgenis.web.menu.model.MenuItem;
+import org.molgenis.web.menu.model.MenuNode;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,12 +31,42 @@ public class RedirectController extends PluginController {
   public static final String ID = "redirect";
   public static final String URI = PluginController.PLUGIN_URI_PREFIX + ID;
 
-  public RedirectController() {
+  private final MenuReaderService menuReaderService;
+
+  public RedirectController(MenuReaderService menuReaderService) {
     super(URI);
+    this.menuReaderService = menuReaderService;
+  }
+
+  /**
+   * Indicates if a MenuNode is a redirect menu item with specified URL.
+   *
+   * @param node the MenuNode to test
+   * @param url the URL that should match
+   * @return boolean indicating if they match
+   */
+  static boolean nodeMatches(MenuNode node, String url) {
+    return node instanceof MenuItem && itemMatches((MenuItem) node, url);
+  }
+
+  private static boolean itemMatches(MenuItem menuItem, String url) {
+    return ID.equals(menuItem.getId()) && paramsMatch(menuItem.getParams(), url);
+  }
+
+  private static boolean paramsMatch(String params, String url) {
+    NameValuePair expected = new BasicNameValuePair("url", url);
+    List<NameValuePair> paramPairs = URLEncodedUtils.parse(params, UTF_8);
+    return paramPairs.contains(expected);
   }
 
   @GetMapping
-  public View redirect(@RequestParam("url") String url) {
+  public View redirect(@RequestParam("url") String url) throws AccessDeniedException {
+    if (!menuReaderService
+        .getMenu()
+        .filter(menu -> menu.contains(node -> nodeMatches(node, url)))
+        .isPresent()) {
+      throw new AccessDeniedException("URL not present in menu!");
+    }
     return new RedirectView(url, false, false, false);
   }
 }

--- a/molgenis-core-ui/src/test/java/org/molgenis/core/ui/controller/RedirectControllerTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/core/ui/controller/RedirectControllerTest.java
@@ -1,0 +1,75 @@
+package org.molgenis.core.ui.controller;
+
+import static org.mockito.Mockito.when;
+import static org.molgenis.core.ui.controller.RedirectController.ID;
+import static org.molgenis.core.ui.controller.RedirectController.nodeMatches;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import java.nio.file.AccessDeniedException;
+import java.util.Optional;
+import org.mockito.Mock;
+import org.molgenis.test.AbstractMockitoTest;
+import org.molgenis.web.menu.MenuReaderService;
+import org.molgenis.web.menu.model.Menu;
+import org.molgenis.web.menu.model.MenuItem;
+import org.springframework.web.servlet.view.RedirectView;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RedirectControllerTest extends AbstractMockitoTest {
+
+  private RedirectController redirectController;
+
+  private MenuItem item = MenuItem.create(ID, "Procrastinate!", "url=https://nu.nl/?a%3Db%26c%3Dd");
+  private MenuItem userManual =
+      MenuItem.create(
+          ID,
+          "User Manual",
+          "url\u003dhttps://drive.google.com/file/d/abcde/view?usp\u003dsharing");
+
+  Menu menu = Menu.create("main", "Main", ImmutableList.of(item, userManual));
+
+  @Mock private MenuReaderService menuReaderService;
+
+  @BeforeMethod
+  public void beforeMethod() {
+    redirectController = new RedirectController(menuReaderService);
+  }
+
+  @Test
+  public void testNodeMatchesUrlEncoded() {
+    assertTrue(nodeMatches(item, "https://nu.nl/?a=b&c=d"));
+  }
+
+  @Test
+  public void testNodeMatchesEscapeEqualsCharacter() {
+    assertTrue(nodeMatches(userManual, "https://drive.google.com/file/d/abcde/view?usp=sharing"));
+  }
+
+  @Test
+  public void testNodeMatchesWrongID() {
+    assertFalse(nodeMatches(MenuItem.create("wrong-id", "Wrong ID"), "https://nu.nl/"));
+  }
+
+  @Test
+  public void testNodeMatchesNotAMenuItem() {
+    assertFalse(nodeMatches(menu, "https://nu.nl/"));
+  }
+
+  @Test(expectedExceptions = AccessDeniedException.class)
+  public void testRedirectToUnknownSite() throws AccessDeniedException {
+    when(menuReaderService.getMenu()).thenReturn(Optional.of(menu));
+    redirectController.redirect("https://rogue.com/");
+  }
+
+  @Test
+  public void testCorrectRedirect() throws AccessDeniedException {
+    when(menuReaderService.getMenu()).thenReturn(Optional.of(menu));
+    String url = "https://nu.nl/?a=b&c=d";
+    RedirectView response = (RedirectView) redirectController.redirect(url);
+    assertEquals(response.getUrl(), url);
+  }
+}


### PR DESCRIPTION
Fixes #8548

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
