### PR TITLE
Fix #8505 Search operator inconsistent search-all vs search-attribute

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseGenerator.java
@@ -1,0 +1,238 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.toList;
+
+import com.google.common.collect.Streams;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.Entity;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.IllegalAttributeTypeException;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+abstract class BaseQueryClauseGenerator implements QueryClauseGenerator {
+  private final Operator operator;
+
+  static final String ATTRIBUTE_SEPARATOR = ".";
+
+  static final String CANNOT_FILTER_DEEP_REFERENCE_MSG =
+      "Can not filter on references deeper than %d.";
+  static final String QUERY_VALUE_CANNOT_BE_NULL_MSG = "Query value cannot be null";
+  private DocumentIdGenerator documentIdGenerator;
+
+  BaseQueryClauseGenerator(DocumentIdGenerator documentIdGenerator, Operator operator) {
+    this.documentIdGenerator = requireNonNull(documentIdGenerator);
+    this.operator = requireNonNull(operator);
+  }
+
+  @Override
+  public Operator getOperator() {
+    return operator;
+  }
+
+  @Override
+  public QueryBuilder createQueryClause(QueryRule queryRule, EntityType entityType) {
+    if (operator != queryRule.getOperator()) {
+      throw new IllegalArgumentException(
+          format(
+              "Illegal query operator '%s' does not equal '%s'",
+              queryRule.getOperator(), operator));
+    }
+    return mapQueryRule(queryRule, entityType);
+  }
+
+  abstract QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType);
+
+  String getQueryFieldName(List<Attribute> attributePath) {
+    return attributePath.stream()
+        .map(this::getQueryFieldName)
+        .collect(joining(ATTRIBUTE_SEPARATOR));
+  }
+
+  String getQueryFieldName(Attribute attribute) {
+    return documentIdGenerator.generateId(attribute);
+  }
+
+  boolean useNotAnalyzedField(Attribute attr) {
+    AttributeType attrType = attr.getDataType();
+    switch (attrType) {
+      case BOOL:
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case INT:
+      case LONG:
+        return false;
+      case EMAIL:
+      case ENUM:
+      case HTML:
+      case HYPERLINK:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+        return true;
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case XREF:
+      case MREF:
+      case FILE:
+      case ONE_TO_MANY:
+        return useNotAnalyzedField(attr.getRefEntity().getIdAttribute());
+      case COMPOUND:
+        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
+      default:
+        throw new UnexpectedEnumException(attrType);
+    }
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  List<Object> getQueryValues(Attribute attr, Object queryRuleValue) {
+    if (queryRuleValue == null) {
+      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
+    }
+    if (!(queryRuleValue instanceof Iterable<?>)) {
+      throw new MolgenisQueryException(
+          "Query value must be a Iterable instead of ["
+              + queryRuleValue.getClass().getSimpleName()
+              + "]");
+    }
+    return Streams.stream((Iterable<?>) queryRuleValue)
+        .map(aQueryRuleValue -> getQueryValue(attr, aQueryRuleValue))
+        .collect(toList());
+  }
+
+  Object getQueryValue(Attribute attribute, Object queryRuleValue) {
+    AttributeType attrType = attribute.getDataType();
+    switch (attrType) {
+      case BOOL:
+      case DECIMAL:
+      case EMAIL:
+      case ENUM:
+      case HTML:
+      case HYPERLINK:
+      case INT:
+      case LONG:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+        return queryRuleValue;
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case FILE:
+      case MREF:
+      case ONE_TO_MANY:
+      case XREF:
+        return queryRuleValue instanceof Entity
+            ? ((Entity) queryRuleValue).getIdValue()
+            : queryRuleValue;
+      case DATE:
+        if (queryRuleValue instanceof LocalDate) {
+          return queryRuleValue.toString();
+        } else if (queryRuleValue instanceof String) {
+          return queryRuleValue;
+        } else {
+          throw new MolgenisQueryException(
+              format(
+                  "Query value must be of type LocalDate instead of [%s]",
+                  queryRuleValue.getClass().getSimpleName()));
+        }
+      case DATE_TIME:
+        if (queryRuleValue instanceof Instant) {
+          return queryRuleValue.toString();
+        } else if (queryRuleValue instanceof String) {
+          return queryRuleValue;
+        } else {
+          throw new MolgenisQueryException(
+              format(
+                  "Query value must be of type Instant instead of [%s]",
+                  queryRuleValue.getClass().getSimpleName()));
+        }
+      case COMPOUND:
+        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
+      default:
+        throw new UnexpectedEnumException(attrType);
+    }
+  }
+
+  /**
+   * Wraps the query in a nested query when a query is done on a reference entity. Returns the
+   * original query when it is applied to the current entity.
+   *
+   * <p>Package-private for testability
+   */
+  QueryBuilder nestedQueryBuilder(
+      EntityType entityType, List<Attribute> attributePath, QueryBuilder queryBuilder) {
+    validateIndexingDepth(entityType, attributePath);
+
+    QueryBuilder nestedQueryBuilder = queryBuilder;
+    if (attributePath.size() > 1) {
+      List<String> fieldNamePath =
+          attributePath.stream().map(this::getQueryFieldName).collect(toList());
+
+      for (int i = attributePath.size() - 1; i > 0; --i) {
+        String path = String.join(".", fieldNamePath.subList(0, i));
+        nestedQueryBuilder = QueryBuilders.nestedQuery(path, nestedQueryBuilder, ScoreMode.Avg);
+      }
+    }
+
+    return nestedQueryBuilder;
+  }
+
+  private void validateIndexingDepth(EntityType entityType, List<Attribute> attributePath) {
+    int requiredIndexingDepth = attributePath.size() - 1;
+    if (requiredIndexingDepth > 1) {
+      Attribute lastAttribute = attributePath.get(attributePath.size() - 1);
+      if (lastAttribute.isIdAttribute()) {
+        requiredIndexingDepth -= 1;
+      }
+    }
+
+    if (requiredIndexingDepth > entityType.getIndexingDepth()) {
+      throw new UnsupportedOperationException(
+          format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
+    }
+  }
+
+  void validateNumericalQueryField(Attribute attr) {
+    AttributeType dataType = attr.getDataType();
+
+    switch (dataType) {
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case INT:
+      case LONG:
+        break;
+      case BOOL:
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case COMPOUND:
+      case EMAIL:
+      case ENUM:
+      case FILE:
+      case HTML:
+      case HYPERLINK:
+      case MREF:
+      case ONE_TO_MANY:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+      case XREF:
+        throw new MolgenisQueryException("Range query not allowed for type [" + dataType + "]");
+      default:
+        throw new UnexpectedEnumException(dataType);
+    }
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseRangeGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseRangeGenerator.java
@@ -1,6 +1,5 @@
 package org.molgenis.data.elasticsearch.generator;
 
-import static java.lang.String.format;
 import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
 
 import java.util.List;
@@ -23,6 +22,7 @@ abstract class BaseQueryClauseRangeGenerator extends BaseQueryClauseGenerator {
     List<Attribute> attributePath = getAttributePathExpanded(queryRule.getField(), entityType);
     Attribute attr = attributePath.get(attributePath.size() - 1);
     validateNumericalQueryField(attr);
+
     String fieldName = getQueryFieldName(attributePath);
 
     Object queryValue = getQueryValue(attr, queryRule.getValue());
@@ -30,41 +30,24 @@ abstract class BaseQueryClauseRangeGenerator extends BaseQueryClauseGenerator {
       throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
     }
 
-    RangeQueryBuilder filterBuilder = QueryBuilders.rangeQuery(fieldName);
-    QueryRule.Operator operator = queryRule.getOperator();
-    switch (operator) {
+    RangeQueryBuilder rangeQueryBuilder = QueryBuilders.rangeQuery(fieldName);
+    switch (getOperator()) {
       case GREATER:
-        filterBuilder = filterBuilder.gt(queryValue);
+        rangeQueryBuilder.gt(queryValue);
         break;
       case GREATER_EQUAL:
-        filterBuilder = filterBuilder.gte(queryValue);
+        rangeQueryBuilder.gte(queryValue);
         break;
       case LESS:
-        filterBuilder = filterBuilder.lt(queryValue);
+        rangeQueryBuilder.lt(queryValue);
         break;
       case LESS_EQUAL:
-        filterBuilder = filterBuilder.lte(queryValue);
+        rangeQueryBuilder.lte(queryValue);
         break;
-      case AND:
-      case DIS_MAX:
-      case EQUALS:
-      case FUZZY_MATCH:
-      case FUZZY_MATCH_NGRAM:
-      case IN:
-      case LIKE:
-      case NESTED:
-      case NOT:
-      case OR:
-      case RANGE:
-      case SEARCH:
-      case SHOULD:
-        throw new MolgenisQueryException(
-            format("Illegal query rule operator [%s]", operator.toString()));
       default:
-        throw new UnexpectedEnumException(operator);
+        throw new UnexpectedEnumException(getOperator());
     }
-
     return QueryBuilders.constantScoreQuery(
-        nestedQueryBuilder(entityType, attributePath, filterBuilder));
+        nestedQueryBuilder(entityType, attributePath, rangeQueryBuilder));
   }
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseRangeGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseRangeGenerator.java
@@ -1,0 +1,70 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
+
+import java.util.List;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+abstract class BaseQueryClauseRangeGenerator extends BaseQueryClauseGenerator {
+  BaseQueryClauseRangeGenerator(DocumentIdGenerator documentIdGenerator, Operator operator) {
+    super(documentIdGenerator, operator);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    List<Attribute> attributePath = getAttributePathExpanded(queryRule.getField(), entityType);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+    validateNumericalQueryField(attr);
+    String fieldName = getQueryFieldName(attributePath);
+
+    Object queryValue = getQueryValue(attr, queryRule.getValue());
+    if (queryValue == null) {
+      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
+    }
+
+    RangeQueryBuilder filterBuilder = QueryBuilders.rangeQuery(fieldName);
+    QueryRule.Operator operator = queryRule.getOperator();
+    switch (operator) {
+      case GREATER:
+        filterBuilder = filterBuilder.gt(queryValue);
+        break;
+      case GREATER_EQUAL:
+        filterBuilder = filterBuilder.gte(queryValue);
+        break;
+      case LESS:
+        filterBuilder = filterBuilder.lt(queryValue);
+        break;
+      case LESS_EQUAL:
+        filterBuilder = filterBuilder.lte(queryValue);
+        break;
+      case AND:
+      case DIS_MAX:
+      case EQUALS:
+      case FUZZY_MATCH:
+      case FUZZY_MATCH_NGRAM:
+      case IN:
+      case LIKE:
+      case NESTED:
+      case NOT:
+      case OR:
+      case RANGE:
+      case SEARCH:
+      case SHOULD:
+        throw new MolgenisQueryException(
+            format("Illegal query rule operator [%s]", operator.toString()));
+      default:
+        throw new UnexpectedEnumException(operator);
+    }
+
+    return QueryBuilders.constantScoreQuery(
+        nestedQueryBuilder(entityType, attributePath, filterBuilder));
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseEqualsGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseEqualsGenerator.java
@@ -1,0 +1,76 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
+import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
+
+import java.util.List;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.IllegalAttributeTypeException;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+class QueryClauseEqualsGenerator extends BaseQueryClauseGenerator {
+  QueryClauseEqualsGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.EQUALS);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    List<Attribute> attributePath = getAttributePathExpanded(queryRule.getField(), entityType);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+
+    QueryBuilder queryBuilder;
+
+    AttributeType attrType = attr.getDataType();
+    switch (attrType) {
+      case BOOL:
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case EMAIL:
+      case ENUM:
+      case HTML:
+      case HYPERLINK:
+      case INT:
+      case LONG:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+        String fieldName = getQueryFieldName(attributePath);
+        if (queryRule.getValue() != null) {
+          Object queryValue = getQueryValue(attr, queryRule.getValue());
+          if (useNotAnalyzedField(attr)) {
+            fieldName = fieldName + '.' + FIELD_NOT_ANALYZED;
+          }
+
+          queryBuilder =
+              nestedQueryBuilder(
+                  entityType, attributePath, QueryBuilders.termQuery(fieldName, queryValue));
+        } else {
+          queryBuilder =
+              QueryBuilders.boolQuery()
+                  .mustNot(
+                      nestedQueryBuilder(
+                          entityType, attributePath, QueryBuilders.existsQuery(fieldName)));
+        }
+        break;
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case XREF:
+      case MREF:
+      case FILE:
+      case ONE_TO_MANY:
+      case COMPOUND:
+        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
+      default:
+        throw new UnexpectedEnumException(attrType);
+    }
+
+    return QueryBuilders.constantScoreQuery(queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchGenerator.java
@@ -1,0 +1,58 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
+
+import java.util.List;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+class QueryClauseFuzzyMatchGenerator extends BaseQueryClauseGenerator {
+  QueryClauseFuzzyMatchGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.FUZZY_MATCH);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    List<Attribute> attributePath =
+        getAttributePathExpanded(queryRule.getField(), entityType, true);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+    Object queryValue = getQueryValue(attr, queryRule.getValue());
+
+    String fieldName = getQueryFieldName(attributePath);
+    AttributeType attrType = attr.getDataType();
+
+    switch (attrType) {
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case EMAIL:
+      case ENUM:
+      case HTML:
+      case HYPERLINK:
+      case INT:
+      case LONG:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+        return nestedQueryBuilder(
+            entityType,
+            attributePath,
+            QueryBuilders.queryStringQuery(fieldName + ":(" + queryValue + ")"));
+      case BOOL:
+      case COMPOUND:
+        throw new MolgenisQueryException(
+            format(
+                "Illegal data type [%s] for operator [%s]",
+                attrType, QueryRule.Operator.FUZZY_MATCH));
+      default:
+        throw new UnexpectedEnumException(attrType);
+    }
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchNgramGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchNgramGenerator.java
@@ -1,0 +1,67 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+class QueryClauseFuzzyMatchNgramGenerator extends BaseQueryClauseGenerator {
+  QueryClauseFuzzyMatchNgramGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.FUZZY_MATCH_NGRAM);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    String queryField = queryRule.getField();
+    Object queryValue = queryRule.getValue();
+
+    QueryBuilder queryBuilder;
+    if (queryValue == null) throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
+
+    if (queryField == null) {
+      queryBuilder = QueryBuilders.matchQuery("_all", queryValue);
+    } else {
+      Attribute attr = entityType.getAttributeByName(queryField);
+      // construct query part
+      AttributeType dataType = attr.getDataType();
+      switch (dataType) {
+        case DATE:
+        case DATE_TIME:
+        case DECIMAL:
+        case EMAIL:
+        case ENUM:
+        case HTML:
+        case HYPERLINK:
+        case INT:
+        case LONG:
+        case SCRIPT:
+        case STRING:
+        case TEXT:
+          queryField = getQueryFieldName(attr) + ".ngram";
+          queryBuilder = QueryBuilders.queryStringQuery(queryField + ":(" + queryValue + ")");
+          break;
+        case MREF:
+        case XREF:
+          queryField =
+              getQueryFieldName(attr)
+                  + "."
+                  + getQueryFieldName(attr.getRefEntity().getLabelAttribute())
+                  + ".ngram";
+          queryBuilder =
+              QueryBuilders.nestedQuery(
+                  getQueryFieldName(attr),
+                  QueryBuilders.queryStringQuery(queryField + ":(" + queryValue + ")"),
+                  ScoreMode.Max);
+          break;
+        default:
+          throw new UnexpectedEnumException(dataType);
+      }
+    }
+    return queryBuilder;
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseGenerator.java
@@ -1,0 +1,12 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.model.EntityType;
+
+interface QueryClauseGenerator {
+  Operator getOperator();
+
+  QueryBuilder createQueryClause(QueryRule queryRule, EntityType entityType);
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterEqualGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterEqualGenerator.java
@@ -1,0 +1,9 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import org.molgenis.data.QueryRule.Operator;
+
+class QueryClauseGreaterEqualGenerator extends BaseQueryClauseRangeGenerator {
+  QueryClauseGreaterEqualGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.GREATER_EQUAL);
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterGenerator.java
@@ -1,0 +1,9 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import org.molgenis.data.QueryRule.Operator;
+
+class QueryClauseGreaterGenerator extends BaseQueryClauseRangeGenerator {
+  QueryClauseGreaterGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.GREATER);
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseInGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseInGenerator.java
@@ -1,0 +1,132 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static java.util.stream.Collectors.toList;
+import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
+import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import org.elasticsearch.index.query.BoolQueryBuilder;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+class QueryClauseInGenerator extends BaseQueryClauseGenerator {
+  QueryClauseInGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.IN);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+
+    List<Attribute> attributePath = getAttributePathExpanded(queryRule.getField(), entityType);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+
+    String fieldName = getQueryFieldName(attributePath);
+    List<Object> queryValues = getQueryValues(attr, queryRule.getValue());
+    List<Object> queryValuesWithoutNulls =
+        queryValues.stream().filter(Objects::nonNull).collect(toList());
+
+    Optional<QueryBuilder> nonNullQueryBuilder;
+    if (!queryValuesWithoutNulls.isEmpty()) {
+      nonNullQueryBuilder =
+          createNonNullValuesQueryBuilder(
+              entityType, attributePath, attr, fieldName, queryValuesWithoutNulls);
+    } else {
+      nonNullQueryBuilder = Optional.empty();
+    }
+
+    Optional<QueryBuilder> nullValueQueryBuilder;
+    if (queryValuesWithoutNulls.size() < queryValues.size()) {
+      nullValueQueryBuilder = createNullValuesQueryBuilder(entityType, attributePath, fieldName);
+    } else {
+      nullValueQueryBuilder = Optional.empty();
+    }
+
+    QueryBuilder queryBuilder;
+    if (nonNullQueryBuilder.isPresent()) {
+      if (nullValueQueryBuilder.isPresent()) {
+        BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery().minimumShouldMatch(1);
+        boolQueryBuilder.should(nonNullQueryBuilder.get());
+        boolQueryBuilder.should(nullValueQueryBuilder.get());
+        queryBuilder = boolQueryBuilder;
+      } else {
+        queryBuilder = nonNullQueryBuilder.get();
+      }
+    } else {
+      if (nullValueQueryBuilder.isPresent()) {
+        queryBuilder = nullValueQueryBuilder.get();
+      } else {
+        throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
+      }
+    }
+
+    return QueryBuilders.constantScoreQuery(queryBuilder);
+  }
+
+  private Optional<QueryBuilder> createNullValuesQueryBuilder(
+      EntityType entityType, List<Attribute> attributePath, String fieldName) {
+    Optional<QueryBuilder> nullValueQueryBuilder;
+    nullValueQueryBuilder =
+        Optional.of(
+            QueryBuilders.boolQuery()
+                .mustNot(
+                    nestedQueryBuilder(
+                        entityType, attributePath, QueryBuilders.existsQuery(fieldName))));
+    return nullValueQueryBuilder;
+  }
+
+  private Optional<QueryBuilder> createNonNullValuesQueryBuilder(
+      EntityType entityType,
+      List<Attribute> attributePath,
+      Attribute attr,
+      String fieldName,
+      List<Object> queryValuesWithoutNulls) {
+    Optional<QueryBuilder> nonNullQueryBuilder;
+    AttributeType dataType = attr.getDataType();
+    switch (dataType) {
+      case BOOL:
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case EMAIL:
+      case ENUM:
+      case HTML:
+      case HYPERLINK:
+      case INT:
+      case LONG:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+        String termsQueryFieldName = fieldName;
+        if (useNotAnalyzedField(attr)) {
+          termsQueryFieldName += '.' + FIELD_NOT_ANALYZED;
+        }
+
+        QueryBuilder termsQueryBuilder =
+            QueryBuilders.termsQuery(termsQueryFieldName, queryValuesWithoutNulls.toArray());
+        nonNullQueryBuilder =
+            Optional.of(nestedQueryBuilder(entityType, attributePath, termsQueryBuilder));
+        break;
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case MREF:
+      case XREF:
+      case FILE:
+      case ONE_TO_MANY:
+      case COMPOUND:
+        throw new MolgenisQueryException(
+            format("Illegal data type [%s] for operator [%s]", dataType, Operator.IN));
+      default:
+        throw new UnexpectedEnumException(dataType);
+    }
+    return nonNullQueryBuilder;
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessEqualGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessEqualGenerator.java
@@ -1,0 +1,9 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import org.molgenis.data.QueryRule.Operator;
+
+class QueryClauseLessEqualGenerator extends BaseQueryClauseRangeGenerator {
+  QueryClauseLessEqualGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.LESS_EQUAL);
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessGenerator.java
@@ -1,0 +1,9 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import org.molgenis.data.QueryRule.Operator;
+
+class QueryClauseLessGenerator extends BaseQueryClauseRangeGenerator {
+  QueryClauseLessGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.LESS);
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseLikeGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseLikeGenerator.java
@@ -1,0 +1,66 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static org.molgenis.data.QueryRule.Operator.LIKE;
+import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
+import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
+
+import java.util.List;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+class QueryClauseLikeGenerator extends BaseQueryClauseGenerator {
+  QueryClauseLikeGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, LIKE);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    List<Attribute> attributePath = getAttributePathExpanded(queryRule.getField(), entityType);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+    Object queryValue = getQueryValue(attr, queryRule.getValue());
+
+    String fieldName = getQueryFieldName(attributePath);
+    AttributeType attrType = attr.getDataType();
+    switch (attrType) {
+      case EMAIL:
+      case ENUM:
+      case HYPERLINK:
+      case STRING:
+        return nestedQueryBuilder(
+            entityType,
+            attributePath,
+            QueryBuilders.matchPhrasePrefixQuery(fieldName, queryValue)
+                .maxExpansions(50)
+                .slop(10)
+                .analyzer(DEFAULT_ANALYZER));
+      case BOOL:
+      case COMPOUND:
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case INT:
+      case LONG:
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case FILE:
+      case MREF:
+      case ONE_TO_MANY:
+      case XREF:
+        throw new MolgenisQueryException(
+            format("Illegal data type [%s] for operator [%s]", attrType, LIKE));
+      case HTML: // due to size would result in large amount of ngrams
+      case SCRIPT: // due to size would result in large amount of ngrams
+      case TEXT: // due to size would result in large amount of ngrams
+        throw new UnsupportedOperationException(
+            format("Unsupported data type [%s] for operator [%s]", attrType, LIKE));
+      default:
+        throw new UnexpectedEnumException(attrType);
+    }
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseRangeGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseRangeGenerator.java
@@ -1,7 +1,7 @@
 package org.molgenis.data.elasticsearch.generator;
 
 import static java.lang.String.format;
-import static org.molgenis.data.QueryUtils.getAttributePath;
+import static org.molgenis.data.QueryUtils.getAttributePathExpanded;
 
 import java.util.Iterator;
 import java.util.List;
@@ -19,7 +19,7 @@ class QueryClauseRangeGenerator extends BaseQueryClauseGenerator {
   }
 
   QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
+    List<Attribute> attributePath = getAttributePathExpanded(queryRule.getField(), entityType);
     Attribute attr = attributePath.get(attributePath.size() - 1);
     validateNumericalQueryField(attr);
     String fieldName = getQueryFieldName(attributePath);

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseRangeGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseRangeGenerator.java
@@ -1,0 +1,47 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static org.molgenis.data.QueryUtils.getAttributePath;
+
+import java.util.Iterator;
+import java.util.List;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+
+class QueryClauseRangeGenerator extends BaseQueryClauseGenerator {
+  QueryClauseRangeGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.RANGE);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+    validateNumericalQueryField(attr);
+    String fieldName = getQueryFieldName(attributePath);
+
+    Object queryValue = getQueryValue(attr, queryRule.getValue());
+    if (queryValue == null) {
+      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
+    }
+    if (!(queryValue instanceof Iterable<?>)) {
+      throw new MolgenisQueryException(
+          format(
+              "Query value must be a Iterable instead of [%s]",
+              queryValue.getClass().getSimpleName()));
+    }
+    Iterator<?> queryValuesIterator = ((Iterable<?>) queryValue).iterator();
+    Object queryValueFrom = getQueryValue(attr, queryValuesIterator.next());
+    Object queryValueTo = getQueryValue(attr, queryValuesIterator.next());
+
+    return QueryBuilders.constantScoreQuery(
+        nestedQueryBuilder(
+            entityType,
+            attributePath,
+            QueryBuilders.rangeQuery(fieldName).gte(queryValueFrom).lte(queryValueTo)));
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGenerator.java
@@ -1,0 +1,87 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.lang.String.format;
+import static org.molgenis.data.QueryUtils.getAttributePath;
+
+import java.util.List;
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.util.UnexpectedEnumException;
+
+class QueryClauseSearchGenerator extends BaseQueryClauseGenerator {
+  QueryClauseSearchGenerator(DocumentIdGenerator documentIdGenerator) {
+    super(documentIdGenerator, Operator.SEARCH);
+  }
+
+  QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+    if (queryRule.getValue() == null) {
+      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
+    }
+
+    if (queryRule.getField() == null) {
+      return createQueryClauseSearchAll(queryRule);
+    } else {
+      return createQueryClauseSearchAttribute(queryRule, entityType);
+    }
+  }
+
+  private QueryBuilder createQueryClauseSearchAll(QueryRule queryRule) {
+    return QueryBuilders.matchPhraseQuery("_all", queryRule.getValue()).slop(10);
+  }
+
+  private QueryBuilder createQueryClauseSearchAttribute(
+      QueryRule queryRule, EntityType entityType) {
+    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
+    Attribute attr = attributePath.get(attributePath.size() - 1);
+    Object queryValue = getQueryValue(attr, queryRule.getValue());
+
+    String fieldName = getQueryFieldName(attributePath);
+    AttributeType dataType = attr.getDataType();
+    switch (dataType) {
+      case DATE:
+      case DATE_TIME:
+      case DECIMAL:
+      case EMAIL:
+      case ENUM:
+      case HTML:
+      case HYPERLINK:
+      case INT:
+      case LONG:
+      case SCRIPT:
+      case STRING:
+      case TEXT:
+        return nestedQueryBuilder(
+            entityType, attributePath, QueryBuilders.matchQuery(fieldName, queryValue));
+      case CATEGORICAL:
+      case CATEGORICAL_MREF:
+      case MREF:
+      case ONE_TO_MANY:
+      case XREF:
+      case FILE:
+        if (attributePath.size() > entityType.getIndexingDepth()) {
+          throw new MolgenisQueryException(
+              format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
+        }
+        return QueryBuilders.nestedQuery(
+            fieldName,
+            QueryBuilders.matchQuery(fieldName + '.' + "_all", queryValue),
+            ScoreMode.Avg);
+      case BOOL:
+        throw new MolgenisQueryException(
+            "Cannot execute search query on [" + dataType + "] attribute");
+      case COMPOUND:
+        throw new MolgenisQueryException(
+            format(
+                "Illegal data type [%s] for operator [%s]", dataType, QueryRule.Operator.SEARCH));
+      default:
+        throw new UnexpectedEnumException(dataType);
+    }
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGenerator.java
@@ -49,15 +49,19 @@ class QueryClauseSearchGenerator extends BaseQueryClauseGenerator {
       case DECIMAL:
       case EMAIL:
       case ENUM:
-      case HTML:
       case HYPERLINK:
       case INT:
       case LONG:
+        return nestedQueryBuilder(
+            entityType, attributePath, QueryBuilders.matchQuery(fieldName, queryValue));
+      case HTML:
       case SCRIPT:
       case STRING:
       case TEXT:
         return nestedQueryBuilder(
-            entityType, attributePath, QueryBuilders.matchQuery(fieldName, queryValue));
+            entityType,
+            attributePath,
+            QueryBuilders.matchPhraseQuery(fieldName, queryValue).slop(10));
       case BOOL:
         throw new MolgenisQueryException(
             "Cannot execute search query on [" + dataType + "] attribute");

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryGenerator.java
@@ -1,35 +1,29 @@
 package org.molgenis.data.elasticsearch.generator;
 
 import static java.lang.String.format;
-import static java.util.Objects.requireNonNull;
-import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Stream.concat;
-import static java.util.stream.Stream.of;
+import static org.molgenis.data.QueryRule.Operator.EQUALS;
+import static org.molgenis.data.QueryRule.Operator.FUZZY_MATCH;
+import static org.molgenis.data.QueryRule.Operator.FUZZY_MATCH_NGRAM;
+import static org.molgenis.data.QueryRule.Operator.GREATER;
+import static org.molgenis.data.QueryRule.Operator.GREATER_EQUAL;
+import static org.molgenis.data.QueryRule.Operator.IN;
+import static org.molgenis.data.QueryRule.Operator.LESS;
+import static org.molgenis.data.QueryRule.Operator.LESS_EQUAL;
 import static org.molgenis.data.QueryRule.Operator.LIKE;
-import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
-import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
+import static org.molgenis.data.QueryRule.Operator.RANGE;
+import static org.molgenis.data.QueryRule.Operator.SEARCH;
 
-import com.google.common.collect.Streams;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.EnumMap;
 import java.util.List;
-import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.DisMaxQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.molgenis.data.Entity;
 import org.molgenis.data.MolgenisQueryException;
 import org.molgenis.data.Query;
 import org.molgenis.data.QueryRule;
-import org.molgenis.data.UnknownAttributeException;
-import org.molgenis.data.meta.AttributeType;
-import org.molgenis.data.meta.IllegalAttributeTypeException;
-import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.QueryRule.Operator;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.util.UnexpectedEnumException;
 import org.springframework.stereotype.Component;
@@ -39,21 +33,31 @@ import org.springframework.stereotype.Component;
 public class QueryGenerator {
   static final String ATTRIBUTE_SEPARATOR = ".";
 
-  private static final String CANNOT_FILTER_DEEP_REFERENCE_MSG =
-      "Can not filter on references deeper than %d.";
-  private static final String QUERY_VALUE_CANNOT_BE_NULL_MSG = "Query value cannot be null";
-
-  private final DocumentIdGenerator documentIdGenerator;
+  private final EnumMap<Operator, QueryClauseGenerator> queryClauseGeneratorMap;
 
   public QueryGenerator(DocumentIdGenerator documentIdGenerator) {
-    this.documentIdGenerator = requireNonNull(documentIdGenerator);
+    queryClauseGeneratorMap = new EnumMap<>(Operator.class);
+    queryClauseGeneratorMap.put(EQUALS, new QueryClauseEqualsGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(
+        FUZZY_MATCH, new QueryClauseFuzzyMatchGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(
+        FUZZY_MATCH_NGRAM, new QueryClauseFuzzyMatchNgramGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(GREATER, new QueryClauseGreaterGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(
+        GREATER_EQUAL, new QueryClauseGreaterEqualGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(IN, new QueryClauseInGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(LESS, new QueryClauseLessGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(LESS_EQUAL, new QueryClauseLessEqualGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(LIKE, new QueryClauseLikeGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(RANGE, new QueryClauseRangeGenerator(documentIdGenerator));
+    queryClauseGeneratorMap.put(SEARCH, new QueryClauseSearchGenerator(documentIdGenerator));
   }
 
   QueryBuilder createQueryBuilder(Query<Entity> query, EntityType entityType) {
     return createQueryBuilder(query.getRules(), entityType);
   }
 
-  public QueryBuilder createQueryBuilder(List<QueryRule> queryRules, EntityType entityType) {
+  private QueryBuilder createQueryBuilder(List<QueryRule> queryRules, EntityType entityType) {
     QueryBuilder queryBuilder;
 
     final int nrQueryRules = queryRules.size();
@@ -128,27 +132,8 @@ public class QueryGenerator {
     switch (queryOperator) {
       case DIS_MAX:
         return createQueryClauseDisMax(queryRule, entityType);
-      case EQUALS:
-        return createQueryClauseEquals(queryRule, entityType);
-      case FUZZY_MATCH:
-        return createQueryClauseFuzzyMatch(queryRule, entityType);
-      case FUZZY_MATCH_NGRAM:
-        return createQueryClauseFuzzyMatchNgram(queryRule, entityType);
-      case GREATER:
-      case GREATER_EQUAL:
-      case LESS:
-      case LESS_EQUAL:
-        return createQueryClauseRangeOpen(queryRule, entityType);
-      case IN:
-        return createQueryClauseIn(queryRule, entityType);
-      case LIKE:
-        return createQueryClauseLike(queryRule, entityType);
       case NESTED:
         return createQueryClauseNested(queryRule, entityType);
-      case RANGE:
-        return createQueryClauseRangeClosed(queryRule, entityType);
-      case SEARCH:
-        return createQueryClauseSearch(queryRule, entityType);
       case SHOULD:
         return createQueryClauseShould(queryRule, entityType);
       case AND:
@@ -157,8 +142,28 @@ public class QueryGenerator {
         throw new MolgenisQueryException(
             format("Unexpected query operator [%s]", queryOperator.toString()));
       default:
-        throw new UnexpectedEnumException(queryOperator);
+        QueryClauseGenerator queryClauseGenerator = queryClauseGeneratorMap.get(queryOperator);
+        if (queryClauseGenerator == null) {
+          throw new UnexpectedEnumException(queryOperator);
+        }
+        return queryClauseGenerator.createQueryClause(queryRule, entityType);
     }
+  }
+
+  private QueryBuilder createQueryClauseNested(QueryRule queryRule, EntityType entityType) {
+    List<QueryRule> nestedQueryRules = queryRule.getNestedRules();
+    if (nestedQueryRules == null || nestedQueryRules.isEmpty()) {
+      throw new MolgenisQueryException("Missing nested rules for nested query");
+    }
+    return createQueryBuilder(nestedQueryRules, entityType);
+  }
+
+  private QueryBuilder createQueryClauseShould(QueryRule queryRule, EntityType entityType) {
+    BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
+    for (QueryRule subQuery : queryRule.getNestedRules()) {
+      boolQueryBuilder.should(createQueryClause(subQuery, entityType));
+    }
+    return boolQueryBuilder;
   }
 
   private QueryBuilder createQueryClauseDisMax(QueryRule queryRule, EntityType entityType) {
@@ -171,685 +176,5 @@ public class QueryGenerator {
       disMaxQueryBuilder.boost(Float.parseFloat(queryRule.getValue().toString()));
     }
     return disMaxQueryBuilder;
-  }
-
-  private QueryBuilder createQueryClauseEquals(QueryRule queryRule, EntityType entityType) {
-    QueryBuilder queryBuilder;
-    if (queryRule.getValue() != null) {
-      queryBuilder = createQueryClauseEqualsValue(queryRule, entityType);
-    } else {
-      queryBuilder = createQueryClauseEqualsNoValue(queryRule, entityType);
-    }
-    return QueryBuilders.constantScoreQuery(queryBuilder);
-  }
-
-  private QueryBuilder createQueryClauseEqualsValue(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-    Attribute attr = attributePath.get(attributePath.size() - 1);
-    Object queryValue = getQueryValue(attr, queryRule.getValue());
-
-    String fieldName = getQueryFieldName(attributePath);
-    AttributeType attrType = attr.getDataType();
-    switch (attrType) {
-      case BOOL:
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case EMAIL:
-      case ENUM:
-      case HTML:
-      case HYPERLINK:
-      case INT:
-      case LONG:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-        if (useNotAnalyzedField(attr)) {
-          fieldName = fieldName + '.' + FIELD_NOT_ANALYZED;
-        }
-        return nestedQueryBuilder(
-            entityType, attributePath, QueryBuilders.termQuery(fieldName, queryValue));
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case XREF:
-      case MREF:
-      case FILE:
-      case ONE_TO_MANY:
-        if (attributePath.size() > entityType.getIndexingDepth()) {
-          throw new MolgenisQueryException(
-              format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
-        }
-
-        Attribute refIdAttr = attr.getRefEntity().getIdAttribute();
-        List<Attribute> refAttributePath =
-            concat(attributePath.stream(), of(refIdAttr)).collect(toList());
-        String indexFieldName = getQueryFieldName(refAttributePath);
-        if (useNotAnalyzedField(refIdAttr)) {
-          indexFieldName = indexFieldName + '.' + FIELD_NOT_ANALYZED;
-        }
-        return QueryBuilders.nestedQuery(
-            fieldName, QueryBuilders.termQuery(indexFieldName, queryValue), ScoreMode.Avg);
-      case COMPOUND:
-        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
-      default:
-        throw new UnexpectedEnumException(attrType);
-    }
-  }
-
-  private QueryBuilder createQueryClauseEqualsNoValue(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-
-    String fieldName = getQueryFieldName(attributePath);
-    Attribute attr = attributePath.get(0);
-    AttributeType attrType = attr.getDataType();
-    switch (attrType) {
-      case BOOL:
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case EMAIL:
-      case ENUM:
-      case HTML:
-      case HYPERLINK:
-      case INT:
-      case LONG:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-        return QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery(fieldName));
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case FILE:
-      case MREF:
-      case ONE_TO_MANY:
-      case XREF:
-        if (attributePath.size() > entityType.getIndexingDepth()) {
-          throw new MolgenisQueryException(
-              format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
-        }
-
-        Attribute refIdAttr = attr.getRefEntity().getIdAttribute();
-        List<Attribute> refAttributePath =
-            concat(attributePath.stream(), of(refIdAttr)).collect(toList());
-        String indexFieldName = getQueryFieldName(refAttributePath);
-
-        return QueryBuilders.boolQuery()
-            .mustNot(
-                QueryBuilders.nestedQuery(
-                    fieldName, QueryBuilders.existsQuery(indexFieldName), ScoreMode.Avg));
-      case COMPOUND:
-        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
-      default:
-        throw new UnexpectedEnumException(attrType);
-    }
-  }
-
-  private QueryBuilder createQueryClauseFuzzyMatch(QueryRule queryRule, EntityType entityType) {
-    String queryField = queryRule.getField();
-    Object queryValue = queryRule.getValue();
-
-    QueryBuilder queryBuilder;
-    if (queryValue == null) throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
-
-    if (queryField == null) {
-      queryBuilder = QueryBuilders.matchQuery("_all", queryValue);
-    } else {
-      Attribute attr = entityType.getAttribute(queryField);
-      if (attr == null) {
-        throw new UnknownAttributeException(entityType, queryField);
-      }
-      // construct query part
-      AttributeType dataType = attr.getDataType();
-      switch (dataType) {
-        case DATE:
-        case DATE_TIME:
-        case DECIMAL:
-        case EMAIL:
-        case ENUM:
-        case HTML:
-        case HYPERLINK:
-        case INT:
-        case LONG:
-        case SCRIPT:
-        case STRING:
-        case TEXT:
-          queryBuilder =
-              QueryBuilders.queryStringQuery(getQueryFieldName(attr) + ":(" + queryValue + ")");
-          break;
-        case MREF:
-        case XREF:
-        case CATEGORICAL:
-        case CATEGORICAL_MREF:
-        case ONE_TO_MANY:
-        case FILE:
-          queryField =
-              getQueryFieldName(attr)
-                  + "."
-                  + getQueryFieldName(attr.getRefEntity().getLabelAttribute());
-          queryBuilder =
-              QueryBuilders.nestedQuery(
-                  getQueryFieldName(attr),
-                  QueryBuilders.queryStringQuery(queryField + ":(" + queryValue + ")"),
-                  ScoreMode.Max);
-          break;
-        case BOOL:
-        case COMPOUND:
-          throw new MolgenisQueryException(
-              format(
-                  "Illegal data type [%s] for operator [%s]",
-                  dataType, QueryRule.Operator.FUZZY_MATCH));
-        default:
-          throw new UnexpectedEnumException(dataType);
-      }
-    }
-    return queryBuilder;
-  }
-
-  private QueryBuilder createQueryClauseFuzzyMatchNgram(
-      QueryRule queryRule, EntityType entityType) {
-    String queryField = queryRule.getField();
-    Object queryValue = queryRule.getValue();
-
-    QueryBuilder queryBuilder;
-    if (queryValue == null) throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
-
-    if (queryField == null) {
-      queryBuilder = QueryBuilders.matchQuery("_all", queryValue);
-    } else {
-      Attribute attr = entityType.getAttribute(queryField);
-      if (attr == null) {
-        throw new UnknownAttributeException(entityType, queryField);
-      }
-      // construct query part
-      AttributeType dataType = attr.getDataType();
-      switch (dataType) {
-        case DATE:
-        case DATE_TIME:
-        case DECIMAL:
-        case EMAIL:
-        case ENUM:
-        case HTML:
-        case HYPERLINK:
-        case INT:
-        case LONG:
-        case SCRIPT:
-        case STRING:
-        case TEXT:
-          queryField = getQueryFieldName(attr) + ".ngram";
-          queryBuilder = QueryBuilders.queryStringQuery(queryField + ":(" + queryValue + ")");
-          break;
-        case MREF:
-        case XREF:
-          queryField =
-              getQueryFieldName(attr)
-                  + "."
-                  + getQueryFieldName(attr.getRefEntity().getLabelAttribute())
-                  + ".ngram";
-          queryBuilder =
-              QueryBuilders.nestedQuery(
-                  getQueryFieldName(attr),
-                  QueryBuilders.queryStringQuery(queryField + ":(" + queryValue + ")"),
-                  ScoreMode.Max);
-          break;
-        default:
-          throw new UnexpectedEnumException(dataType);
-      }
-    }
-    return queryBuilder;
-  }
-
-  private QueryBuilder createQueryClauseIn(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-    Attribute attr = attributePath.get(attributePath.size() - 1);
-
-    Object queryRuleValue = queryRule.getValue();
-    if (queryRuleValue == null) {
-      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
-    }
-    if (!(queryRuleValue instanceof Iterable<?>)) {
-      throw new MolgenisQueryException(
-          "Query value must be a Iterable instead of ["
-              + queryRuleValue.getClass().getSimpleName()
-              + "]");
-    }
-    Object[] queryValues =
-        Streams.stream((Iterable<?>) queryRuleValue)
-            .map(aQueryRuleValue -> getQueryValue(attr, aQueryRuleValue))
-            .toArray();
-
-    QueryBuilder queryBuilder;
-    String fieldName = getQueryFieldName(attr);
-    AttributeType dataType = attr.getDataType();
-    switch (dataType) {
-      case BOOL:
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case EMAIL:
-      case ENUM:
-      case HTML:
-      case HYPERLINK:
-      case INT:
-      case LONG:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-        {
-          String indexFieldName = getQueryFieldName(attributePath);
-          if (useNotAnalyzedField(attr)) {
-            indexFieldName = indexFieldName + '.' + FIELD_NOT_ANALYZED;
-          }
-          // note: inFilter expects array, not iterable
-          queryBuilder = QueryBuilders.termsQuery(indexFieldName, queryValues);
-          queryBuilder = nestedQueryBuilder(entityType, attributePath, queryBuilder);
-          break;
-        }
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case MREF:
-      case XREF:
-      case FILE:
-      case ONE_TO_MANY:
-        if (attributePath.size() > entityType.getIndexingDepth()) {
-          throw new MolgenisQueryException(
-              format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
-        }
-
-        Attribute refIdAttr = attr.getRefEntity().getIdAttribute();
-        List<Attribute> refAttributePath =
-            concat(attributePath.stream(), of(refIdAttr)).collect(toList());
-        String indexFieldName = getQueryFieldName(refAttributePath);
-        if (useNotAnalyzedField(refIdAttr)) {
-          indexFieldName = indexFieldName + '.' + FIELD_NOT_ANALYZED;
-        }
-        queryBuilder = QueryBuilders.termsQuery(indexFieldName, queryValues);
-        queryBuilder = QueryBuilders.nestedQuery(fieldName, queryBuilder, ScoreMode.Avg);
-        break;
-      case COMPOUND:
-        throw new MolgenisQueryException(
-            format("Illegal data type [%s] for operator [%s]", dataType, QueryRule.Operator.IN));
-      default:
-        throw new UnexpectedEnumException(dataType);
-    }
-    return QueryBuilders.constantScoreQuery(queryBuilder);
-  }
-
-  private QueryBuilder createQueryClauseLike(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-    Attribute attr = attributePath.get(attributePath.size() - 1);
-    Object queryValue = getQueryValue(attr, queryRule.getValue());
-
-    String fieldName = getQueryFieldName(attributePath);
-    AttributeType attrType = attr.getDataType();
-    switch (attrType) {
-      case EMAIL:
-      case ENUM:
-      case HYPERLINK:
-      case STRING:
-        return nestedQueryBuilder(
-            entityType,
-            attributePath,
-            QueryBuilders.matchPhrasePrefixQuery(fieldName, queryValue)
-                .maxExpansions(50)
-                .slop(10)
-                .analyzer(DEFAULT_ANALYZER));
-      case BOOL:
-      case COMPOUND:
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case INT:
-      case LONG:
-        throw new MolgenisQueryException(
-            format("Illegal data type [%s] for operator [%s]", attrType, LIKE));
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case FILE:
-      case HTML: // due to size would result in large amount of ngrams
-      case MREF:
-      case ONE_TO_MANY:
-      case SCRIPT: // due to size would result in large amount of ngrams
-      case TEXT: // due to size would result in large amount of ngrams
-      case XREF:
-        throw new UnsupportedOperationException(
-            format("Unsupported data type [%s] for operator [%s]", attrType, LIKE));
-      default:
-        throw new UnexpectedEnumException(attrType);
-    }
-  }
-
-  private QueryBuilder createQueryClauseNested(QueryRule queryRule, EntityType entityType) {
-    List<QueryRule> nestedQueryRules = queryRule.getNestedRules();
-    if (nestedQueryRules == null || nestedQueryRules.isEmpty()) {
-      throw new MolgenisQueryException("Missing nested rules for nested query");
-    }
-    return createQueryBuilder(nestedQueryRules, entityType);
-  }
-
-  private QueryBuilder createQueryClauseRangeClosed(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-    Attribute attr = attributePath.get(attributePath.size() - 1);
-    validateNumericalQueryField(attr);
-    String fieldName = getQueryFieldName(attributePath);
-
-    Object queryValue = getQueryValue(attr, queryRule.getValue());
-    if (queryValue == null) {
-      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
-    }
-    if (!(queryValue instanceof Iterable<?>)) {
-      throw new MolgenisQueryException(
-          format(
-              "Query value must be a Iterable instead of [%s]",
-              queryValue.getClass().getSimpleName()));
-    }
-    Iterator<?> queryValuesIterator = ((Iterable<?>) queryValue).iterator();
-    Object queryValueFrom = getQueryValue(attr, queryValuesIterator.next());
-    Object queryValueTo = getQueryValue(attr, queryValuesIterator.next());
-
-    return QueryBuilders.constantScoreQuery(
-        nestedQueryBuilder(
-            entityType,
-            attributePath,
-            QueryBuilders.rangeQuery(fieldName).gte(queryValueFrom).lte(queryValueTo)));
-  }
-
-  private QueryBuilder createQueryClauseRangeOpen(QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-    Attribute attr = attributePath.get(attributePath.size() - 1);
-    validateNumericalQueryField(attr);
-    String fieldName = getQueryFieldName(attributePath);
-
-    Object queryValue = getQueryValue(attr, queryRule.getValue());
-    if (queryValue == null) {
-      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
-    }
-
-    RangeQueryBuilder filterBuilder = QueryBuilders.rangeQuery(fieldName);
-    QueryRule.Operator operator = queryRule.getOperator();
-    switch (operator) {
-      case GREATER:
-        filterBuilder = filterBuilder.gt(queryValue);
-        break;
-      case GREATER_EQUAL:
-        filterBuilder = filterBuilder.gte(queryValue);
-        break;
-      case LESS:
-        filterBuilder = filterBuilder.lt(queryValue);
-        break;
-      case LESS_EQUAL:
-        filterBuilder = filterBuilder.lte(queryValue);
-        break;
-      case AND:
-      case DIS_MAX:
-      case EQUALS:
-      case FUZZY_MATCH:
-      case FUZZY_MATCH_NGRAM:
-      case IN:
-      case LIKE:
-      case NESTED:
-      case NOT:
-      case OR:
-      case RANGE:
-      case SEARCH:
-      case SHOULD:
-        throw new MolgenisQueryException(
-            format("Illegal query rule operator [%s]", operator.toString()));
-      default:
-        throw new UnexpectedEnumException(operator);
-    }
-
-    return QueryBuilders.constantScoreQuery(
-        nestedQueryBuilder(entityType, attributePath, filterBuilder));
-  }
-
-  private QueryBuilder createQueryClauseSearch(QueryRule queryRule, EntityType entityType) {
-    if (queryRule.getValue() == null) {
-      throw new MolgenisQueryException(QUERY_VALUE_CANNOT_BE_NULL_MSG);
-    }
-
-    if (queryRule.getField() == null) {
-      return createQueryClauseSearchAll(queryRule);
-    } else {
-      return createQueryClauseSearchAttribute(queryRule, entityType);
-    }
-  }
-
-  private QueryBuilder createQueryClauseSearchAll(QueryRule queryRule) {
-    return QueryBuilders.matchPhraseQuery("_all", queryRule.getValue()).slop(10);
-  }
-
-  private QueryBuilder createQueryClauseSearchAttribute(
-      QueryRule queryRule, EntityType entityType) {
-    List<Attribute> attributePath = getAttributePath(queryRule.getField(), entityType);
-    Attribute attr = attributePath.get(attributePath.size() - 1);
-    Object queryValue = getQueryValue(attr, queryRule.getValue());
-
-    String fieldName = getQueryFieldName(attributePath);
-    AttributeType dataType = attr.getDataType();
-    switch (dataType) {
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case EMAIL:
-      case ENUM:
-      case HTML:
-      case HYPERLINK:
-      case INT:
-      case LONG:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-        return nestedQueryBuilder(
-            entityType, attributePath, QueryBuilders.matchQuery(fieldName, queryValue));
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case MREF:
-      case ONE_TO_MANY:
-      case XREF:
-      case FILE:
-        if (attributePath.size() > entityType.getIndexingDepth()) {
-          throw new MolgenisQueryException(
-              format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
-        }
-        return QueryBuilders.nestedQuery(
-            fieldName,
-            QueryBuilders.matchQuery(fieldName + '.' + "_all", queryValue),
-            ScoreMode.Avg);
-      case BOOL:
-        throw new MolgenisQueryException(
-            "Cannot execute search query on [" + dataType + "] attribute");
-      case COMPOUND:
-        throw new MolgenisQueryException(
-            format(
-                "Illegal data type [%s] for operator [%s]", dataType, QueryRule.Operator.SEARCH));
-      default:
-        throw new UnexpectedEnumException(dataType);
-    }
-  }
-
-  private QueryBuilder createQueryClauseShould(QueryRule queryRule, EntityType entityType) {
-    BoolQueryBuilder boolQueryBuilder = QueryBuilders.boolQuery();
-    for (QueryRule subQuery : queryRule.getNestedRules()) {
-      boolQueryBuilder.should(createQueryClause(subQuery, entityType));
-    }
-    return boolQueryBuilder;
-  }
-
-  private boolean useNotAnalyzedField(Attribute attr) {
-    AttributeType attrType = attr.getDataType();
-    switch (attrType) {
-      case BOOL:
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case INT:
-      case LONG:
-        return false;
-      case EMAIL:
-      case ENUM:
-      case HTML:
-      case HYPERLINK:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-        return true;
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case XREF:
-      case MREF:
-      case FILE:
-      case ONE_TO_MANY:
-        return useNotAnalyzedField(attr.getRefEntity().getIdAttribute());
-      case COMPOUND:
-        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
-      default:
-        throw new UnexpectedEnumException(attrType);
-    }
-  }
-
-  private void validateNumericalQueryField(Attribute attr) {
-    AttributeType dataType = attr.getDataType();
-
-    switch (dataType) {
-      case DATE:
-      case DATE_TIME:
-      case DECIMAL:
-      case INT:
-      case LONG:
-        break;
-      case BOOL:
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case COMPOUND:
-      case EMAIL:
-      case ENUM:
-      case FILE:
-      case HTML:
-      case HYPERLINK:
-      case MREF:
-      case ONE_TO_MANY:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-      case XREF:
-        throw new MolgenisQueryException("Range query not allowed for type [" + dataType + "]");
-      default:
-        throw new UnexpectedEnumException(dataType);
-    }
-  }
-
-  private List<Attribute> getAttributePath(String queryRuleField, EntityType entityType) {
-    String[] queryRuleFieldTokens = queryRuleField.split("\\" + ATTRIBUTE_SEPARATOR);
-    List<Attribute> attributePath = new ArrayList<>(queryRuleFieldTokens.length);
-    EntityType entityTypeAtCurrentDepth = entityType;
-    for (int depth = 0; depth < queryRuleFieldTokens.length; ++depth) {
-      Attribute attribute = entityTypeAtCurrentDepth.getAttribute(queryRuleFieldTokens[depth]);
-      if (attribute == null) {
-        throw new UnknownAttributeException(entityTypeAtCurrentDepth, queryRuleFieldTokens[depth]);
-      }
-      attributePath.add(attribute);
-
-      if (depth + 1 < queryRuleFieldTokens.length) {
-        if (!attribute.hasRefEntity()) {
-          throw new MolgenisQueryException(
-              format(
-                  "Invalid query field [%s]: attribute [%s] does not refer to another entity",
-                  queryRuleField, attribute.getName()));
-        }
-        entityTypeAtCurrentDepth = attribute.getRefEntity();
-      }
-    }
-    return attributePath;
-  }
-
-  /**
-   * Wraps the query in a nested query when a query is done on a reference entity. Returns the
-   * original query when it is applied to the current entity.
-   *
-   * <p>Package-private for testability
-   */
-  QueryBuilder nestedQueryBuilder(
-      EntityType entityType, List<Attribute> attributePath, QueryBuilder queryBuilder) {
-    final int pathLength = attributePath.size();
-    if (pathLength - 1 > entityType.getIndexingDepth()) {
-      throw new UnsupportedOperationException(
-          format(CANNOT_FILTER_DEEP_REFERENCE_MSG, entityType.getIndexingDepth()));
-    }
-
-    QueryBuilder nestedQueryBuilder = queryBuilder;
-    if (pathLength > 1) {
-      List<String> fieldNamePath =
-          attributePath.stream().map(this::getQueryFieldName).collect(toList());
-
-      for (int i = pathLength - 1; i > 0; --i) {
-        String path = String.join(".", fieldNamePath.subList(0, i));
-        nestedQueryBuilder = QueryBuilders.nestedQuery(path, nestedQueryBuilder, ScoreMode.Avg);
-      }
-    }
-
-    return nestedQueryBuilder;
-  }
-
-  private String getQueryFieldName(List<Attribute> attributePath) {
-    return attributePath.stream()
-        .map(this::getQueryFieldName)
-        .collect(joining(ATTRIBUTE_SEPARATOR));
-  }
-
-  private String getQueryFieldName(Attribute attribute) {
-    return documentIdGenerator.generateId(attribute);
-  }
-
-  private Object getQueryValue(Attribute attribute, Object queryRuleValue) {
-    AttributeType attrType = attribute.getDataType();
-    switch (attrType) {
-      case BOOL:
-      case DECIMAL:
-      case EMAIL:
-      case ENUM:
-      case HTML:
-      case HYPERLINK:
-      case INT:
-      case LONG:
-      case SCRIPT:
-      case STRING:
-      case TEXT:
-        return queryRuleValue;
-      case CATEGORICAL:
-      case CATEGORICAL_MREF:
-      case FILE:
-      case MREF:
-      case ONE_TO_MANY:
-      case XREF:
-        return queryRuleValue instanceof Entity
-            ? ((Entity) queryRuleValue).getIdValue()
-            : queryRuleValue;
-      case DATE:
-        if (queryRuleValue instanceof LocalDate) {
-          return queryRuleValue.toString();
-        } else if (queryRuleValue instanceof String) {
-          return queryRuleValue;
-        } else {
-          throw new MolgenisQueryException(
-              format(
-                  "Query value must be of type LocalDate instead of [%s]",
-                  queryRuleValue.getClass().getSimpleName()));
-        }
-      case DATE_TIME:
-        if (queryRuleValue instanceof Instant) {
-          return queryRuleValue.toString();
-        } else if (queryRuleValue instanceof String) {
-          return queryRuleValue;
-        } else {
-          throw new MolgenisQueryException(
-              format(
-                  "Query value must be of type Instant instead of [%s]",
-                  queryRuleValue.getClass().getSimpleName()));
-        }
-      case COMPOUND:
-        throw new MolgenisQueryException(new IllegalAttributeTypeException(attrType));
-      default:
-        throw new UnexpectedEnumException(attrType);
-    }
   }
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseGeneratorTest.java
@@ -1,0 +1,171 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.elasticsearch.index.query.QueryBuilders.termQuery;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class BaseQueryClauseGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private BaseQueryClauseGenerator queryGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryGenerator =
+        new BaseQueryClauseGenerator(documentIdGenerator, Operator.EQUALS) {
+          @Override
+          QueryBuilder mapQueryRule(QueryRule queryRule, EntityType entityType) {
+            return null;
+          }
+        };
+  }
+
+  @Test
+  void testNestedQueryBuilderSizeOne() {
+    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(1).getMock();
+    String fieldName = "attribute";
+    String queryValue = "value";
+    QueryBuilder queryBuilder = termQuery(fieldName, queryValue);
+
+    Attribute attribute = mock(Attribute.class);
+    QueryBuilder nestedQueryBuilder =
+        queryGenerator.nestedQueryBuilder(entityType, singletonList(attribute), queryBuilder);
+    assertQueryBuilderEquals(nestedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void testNestedQueryBuilderSizeTwo() {
+    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(1).getMock();
+    String parentFieldName = "parent";
+    String childFieldName = "child";
+    String queryValue = "value";
+    QueryBuilder queryBuilder = termQuery(parentFieldName + '.' + childFieldName, queryValue);
+
+    Attribute parentAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(parentAttribute)).thenReturn(parentFieldName);
+    Attribute childAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(childAttribute)).thenReturn(childFieldName);
+    QueryBuilder nestedQueryBuilder =
+        queryGenerator.nestedQueryBuilder(
+            entityType, asList(parentAttribute, childAttribute), queryBuilder);
+
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.nestedQuery(
+            parentFieldName,
+            termQuery(parentFieldName + '.' + childFieldName, queryValue),
+            ScoreMode.Avg);
+    assertQueryBuilderEquals(nestedQueryBuilder, expectedQueryBuilder);
+  }
+
+  @Test
+  void testNestedQueryBuilderSizeThree() {
+    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(2).getMock();
+    String grandparentFieldName = "grandparent";
+    String parentFieldName = "parent";
+    String childFieldName = "child";
+    String queryValue = "value";
+    QueryBuilder queryBuilder =
+        termQuery(grandparentFieldName + '.' + parentFieldName + '.' + childFieldName, queryValue);
+
+    Attribute grandparentAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(grandparentAttribute)).thenReturn(grandparentFieldName);
+    Attribute parentAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(parentAttribute)).thenReturn(parentFieldName);
+    Attribute childAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(childAttribute)).thenReturn(childFieldName);
+    QueryBuilder nestedQueryBuilder =
+        queryGenerator.nestedQueryBuilder(
+            entityType,
+            asList(grandparentAttribute, parentAttribute, childAttribute),
+            queryBuilder);
+
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.nestedQuery(
+            grandparentFieldName,
+            QueryBuilders.nestedQuery(
+                grandparentFieldName + '.' + parentFieldName,
+                termQuery(
+                    grandparentFieldName + '.' + parentFieldName + '.' + childFieldName,
+                    queryValue),
+                ScoreMode.Avg),
+            ScoreMode.Avg);
+    assertQueryBuilderEquals(nestedQueryBuilder, expectedQueryBuilder);
+  }
+
+  @Test
+  void testNestedQueryBuilderSizeFour() {
+    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(3).getMock();
+    String greatGrandparentFieldName = "grandGrandparent";
+    String grandparentFieldName = "grandparent";
+    String parentFieldName = "parent";
+    String childFieldName = "child";
+    String queryValue = "value";
+    QueryBuilder queryBuilder =
+        termQuery(
+            greatGrandparentFieldName
+                + '.'
+                + grandparentFieldName
+                + '.'
+                + parentFieldName
+                + '.'
+                + childFieldName,
+            queryValue);
+
+    Attribute greatGrandparentAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(greatGrandparentAttribute))
+        .thenReturn(greatGrandparentFieldName);
+    Attribute grandparentAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(grandparentAttribute)).thenReturn(grandparentFieldName);
+    Attribute parentAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(parentAttribute)).thenReturn(parentFieldName);
+    Attribute childAttribute = mock(Attribute.class);
+    when(documentIdGenerator.generateId(childAttribute)).thenReturn(childFieldName);
+    QueryBuilder nestedQueryBuilder =
+        queryGenerator.nestedQueryBuilder(
+            entityType,
+            asList(
+                greatGrandparentAttribute, grandparentAttribute, parentAttribute, childAttribute),
+            queryBuilder);
+
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.nestedQuery(
+            greatGrandparentFieldName,
+            QueryBuilders.nestedQuery(
+                greatGrandparentFieldName + '.' + grandparentFieldName,
+                QueryBuilders.nestedQuery(
+                    greatGrandparentFieldName + '.' + grandparentFieldName + '.' + parentFieldName,
+                    termQuery(
+                        greatGrandparentFieldName
+                            + '.'
+                            + grandparentFieldName
+                            + '.'
+                            + parentFieldName
+                            + '.'
+                            + childFieldName,
+                        queryValue),
+                    ScoreMode.Avg),
+                ScoreMode.Avg),
+            ScoreMode.Avg);
+    assertQueryBuilderEquals(nestedQueryBuilder, expectedQueryBuilder);
+  }
+
+  private void assertQueryBuilderEquals(QueryBuilder actual, QueryBuilder expected) {
+    // QueryBuilder classes do not implement equals
+    assertEquals(
+        expected.toString().replaceAll("\\s", ""), actual.toString().replaceAll("\\s", ""));
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseRangeGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/BaseQueryClauseRangeGeneratorTest.java
@@ -1,0 +1,45 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class BaseQueryClauseRangeGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private BaseQueryClauseRangeGenerator baseQueryClauseRangeGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    baseQueryClauseRangeGenerator =
+        new BaseQueryClauseRangeGenerator(documentIdGenerator, Operator.GREATER) {};
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void mapQueryRuleNullValue() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    assertThrows(
+        MolgenisQueryException.class,
+        () -> baseQueryClauseRangeGenerator.mapQueryRule(queryRule, entityType));
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryBuilderAssertions.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryBuilderAssertions.java
@@ -1,0 +1,15 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+
+public class QueryBuilderAssertions {
+  private QueryBuilderAssertions() {}
+
+  public static void assertQueryBuilderEquals(QueryBuilder expected, QueryBuilder actual) {
+    // QueryBuilder classes do not implement equals
+    assertEquals(
+        expected.toString().replaceAll("\\s", ""), actual.toString().replaceAll("\\s", ""));
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseEqualsGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseEqualsGeneratorTest.java
@@ -1,0 +1,83 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseEqualsGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseEqualsGenerator queryClauseEqualsGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseEqualsGenerator = new QueryClauseEqualsGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRuleNonNullValues() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseEqualsGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.termQuery("attr.raw", "val"));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleNonNullIntValues() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(0);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseEqualsGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.termQuery("attr", 0));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleNullValue() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseEqualsGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(
+            QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("attr")));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchGeneratorTest.java
@@ -1,0 +1,65 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseFuzzyMatchGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseFuzzyMatchGenerator queryClauseFuzzyMatchGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseFuzzyMatchGenerator = new QueryClauseFuzzyMatchGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseFuzzyMatchGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder = QueryBuilders.queryStringQuery("attr:(val)");
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void mapQueryRuleIllegalAttributeType() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.BOOL);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    assertThrows(
+        MolgenisQueryException.class,
+        () -> queryClauseFuzzyMatchGenerator.mapQueryRule(queryRule, entityType));
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchNgramGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseFuzzyMatchNgramGeneratorTest.java
@@ -1,0 +1,46 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseFuzzyMatchNgramGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseFuzzyMatchNgramGenerator queryClauseFuzzyMatchNgramGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseFuzzyMatchNgramGenerator =
+        new QueryClauseFuzzyMatchNgramGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder =
+        queryClauseFuzzyMatchNgramGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder = QueryBuilders.queryStringQuery("attr.ngram:(val)");
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterEqualGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterEqualGeneratorTest.java
@@ -1,0 +1,46 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseGreaterEqualGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseGreaterEqualGenerator queryClauseGreaterEqualGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseGreaterEqualGenerator = new QueryClauseGreaterEqualGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(2);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder =
+        queryClauseGreaterEqualGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.rangeQuery("attr").gte(2));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseGreaterGeneratorTest.java
@@ -1,0 +1,45 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseGreaterGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseGreaterGenerator queryClauseGreaterGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseGreaterGenerator = new QueryClauseGreaterGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(2);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseGreaterGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.rangeQuery("attr").gt(2));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseInGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseInGeneratorTest.java
@@ -1,0 +1,110 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseInGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseInGenerator queryClauseInGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseInGenerator = new QueryClauseInGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRuleNonNullValues() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(asList("val0", "val1"));
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseInGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.termsQuery("attr.raw", "val0", "val1"));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleNonNullIntValues() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(asList(0, 1));
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseInGenerator.mapQueryRule(queryRule, entityType);
+    @SuppressWarnings("RedundantArrayCreation")
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.termsQuery("attr", new int[] {0, 1}));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleNullValue() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(singletonList(null));
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseInGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(
+            QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("attr")));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleNonNullValuesAndNullValue() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(asList("val0", "val1", null));
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseInGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(
+            QueryBuilders.boolQuery()
+                .minimumShouldMatch(1)
+                .should(QueryBuilders.termsQuery("attr.raw", "val0", "val1"))
+                .should(QueryBuilders.boolQuery().mustNot(QueryBuilders.existsQuery("attr"))));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessEqualGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessEqualGeneratorTest.java
@@ -1,0 +1,45 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseLessEqualGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseLessEqualGenerator queryClauseLessEqualGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseLessEqualGenerator = new QueryClauseLessEqualGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(2);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseLessEqualGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.rangeQuery("attr").lte(2));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseLessGeneratorTest.java
@@ -1,0 +1,45 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseLessGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseLessGenerator queryClauseLessGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseLessGenerator = new QueryClauseLessGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(2);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseLessGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.rangeQuery("attr").lt(2));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseLikeGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseLikeGeneratorTest.java
@@ -1,0 +1,87 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseLikeGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseLikeGenerator queryClauseLikeGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseLikeGenerator = new QueryClauseLikeGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseLikeGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.matchPhrasePrefixQuery("attr", "val")
+            .maxExpansions(50)
+            .slop(10)
+            .analyzer("default");
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleUnsupportedType() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(0);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.TEXT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    assertThrows(
+        UnsupportedOperationException.class,
+        () -> queryClauseLikeGenerator.mapQueryRule(queryRule, entityType));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void mapQueryRuleIllegalType() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(0);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.BOOL);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    assertThrows(
+        MolgenisQueryException.class,
+        () -> queryClauseLikeGenerator.mapQueryRule(queryRule, entityType));
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseRangeGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseRangeGeneratorTest.java
@@ -1,0 +1,85 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import com.google.common.collect.ImmutableList;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.MolgenisQueryException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseRangeGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseRangeGenerator queryClauseRangeGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseRangeGenerator = new QueryClauseRangeGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRule() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(ImmutableList.of(2, 4));
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseRangeGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.constantScoreQuery(QueryBuilders.rangeQuery("attr").from(2).to(4));
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void mapQueryRuleNullValue() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    assertThrows(
+        MolgenisQueryException.class,
+        () -> queryClauseRangeGenerator.mapQueryRule(queryRule, entityType));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void mapQueryRuleNonRangeValue() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn(2);
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.INT);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    assertThrows(
+        MolgenisQueryException.class,
+        () -> queryClauseRangeGenerator.mapQueryRule(queryRule, entityType));
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
@@ -51,7 +51,7 @@ class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
     when(entityType.getAttributeByName("attr")).thenReturn(attribute);
 
     QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
-    QueryBuilder expectedQueryBuilder = QueryBuilders.matchQuery("attr", "val");
+    QueryBuilder expectedQueryBuilder = QueryBuilders.matchPhraseQuery("attr", "val").slop(10);
     assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
   }
 
@@ -78,7 +78,7 @@ class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
     QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
     QueryBuilder expectedQueryBuilder =
         QueryBuilders.nestedQuery(
-            "attr", QueryBuilders.matchQuery("attr.refAttr", "val"), ScoreMode.Avg);
+            "attr", QueryBuilders.matchPhraseQuery("attr.refAttr", "val").slop(10), ScoreMode.Avg);
     assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
   }
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
@@ -3,14 +3,15 @@ package org.molgenis.data.elasticsearch.generator;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+import static org.molgenis.data.meta.AttributeType.STRING;
 
+import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.molgenis.data.QueryRule;
-import org.molgenis.data.meta.AttributeType;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.test.AbstractMockitoTest;
@@ -43,7 +44,7 @@ class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
     when(queryRule.getValue()).thenReturn("val");
 
     Attribute attribute = mock(Attribute.class);
-    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(attribute.getDataType()).thenReturn(STRING);
     when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
 
     EntityType entityType = mock(EntityType.class);
@@ -51,6 +52,33 @@ class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
 
     QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
     QueryBuilder expectedQueryBuilder = QueryBuilders.matchQuery("attr", "val");
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleAttributeSearchReferencedAttribute() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute refIdAttribute = mock(Attribute.class);
+    when(refIdAttribute.getDataType()).thenReturn(STRING);
+    EntityType refEntityType = mock(EntityType.class);
+    when(refEntityType.getIdAttribute()).thenReturn(refIdAttribute);
+    when(documentIdGenerator.generateId(refIdAttribute)).thenReturn("refAttr");
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.hasRefEntity()).thenReturn(true);
+    when(attribute.getRefEntity()).thenReturn(refEntityType);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getIndexingDepth()).thenReturn(1);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder =
+        QueryBuilders.nestedQuery(
+            "attr", QueryBuilders.matchQuery("attr.refAttr", "val"), ScoreMode.Avg);
     assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
   }
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
@@ -1,0 +1,56 @@
+package org.molgenis.data.elasticsearch.generator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
+
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
+  @Mock DocumentIdGenerator documentIdGenerator;
+  private QueryClauseSearchGenerator queryClauseSearchGenerator;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    queryClauseSearchGenerator = new QueryClauseSearchGenerator(documentIdGenerator);
+  }
+
+  @Test
+  void mapQueryRuleAllAttributeSearch() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getValue()).thenReturn("val");
+
+    EntityType entityType = mock(EntityType.class);
+
+    QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder = QueryBuilders.matchPhraseQuery("_all", "val").slop(10);
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+
+  @Test
+  void mapQueryRuleAttributeSearch() {
+    QueryRule queryRule = mock(QueryRule.class);
+    when(queryRule.getField()).thenReturn("attr");
+    when(queryRule.getValue()).thenReturn("val");
+
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getDataType()).thenReturn(AttributeType.STRING);
+    when(documentIdGenerator.generateId(attribute)).thenReturn("attr");
+
+    EntityType entityType = mock(EntityType.class);
+    when(entityType.getAttributeByName("attr")).thenReturn(attribute);
+
+    QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
+    QueryBuilder expectedQueryBuilder = QueryBuilders.matchQuery("attr", "val");
+    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
+  }
+}

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIT.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIT.java
@@ -1,7 +1,6 @@
 package org.molgenis.data.elasticsearch.generator;
 
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
@@ -12,13 +11,13 @@ import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termsQuery;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
 import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
 import static org.molgenis.data.meta.AttributeType.BOOL;
 import static org.molgenis.data.meta.AttributeType.CATEGORICAL;
 import static org.molgenis.data.meta.AttributeType.COMPOUND;
@@ -46,7 +45,6 @@ import java.util.Arrays;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.junit.jupiter.MockitoSettings;
@@ -64,9 +62,8 @@ import org.molgenis.data.support.DynamicEntity;
 import org.molgenis.data.support.QueryImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 
-// FIXME add nillable tests
 @MockitoSettings(strictness = Strictness.LENIENT)
-class QueryGeneratorTest extends AbstractMolgenisSpringTest {
+class QueryGeneratorIT extends AbstractMolgenisSpringTest {
   private static final String idAttrName = "xid";
 
   private static final String boolAttrName = "xbool";
@@ -169,134 +166,6 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void testNestedQueryBuilderSizeOne() {
-    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(1).getMock();
-    String fieldName = "attribute";
-    String queryValue = "value";
-    QueryBuilder queryBuilder = termQuery(fieldName, queryValue);
-
-    Attribute attribute = when(mock(Attribute.class).getName()).thenReturn(fieldName).getMock();
-    QueryBuilder nestedQueryBuilder =
-        queryGenerator.nestedQueryBuilder(entityType, singletonList(attribute), queryBuilder);
-    assertQueryBuilderEquals(nestedQueryBuilder, queryBuilder);
-  }
-
-  @Test
-  void testNestedQueryBuilderSizeTwo() {
-    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(1).getMock();
-    String parentFieldName = "parent";
-    String childFieldName = "child";
-    String queryValue = "value";
-    QueryBuilder queryBuilder = termQuery(parentFieldName + '.' + childFieldName, queryValue);
-
-    Attribute parentAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(parentFieldName).getMock();
-    Attribute childAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(childFieldName).getMock();
-    QueryBuilder nestedQueryBuilder =
-        queryGenerator.nestedQueryBuilder(
-            entityType, asList(parentAttribute, childAttribute), queryBuilder);
-
-    QueryBuilder expectedQueryBuilder =
-        QueryBuilders.nestedQuery(
-            parentFieldName,
-            termQuery(parentFieldName + '.' + childFieldName, queryValue),
-            ScoreMode.Avg);
-    assertQueryBuilderEquals(nestedQueryBuilder, expectedQueryBuilder);
-  }
-
-  @Test
-  void testNestedQueryBuilderSizeThree() {
-    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(2).getMock();
-    String grandparentFieldName = "grandparent";
-    String parentFieldName = "parent";
-    String childFieldName = "child";
-    String queryValue = "value";
-    QueryBuilder queryBuilder =
-        termQuery(grandparentFieldName + '.' + parentFieldName + '.' + childFieldName, queryValue);
-
-    Attribute grandparentAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(grandparentFieldName).getMock();
-    Attribute parentAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(parentFieldName).getMock();
-    Attribute childAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(childFieldName).getMock();
-    QueryBuilder nestedQueryBuilder =
-        queryGenerator.nestedQueryBuilder(
-            entityType,
-            asList(grandparentAttribute, parentAttribute, childAttribute),
-            queryBuilder);
-
-    QueryBuilder expectedQueryBuilder =
-        QueryBuilders.nestedQuery(
-            grandparentFieldName,
-            QueryBuilders.nestedQuery(
-                grandparentFieldName + '.' + parentFieldName,
-                termQuery(
-                    grandparentFieldName + '.' + parentFieldName + '.' + childFieldName,
-                    queryValue),
-                ScoreMode.Avg),
-            ScoreMode.Avg);
-    assertQueryBuilderEquals(nestedQueryBuilder, expectedQueryBuilder);
-  }
-
-  @Test
-  void testNestedQueryBuilderSizeFour() {
-    EntityType entityType = when(mock(EntityType.class).getIndexingDepth()).thenReturn(3).getMock();
-    String greatGrandparentFieldName = "grandGrandparent";
-    String grandparentFieldName = "grandparent";
-    String parentFieldName = "parent";
-    String childFieldName = "child";
-    String queryValue = "value";
-    QueryBuilder queryBuilder =
-        termQuery(
-            greatGrandparentFieldName
-                + '.'
-                + grandparentFieldName
-                + '.'
-                + parentFieldName
-                + '.'
-                + childFieldName,
-            queryValue);
-
-    Attribute greatGrandparentAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(greatGrandparentFieldName).getMock();
-    Attribute grandparentAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(grandparentFieldName).getMock();
-    Attribute parentAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(parentFieldName).getMock();
-    Attribute childAttribute =
-        when(mock(Attribute.class).getName()).thenReturn(childFieldName).getMock();
-    QueryBuilder nestedQueryBuilder =
-        queryGenerator.nestedQueryBuilder(
-            entityType,
-            asList(
-                greatGrandparentAttribute, grandparentAttribute, parentAttribute, childAttribute),
-            queryBuilder);
-
-    QueryBuilder expectedQueryBuilder =
-        QueryBuilders.nestedQuery(
-            greatGrandparentFieldName,
-            QueryBuilders.nestedQuery(
-                greatGrandparentFieldName + '.' + grandparentFieldName,
-                QueryBuilders.nestedQuery(
-                    greatGrandparentFieldName + '.' + grandparentFieldName + '.' + parentFieldName,
-                    termQuery(
-                        greatGrandparentFieldName
-                            + '.'
-                            + grandparentFieldName
-                            + '.'
-                            + parentFieldName
-                            + '.'
-                            + childFieldName,
-                        queryValue),
-                    ScoreMode.Avg),
-                ScoreMode.Avg),
-            ScoreMode.Avg);
-    assertQueryBuilderEquals(nestedQueryBuilder, expectedQueryBuilder);
-  }
-
-  @Test
   void generateOneQueryRuleGreaterInvalidAttribute() {
     String value = "str";
     Query<Entity> q = new QueryImpl<>().gt(stringAttrName, value);
@@ -311,7 +180,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().gt(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(dateAttrName).gt(date));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -321,7 +190,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(rangeQuery(dateTimeAttrName).gt(DataConverter.toString(value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -330,7 +199,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().gt(decimalAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(decimalAttrName).gt(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -339,7 +208,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().gt(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(intAttrName).gt(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -348,7 +217,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().gt(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(longAttrName).gt(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -366,7 +235,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().ge(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(dateAttrName).gte(date));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -376,7 +245,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(rangeQuery(dateTimeAttrName).gte(DataConverter.toString(value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -385,7 +254,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().ge(decimalAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(decimalAttrName).gte(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -394,7 +263,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().ge(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(intAttrName).gte(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -403,7 +272,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().ge(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(longAttrName).gte(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -421,7 +290,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().le(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(dateAttrName).lte(date));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -431,7 +300,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(rangeQuery(dateTimeAttrName).lte(DataConverter.toString(value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -440,7 +309,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().le(decimalAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(decimalAttrName).lte(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -449,7 +318,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().le(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(intAttrName).lte(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -458,7 +327,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().le(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(longAttrName).lte(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -476,7 +345,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termsQuery(boolAttrName, Boolean.TRUE, Boolean.FALSE));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -492,7 +361,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                     categoricalAttrName + '.' + idAttrName + '.' + FIELD_NOT_ANALYZED,
                     new Object[] {"id0", "id1", "id2"}),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -515,7 +384,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                     categoricalAttrName + '.' + idAttrName + '.' + FIELD_NOT_ANALYZED,
                     new Object[] {"id0", "id1", "id2"}),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -528,7 +397,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(dateAttrName, new Object[] {date1.toString(), date2.toString()}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -541,7 +410,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(dateTimeAttrName, new Object[] {date1.toString(), date2.toString()}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -553,7 +422,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termsQuery(decimalAttrName, new Object[] {double1, double2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -566,7 +435,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(emailAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -579,7 +448,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(enumAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -592,7 +461,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(htmlAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -606,7 +475,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
         constantScoreQuery(
             termsQuery(
                 hyperlinkAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -618,7 +487,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termsQuery(intAttrName, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -630,7 +499,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termsQuery(longAttrName, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -653,7 +522,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                     mrefAttrName + '.' + idAttrName + '.' + FIELD_NOT_ANALYZED,
                     new Object[] {"id0", "id1", "id2"}),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -669,7 +538,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                     mrefAttrName + '.' + idAttrName + '.' + FIELD_NOT_ANALYZED,
                     new Object[] {"id0", "id1", "id2"}),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -682,7 +551,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(scriptAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -695,7 +564,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(stringAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -708,7 +577,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         constantScoreQuery(
             termsQuery(textAttrName + '.' + FIELD_NOT_ANALYZED, new Object[] {value1, value2}));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -724,7 +593,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                     xrefAttrName + '.' + idAttrName + '.' + FIELD_NOT_ANALYZED,
                     new Object[] {"id0", "id1", "id2"}),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -747,7 +616,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                     xrefAttrName + '.' + idAttrName + '.' + FIELD_NOT_ANALYZED,
                     new Object[] {"id0", "id1", "id2"}),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -757,7 +626,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().lt(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(dateAttrName).lt(date));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -767,7 +636,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(rangeQuery(dateTimeAttrName).lt(DataConverter.toString(value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -776,7 +645,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().lt(decimalAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(decimalAttrName).lt(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -785,7 +654,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().lt(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(intAttrName).lt(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -794,7 +663,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().lt(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(longAttrName).lt(value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -829,7 +698,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         matchPhrasePrefixQuery(compoundPart0AttrName, value).slop(10).analyzer(DEFAULT_ANALYZER);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -863,7 +732,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         matchPhrasePrefixQuery(emailAttrName, value).slop(10).analyzer(DEFAULT_ANALYZER);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -873,7 +742,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         matchPhrasePrefixQuery(enumAttrName, value).slop(10).analyzer(DEFAULT_ANALYZER);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -892,7 +761,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         matchPhrasePrefixQuery(hyperlinkAttrName, value).slop(10).analyzer(DEFAULT_ANALYZER);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -936,7 +805,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         matchPhrasePrefixQuery(stringAttrName, value).slop(10).analyzer(DEFAULT_ANALYZER);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -963,11 +832,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(boolAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(boolAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleEqualsCategoricalNull() {
     String value = null;
@@ -981,7 +848,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                         categoricalAttrName,
                         existsQuery(categoricalAttrName + ".xid"),
                         ScoreMode.Avg)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -999,7 +866,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(compoundPart0AttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1008,7 +875,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(dateAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1018,7 +885,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(dateTimeAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1028,7 +895,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(decimalAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1038,7 +905,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(emailAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1047,7 +914,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(enumAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(enumAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1056,7 +923,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(htmlAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(htmlAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1066,7 +933,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(hyperlinkAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1075,7 +942,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(intAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1084,7 +951,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(longAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   // TODO enable when implemented in QueryGenerator (see note in QueryGenerator)
@@ -1100,7 +967,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(scriptAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1110,7 +977,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(boolQuery().mustNot(existsQuery(stringAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1119,11 +986,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(textAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(boolQuery().mustNot(existsQuery(textAttrName)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleEqualsXrefNull() {
     String value = null;
@@ -1134,7 +999,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
             boolQuery()
                 .mustNot(
                     nestedQuery(xrefAttrName, existsQuery(xrefAttrName + ".xid"), ScoreMode.Avg)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1144,11 +1009,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(boolAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleNotEqualsCategoricalNull() {
     String value = null;
@@ -1164,7 +1027,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                                 categoricalAttrName,
                                 existsQuery(categoricalAttrName + ".xid"),
                                 ScoreMode.Avg))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1183,7 +1046,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         boolQuery()
             .mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(compoundPart0AttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1193,7 +1056,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(dateAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1203,7 +1066,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(dateTimeAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1213,7 +1076,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(decimalAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1223,7 +1086,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(emailAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1233,7 +1096,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(enumAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1243,7 +1106,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(htmlAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1254,7 +1117,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         boolQuery()
             .mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(hyperlinkAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1264,7 +1127,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(intAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1274,7 +1137,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(longAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   // TODO enable when implemented in QueryGenerator (see note in QueryGenerator)
@@ -1290,7 +1153,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(scriptAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1300,7 +1163,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(stringAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1310,11 +1173,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(boolQuery().mustNot(existsQuery(textAttrName))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleNotEqualsXrefNull() {
     String value = null;
@@ -1328,7 +1189,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                         .mustNot(
                             nestedQuery(
                                 xrefAttrName, existsQuery(xrefAttrName + ".xid"), ScoreMode.Avg))));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1337,11 +1198,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(boolAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(termQuery(boolAttrName, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleEqualsCategorical() {
     String value = "id";
@@ -1353,7 +1212,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                 categoricalAttrName,
                 termQuery(categoricalAttrName + ".xid." + FIELD_NOT_ANALYZED, value),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1371,7 +1230,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(compoundPart0AttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1380,7 +1239,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(termQuery(dateAttrName, "2015-01-15"));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1389,7 +1248,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(dateTimeAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(termQuery(dateTimeAttrName, value.toString()));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1398,7 +1257,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(decimalAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(termQuery(decimalAttrName, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1408,7 +1267,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(emailAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1418,7 +1277,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(enumAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1428,7 +1287,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(htmlAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1438,7 +1297,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(hyperlinkAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1447,7 +1306,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(termQuery(intAttrName, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1456,7 +1315,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().eq(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(termQuery(longAttrName, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   // TODO enable when implemented in QueryGenerator (see note in QueryGenerator)
@@ -1472,7 +1331,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(scriptAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1482,7 +1341,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(stringAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1492,11 +1351,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         constantScoreQuery(termQuery(textAttrName + '.' + FIELD_NOT_ANALYZED, value));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleEqualsXref() {
     String value = "id";
@@ -1508,7 +1365,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                 xrefAttrName,
                 termQuery(xrefAttrName + ".xid." + FIELD_NOT_ANALYZED, value),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1518,11 +1375,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(termQuery(boolAttrName, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleNotEqualsCategorical() {
     String value = "id";
@@ -1536,7 +1391,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                         categoricalAttrName,
                         termQuery(categoricalAttrName + ".xid." + FIELD_NOT_ANALYZED, value),
                         ScoreMode.Avg)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1557,7 +1412,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
             .mustNot(
                 constantScoreQuery(
                     termQuery(compoundPart0AttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1567,7 +1422,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(termQuery(dateAttrName, value.toString())));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1577,7 +1432,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(termQuery(dateTimeAttrName, value.toString())));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1587,7 +1442,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(termQuery(decimalAttrName, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1599,7 +1454,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
         boolQuery()
             .mustNot(
                 constantScoreQuery(termQuery(emailAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1610,7 +1465,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         boolQuery()
             .mustNot(constantScoreQuery(termQuery(enumAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1621,7 +1476,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         boolQuery()
             .mustNot(constantScoreQuery(termQuery(htmlAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1633,7 +1488,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
         boolQuery()
             .mustNot(
                 constantScoreQuery(termQuery(hyperlinkAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1643,7 +1498,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(termQuery(intAttrName, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1653,7 +1508,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         boolQuery().mustNot(constantScoreQuery(termQuery(longAttrName, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   // TODO enable when implemented in QueryGenerator (see note in QueryGenerator)
@@ -1671,7 +1526,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
         boolQuery()
             .mustNot(
                 constantScoreQuery(termQuery(scriptAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1683,7 +1538,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
         boolQuery()
             .mustNot(
                 constantScoreQuery(termQuery(stringAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1694,11 +1549,9 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         boolQuery()
             .mustNot(constantScoreQuery(termQuery(textAttrName + '.' + FIELD_NOT_ANALYZED, value)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
-  // FIXME add test for ref entity where id attribute is int
-  // FIXME add test where value is entity
   @Test
   void generateOneQueryRuleNotEqualsXref() {
     String value = "id";
@@ -1712,7 +1565,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
                         xrefAttrName,
                         termQuery(xrefAttrName + ".xid." + FIELD_NOT_ANALYZED, value),
                         ScoreMode.Avg)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1722,7 +1575,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().rng(intAttrName, low, high);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(intAttrName).gte(3).lte(9));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1732,7 +1585,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().rng(longAttrName, low, high);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = constantScoreQuery(rangeQuery(longAttrName).gte(3).lte(9));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1741,7 +1594,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchPhraseQuery("_all", value).slop(10);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1760,7 +1613,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         nestedQuery(
             categoricalAttrName, matchQuery(categoricalAttrName + "._all", value), ScoreMode.Avg);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1777,7 +1630,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(compoundPart0AttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(compoundPart0AttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1786,7 +1639,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(dateAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(dateAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1795,7 +1648,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(dateTimeAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(dateTimeAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1804,7 +1657,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(decimalAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(decimalAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1813,7 +1666,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(emailAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(emailAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1822,7 +1675,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(enumAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(enumAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1831,7 +1684,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(htmlAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(htmlAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1840,7 +1693,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(hyperlinkAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(hyperlinkAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1849,7 +1702,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(intAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(intAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1858,7 +1711,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(longAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(longAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1868,7 +1721,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         nestedQuery(mrefAttrName, matchQuery(mrefAttrName + "._all", value), ScoreMode.Avg);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1877,7 +1730,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(scriptAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(scriptAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1886,7 +1739,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(stringAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(stringAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1895,7 +1748,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(textAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(textAttrName, value);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1905,7 +1758,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery =
         nestedQuery(xrefAttrName, matchQuery(xrefAttrName + "._all", value), ScoreMode.Avg);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -1931,7 +1784,7 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     BoolQueryBuilder stringIntQuery = boolQuery().must(stringQuery).must(intQuery);
     QueryBuilder expectedQuery =
         boolQuery().should(booleanQuery).should(stringIntQuery).minimumShouldMatch(1);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   // regression test for https://github.com/molgenis/molgenis/issues/2326
@@ -1957,12 +1810,6 @@ class QueryGeneratorTest extends AbstractMolgenisSpringTest {
     QueryBuilder intQuery = constantScoreQuery(termQuery(intAttrName, intValue));
     QueryBuilder expectedQuery =
         boolQuery().must(booleanQuery).mustNot(stringQuery).mustNot(intQuery);
-    assertQueryBuilderEquals(query, expectedQuery);
-  }
-
-  private void assertQueryBuilderEquals(QueryBuilder actual, QueryBuilder expected) {
-    // QueryBuilder classes do not implement equals
-    assertEquals(
-        expected.toString().replaceAll("\\s", ""), actual.toString().replaceAll("\\s", ""));
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIT.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIT.java
@@ -1591,7 +1591,7 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
     String value = "value";
     Query<Entity> q = new QueryImpl<>().search(compoundPart0AttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery = matchQuery(compoundPart0AttrName, value);
+    QueryBuilder expectedQuery = matchPhraseQuery(compoundPart0AttrName, value).slop(10);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 
@@ -1645,7 +1645,7 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
     String value = "<h1>html</h1>";
     Query<Entity> q = new QueryImpl<>().search(htmlAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery = matchQuery(htmlAttrName, value);
+    QueryBuilder expectedQuery = matchPhraseQuery(htmlAttrName, value).slop(10);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 
@@ -1681,7 +1681,7 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
     String value = "int a = 1;";
     Query<Entity> q = new QueryImpl<>().search(scriptAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery = matchQuery(scriptAttrName, value);
+    QueryBuilder expectedQuery = matchPhraseQuery(scriptAttrName, value).slop(10);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 
@@ -1690,7 +1690,7 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
     String value = "value";
     Query<Entity> q = new QueryImpl<>().search(stringAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery = matchQuery(stringAttrName, value);
+    QueryBuilder expectedQuery = matchPhraseQuery(stringAttrName, value).slop(10);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 
@@ -1699,7 +1699,7 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
     String value = "some long text";
     Query<Entity> q = new QueryImpl<>().search(textAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery = matchQuery(textAttrName, value);
+    QueryBuilder expectedQuery = matchPhraseQuery(textAttrName, value).slop(10);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIT.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIT.java
@@ -675,15 +675,6 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void generateOneQueryRuleLikeCategorical() {
-    String value = "value";
-    Query<Entity> q = new QueryImpl<>().like(categoricalAttrName, value);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> queryGenerator.createQueryBuilder(q, entityType));
-  }
-
-  @Test
   void generateOneQueryRuleLikeCompound() {
     String value = "value";
     Query<Entity> q = new QueryImpl<>().like(compoundAttrName, value);
@@ -781,15 +772,6 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void generateOneQueryRuleLikeMref() {
-    String value = "value";
-    Query<Entity> q = new QueryImpl<>().like(mrefAttrName, value);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> queryGenerator.createQueryBuilder(q, entityType));
-  }
-
-  @Test
   void generateOneQueryRuleLikeScript() {
     String value = "int a = 1;";
     Query<Entity> q = new QueryImpl<>().like(scriptAttrName, value);
@@ -812,15 +794,6 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
   void generateOneQueryRuleLikeText() {
     String value = "some long text";
     Query<Entity> q = new QueryImpl<>().like(textAttrName, value);
-    assertThrows(
-        UnsupportedOperationException.class,
-        () -> queryGenerator.createQueryBuilder(q, entityType));
-  }
-
-  @Test
-  void generateOneQueryRuleLikeXref() {
-    String value = "value";
-    Query<Entity> q = new QueryImpl<>().like(xrefAttrName, value);
     assertThrows(
         UnsupportedOperationException.class,
         () -> queryGenerator.createQueryBuilder(q, entityType));
@@ -1606,17 +1579,6 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void generateOneQueryRuleSearchOneFieldCategorical() {
-    String value = "text";
-    Query<Entity> q = new QueryImpl<>().search(categoricalAttrName, value);
-    QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery =
-        nestedQuery(
-            categoricalAttrName, matchQuery(categoricalAttrName + "._all", value), ScoreMode.Avg);
-    assertQueryBuilderEquals(expectedQuery, query);
-  }
-
-  @Test
   void generateOneQueryRuleSearchOneFieldCompound() {
     String value = "value";
     Query<Entity> q = new QueryImpl<>().search(compoundAttrName, value);
@@ -1715,16 +1677,6 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void generateOneQueryRuleSearchOneFieldMref() {
-    String value = "value";
-    Query<Entity> q = new QueryImpl<>().search(mrefAttrName, value);
-    QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery =
-        nestedQuery(mrefAttrName, matchQuery(mrefAttrName + "._all", value), ScoreMode.Avg);
-    assertQueryBuilderEquals(expectedQuery, query);
-  }
-
-  @Test
   void generateOneQueryRuleSearchOneFieldScript() {
     String value = "int a = 1;";
     Query<Entity> q = new QueryImpl<>().search(scriptAttrName, value);
@@ -1748,16 +1700,6 @@ class QueryGeneratorIT extends AbstractMolgenisSpringTest {
     Query<Entity> q = new QueryImpl<>().search(textAttrName, value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
     QueryBuilder expectedQuery = matchQuery(textAttrName, value);
-    assertQueryBuilderEquals(expectedQuery, query);
-  }
-
-  @Test
-  void generateOneQueryRuleSearchOneFieldXref() {
-    String value = "text";
-    Query<Entity> q = new QueryImpl<>().search(xrefAttrName, value);
-    QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery =
-        nestedQuery(xrefAttrName, matchQuery(xrefAttrName + "._all", value), ScoreMode.Avg);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesIT.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesIT.java
@@ -2,7 +2,7 @@ package org.molgenis.data.elasticsearch.generator;
 
 import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
-import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchPhraseQuery;
 import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -401,7 +401,7 @@ class QueryGeneratorReferencesIT extends AbstractMolgenisSpringTest {
     QueryBuilder expectedQuery =
         nestedQuery(
             REF_ENTITY_ATT,
-            matchQuery(PREFIX + refCompoundPart0AttributeName, value),
+            matchPhraseQuery(PREFIX + refCompoundPart0AttributeName, value).slop(10),
             ScoreMode.Avg);
     assertQueryBuilderEquals(expectedQuery, query);
   }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesIT.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesIT.java
@@ -394,14 +394,6 @@ class QueryGeneratorReferencesIT extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void generateOneQueryRuleSearchOneFieldCategorical() {
-    String value = "text";
-    Query<Entity> q = new QueryImpl<>().search(PREFIX + refCategoricalAttributeName, value);
-    assertThrows(
-        MolgenisQueryException.class, () -> queryGenerator.createQueryBuilder(q, entityType));
-  }
-
-  @Test
   void generateOneQueryRuleSearchOneFieldCompoundPartString() {
     String value = "value";
     Query<Entity> q = new QueryImpl<>().search(PREFIX + refCompoundPart0AttributeName, value);

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesIT.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorReferencesIT.java
@@ -6,13 +6,13 @@ import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.elasticsearch.FieldConstants.DEFAULT_ANALYZER;
 import static org.molgenis.data.elasticsearch.FieldConstants.FIELD_NOT_ANALYZED;
+import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
 import static org.molgenis.data.meta.AttributeType.BOOL;
 import static org.molgenis.data.meta.AttributeType.CATEGORICAL;
 import static org.molgenis.data.meta.AttributeType.COMPOUND;
@@ -57,9 +57,8 @@ import org.molgenis.data.support.QueryImpl;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /** Copy of standard QueryGeneratorTest but now with queries done on the referenced entity */
-// FIXME add nillable tests
 @MockitoSettings(strictness = Strictness.LENIENT)
-class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
+class QueryGeneratorReferencesIT extends AbstractMolgenisSpringTest {
   private EntityType entityType;
 
   private final String refBoolAttributeName = "xbool";
@@ -197,7 +196,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
         constantScoreQuery(
             nestedQuery(
                 REF_ENTITY_ATT, rangeQuery(PREFIX + refDateAttributeName).gt(date), ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -211,7 +210,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 rangeQuery(PREFIX + refDateTimeAttributeName).gt(DataConverter.toString(value)),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -225,7 +224,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 rangeQuery(PREFIX + refDecimalAttributeName).gt(value),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -237,7 +236,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
         constantScoreQuery(
             nestedQuery(
                 REF_ENTITY_ATT, rangeQuery(PREFIX + refIntAttributeName).gt(value), ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -251,7 +250,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 rangeQuery(PREFIX + refLongAttributeName).gt(value),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -267,7 +266,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 rangeQuery(PREFIX + refDateAttributeName).gte(date),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -281,7 +280,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 rangeQuery(PREFIX + refDecimalAttributeName).lte(value),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -293,15 +292,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
         constantScoreQuery(
             nestedQuery(
                 REF_ENTITY_ATT, rangeQuery(PREFIX + refIntAttributeName).lt(value), ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
-  }
-
-  @Test
-  void generateOneQueryRuleInCategorical_Ids() {
-    Iterable<String> values = Arrays.asList("id0", "id1", "id2");
-    Query<Entity> q = new QueryImpl<>().in(PREFIX + refCategoricalAttributeName, values);
-    assertThrows(
-        MolgenisQueryException.class, () -> queryGenerator.createQueryBuilder(q, entityType));
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -316,7 +307,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 .slop(10)
                 .analyzer(DEFAULT_ANALYZER),
             ScoreMode.Avg);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -328,7 +319,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
         constantScoreQuery(
             nestedQuery(
                 REF_ENTITY_ATT, termQuery(PREFIX + refBoolAttributeName, value), ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -342,15 +333,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 termQuery(PREFIX + refStringAttributeName + '.' + FIELD_NOT_ANALYZED, value),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
-  }
-
-  @Test
-  void generateOneQueryRuleEqualsCategorical() {
-    String value = "id";
-    Query<Entity> q = new QueryImpl<>().eq(PREFIX + refCategoricalAttributeName, value);
-    assertThrows(
-        MolgenisQueryException.class, () -> queryGenerator.createQueryBuilder(q, entityType));
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -366,15 +349,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                         REF_ENTITY_ATT,
                         termQuery(PREFIX + refBoolAttributeName, value),
                         ScoreMode.Avg)));
-    assertQueryBuilderEquals(query, expectedQuery);
-  }
-
-  @Test
-  void generateOneQueryRuleNotEqualsCategorical() {
-    String value = "id";
-    Query<Entity> q = new QueryImpl<>().not().eq(PREFIX + refCategoricalAttributeName, value);
-    assertThrows(
-        MolgenisQueryException.class, () -> queryGenerator.createQueryBuilder(q, entityType));
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -400,7 +375,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                             PREFIX + refCompoundPart0AttributeName + '.' + FIELD_NOT_ANALYZED,
                             value),
                         ScoreMode.Avg)));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -415,7 +390,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT,
                 rangeQuery(PREFIX + refIntAttributeName).gte(3).lte(9),
                 ScoreMode.Avg));
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -436,7 +411,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
             REF_ENTITY_ATT,
             matchQuery(PREFIX + refCompoundPart0AttributeName, value),
             ScoreMode.Avg);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -470,7 +445,7 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
     BoolQueryBuilder stringIntQuery = QueryBuilders.boolQuery().must(stringQuery).must(intQuery);
     QueryBuilder expectedQuery =
         QueryBuilders.boolQuery().should(booleanQuery).should(stringIntQuery).minimumShouldMatch(1);
-    assertQueryBuilderEquals(query, expectedQuery);
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 
   @Test
@@ -503,12 +478,6 @@ class QueryGeneratorReferencesTest extends AbstractMolgenisSpringTest {
                 REF_ENTITY_ATT, termQuery(PREFIX + refIntAttributeName, intValue), ScoreMode.Avg));
     QueryBuilder expectedQuery =
         QueryBuilders.boolQuery().must(booleanQuery).mustNot(stringQuery).mustNot(intQuery);
-    assertQueryBuilderEquals(query, expectedQuery);
-  }
-
-  private void assertQueryBuilderEquals(QueryBuilder actual, QueryBuilder expected) {
-    // QueryBuilder classes do not implement equals
-    assertEquals(
-        expected.toString().replaceAll("\\s", ""), actual.toString().replaceAll("\\s", ""));
+    assertQueryBuilderEquals(expectedQuery, query);
   }
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/EntityType.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/EntityType.java
@@ -522,6 +522,21 @@ public class EntityType extends StaticEntity implements Labeled {
   }
 
   /**
+   * Get attribute by name
+   *
+   * @param attributeName attribute name
+   * @return attribute, never <tt>null</tt>
+   * @throws UnknownAttributeException if no attribute exists for the given name
+   */
+  public Attribute getAttributeByName(String attributeName) {
+    Attribute attribute = getAttribute(attributeName);
+    if (attribute == null) {
+      throw new UnknownAttributeException(this, attributeName);
+    }
+    return attribute;
+  }
+
+  /**
    * Get own attribute by identifier
    *
    * @throws UnknownAttributeException if no attribute exists for the given identifier

--- a/molgenis-data/src/test/java/org/molgenis/data/QueryUtilsTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/QueryUtilsTest.java
@@ -14,29 +14,26 @@ import static org.molgenis.data.QueryRule.Operator.FUZZY_MATCH;
 import static org.molgenis.data.QueryRule.Operator.GREATER_EQUAL;
 import static org.molgenis.data.QueryRule.Operator.IN;
 import static org.molgenis.data.QueryRule.Operator.NESTED;
-import static org.molgenis.data.QueryRule.Operator.OR;
 import static org.molgenis.data.QueryRule.Operator.SHOULD;
 import static org.molgenis.data.QueryUtils.getQueryRuleAttribute;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.QueryImpl;
+import org.molgenis.test.AbstractMockitoTest;
 
-class QueryUtilsTest {
-  private Query<Entity> query;
-  private QueryRule rule3;
+class QueryUtilsTest extends AbstractMockitoTest {
+  @Mock private Query<Entity> query;
 
-  @SuppressWarnings("unchecked")
-  @BeforeEach
-  void beforeMethod() {
-    query = mock(Query.class);
-
+  @Test
+  void containsAnyOperator() {
     QueryRule rule1 = mock(QueryRule.class);
     when(rule1.getOperator()).thenReturn(IN);
     when(rule1.getNestedRules()).thenReturn(Collections.emptyList());
@@ -45,32 +42,70 @@ class QueryUtilsTest {
     when(rule2.getOperator()).thenReturn(DIS_MAX);
     when(rule2.getNestedRules()).thenReturn(Collections.emptyList());
 
-    rule3 = mock(QueryRule.class);
-    when(rule3.getOperator()).thenReturn(NESTED);
-    when(rule3.getNestedRules()).thenReturn(Collections.emptyList());
+    QueryRule rule3 = mock(QueryRule.class);
 
     List<QueryRule> queryRules = Lists.newArrayList(rule1, rule2, rule3);
     when(query.getRules()).thenReturn(queryRules);
-  }
 
-  @Test
-  void containsAnyOperator() {
     assertTrue(QueryUtils.containsAnyOperator(query, EnumSet.of(DIS_MAX, FUZZY_MATCH)));
   }
 
   @Test
   void notContainsAnyOperator() {
+    QueryRule rule1 = mock(QueryRule.class);
+    when(rule1.getOperator()).thenReturn(IN);
+    when(rule1.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule2 = mock(QueryRule.class);
+    when(rule2.getOperator()).thenReturn(DIS_MAX);
+    when(rule2.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule3 = mock(QueryRule.class);
+    when(rule3.getOperator()).thenReturn(NESTED);
+    when(rule3.getNestedRules()).thenReturn(Collections.emptyList());
+
+    List<QueryRule> queryRules = Lists.newArrayList(rule1, rule2, rule3);
+    when(query.getRules()).thenReturn(queryRules);
+
     assertFalse(
         QueryUtils.containsAnyOperator(query, EnumSet.of(FUZZY_MATCH, GREATER_EQUAL, SHOULD)));
   }
 
   @Test
   void containsOperator() {
+    QueryRule rule1 = mock(QueryRule.class);
+    when(rule1.getOperator()).thenReturn(IN);
+    when(rule1.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule2 = mock(QueryRule.class);
+    when(rule2.getOperator()).thenReturn(DIS_MAX);
+    when(rule2.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule3 = mock(QueryRule.class);
+
+    List<QueryRule> queryRules = Lists.newArrayList(rule1, rule2, rule3);
+    when(query.getRules()).thenReturn(queryRules);
+
     assertTrue(QueryUtils.containsOperator(query, DIS_MAX));
   }
 
   @Test
   void notContainsOperator() {
+    QueryRule rule1 = mock(QueryRule.class);
+    when(rule1.getOperator()).thenReturn(IN);
+    when(rule1.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule2 = mock(QueryRule.class);
+    when(rule2.getOperator()).thenReturn(DIS_MAX);
+    when(rule2.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule3 = mock(QueryRule.class);
+    when(rule3.getOperator()).thenReturn(NESTED);
+    when(rule3.getNestedRules()).thenReturn(Collections.emptyList());
+
+    List<QueryRule> queryRules = Lists.newArrayList(rule1, rule2, rule3);
+    when(query.getRules()).thenReturn(queryRules);
+
     assertFalse(QueryUtils.containsOperator(query, FUZZY_MATCH));
   }
 
@@ -82,6 +117,20 @@ class QueryUtilsTest {
 
   @Test
   void nestedQueryRules() {
+    QueryRule rule1 = mock(QueryRule.class);
+    when(rule1.getOperator()).thenReturn(IN);
+    when(rule1.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule2 = mock(QueryRule.class);
+    when(rule2.getOperator()).thenReturn(DIS_MAX);
+    when(rule2.getNestedRules()).thenReturn(Collections.emptyList());
+
+    QueryRule rule3 = mock(QueryRule.class);
+    when(rule3.getNestedRules()).thenReturn(Collections.emptyList());
+
+    List<QueryRule> queryRules = Lists.newArrayList(rule1, rule2, rule3);
+    when(query.getRules()).thenReturn(queryRules);
+
     QueryRule nestedRule = mock(QueryRule.class);
     when(nestedRule.getOperator()).thenReturn(EQUALS);
     when(rule3.getNestedRules()).thenReturn(Lists.newArrayList(nestedRule));
@@ -100,19 +149,15 @@ class QueryUtilsTest {
 
     when(qRule1.getField()).thenReturn("attr1");
     when(qRule2.getField()).thenReturn("attr2");
-    when(qRule1.getOperator()).thenReturn(EQUALS);
-    when(qRule2.getOperator()).thenReturn(OR);
     when(qRule1.getNestedRules()).thenReturn(Collections.emptyList());
     when(qRule2.getNestedRules()).thenReturn(Collections.emptyList());
     when(q.getRules()).thenReturn(Lists.newArrayList(qRule1, qRule2));
 
     Attribute attr1 = mock(Attribute.class);
     when(entityType.getAttribute("attr1")).thenReturn(attr1);
-    when(attr1.getExpression()).thenReturn(null);
 
     Attribute attr2 = mock(Attribute.class);
     when(entityType.getAttribute("attr2")).thenReturn(attr2);
-    when(attr2.getExpression()).thenReturn(null);
 
     assertFalse(QueryUtils.containsComputedAttribute(q.getRules(), entityType));
   }
@@ -128,8 +173,6 @@ class QueryUtilsTest {
 
     when(qRule1.getField()).thenReturn("attr1");
     when(qRule2.getField()).thenReturn("attr2");
-    when(qRule1.getOperator()).thenReturn(EQUALS);
-    when(qRule2.getOperator()).thenReturn(OR);
     when(qRule1.getNestedRules()).thenReturn(Collections.emptyList());
     when(qRule2.getNestedRules()).thenReturn(Collections.emptyList());
     when(q.getRules()).thenReturn(Lists.newArrayList(qRule1, qRule2));
@@ -171,34 +214,14 @@ class QueryUtilsTest {
     Query<Entity> q = mock(Query.class);
     QueryRule qRule1 = mock(QueryRule.class);
     QueryRule qRule2 = mock(QueryRule.class);
-    QueryRule nestedRule1 = mock(QueryRule.class);
-    QueryRule nestedRule2 = mock(QueryRule.class);
 
     when(qRule1.getField()).thenReturn("attr1");
-    when(qRule2.getField()).thenReturn("attr2");
-    when(nestedRule1.getField()).thenReturn("attr3");
-    when(nestedRule2.getField()).thenReturn("attr4");
 
-    when(qRule1.getOperator()).thenReturn(EQUALS);
-    when(qRule2.getOperator()).thenReturn(OR);
     when(qRule1.getNestedRules()).thenReturn(Collections.emptyList());
-    when(qRule2.getNestedRules()).thenReturn(Lists.newArrayList(nestedRule1, nestedRule2));
     when(q.getRules()).thenReturn(Lists.newArrayList(qRule1, qRule2));
 
     Attribute attr1 = mock(Attribute.class);
     when(entityType.getAttribute("attr1")).thenReturn(attr1);
-    when(attr1.hasExpression()).thenReturn(false);
-
-    Attribute attr2 = mock(Attribute.class);
-    when(entityType.getAttribute("attr2")).thenReturn(attr2);
-    when(attr2.hasExpression()).thenReturn(false);
-
-    Attribute attr3 = mock(Attribute.class);
-    when(entityType.getAttribute("attr3")).thenReturn(attr3);
-    when(attr1.hasExpression()).thenReturn(false);
-
-    Attribute attr4 = mock(Attribute.class);
-    when(entityType.getAttribute("attr4")).thenReturn(attr4);
     when(attr1.hasExpression()).thenReturn(true);
 
     assertTrue(QueryUtils.containsComputedAttribute(q.getRules(), entityType));
@@ -288,5 +311,106 @@ class QueryUtilsTest {
     when(queryRule1.getNestedRules()).thenReturn(singletonList(nestedQueryRule0));
     when(q.getRules()).thenReturn(asList(queryRule0, queryRule1));
     assertFalse(QueryUtils.containsNestedQueryRuleField(q));
+  }
+
+  @Test
+  void testGetAttributePathOneElement() {
+    String attributePath = "grandparent";
+    EntityType entityType = mock(EntityType.class);
+    Attribute attribute = mock(Attribute.class);
+    when(entityType.getAttributeByName(attributePath)).thenReturn(attribute);
+    assertEquals(
+        ImmutableList.of(attribute), QueryUtils.getAttributePath(attributePath, entityType));
+  }
+
+  @Test
+  void testGetAttributePathMultipleElements() {
+    EntityType grandparentEntityType = mock(EntityType.class);
+    EntityType parentEntityType = mock(EntityType.class);
+    EntityType childEntityType = mock(EntityType.class);
+    Attribute grandparentAttribute = mock(Attribute.class);
+    when(grandparentAttribute.hasRefEntity()).thenReturn(true);
+    when(grandparentAttribute.getRefEntity()).thenReturn(parentEntityType);
+    Attribute parentAttribute = mock(Attribute.class);
+    when(parentAttribute.hasRefEntity()).thenReturn(true);
+    when(parentAttribute.getRefEntity()).thenReturn(childEntityType);
+    Attribute childAttribute = mock(Attribute.class);
+    when(grandparentEntityType.getAttributeByName("grandparent")).thenReturn(grandparentAttribute);
+    when(parentEntityType.getAttributeByName("parent")).thenReturn(parentAttribute);
+    when(childEntityType.getAttributeByName("child")).thenReturn(childAttribute);
+    assertEquals(
+        ImmutableList.of(grandparentAttribute, parentAttribute, childAttribute),
+        QueryUtils.getAttributePath("grandparent.parent.child", grandparentEntityType));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  void testGetAttributePathMultipleElementsIllegalAttributeType() {
+    EntityType childEntityType = mock(EntityType.class);
+    Attribute childAttribute = mock(Attribute.class);
+    when(childEntityType.getAttributeByName("child")).thenReturn(childAttribute);
+    assertThrows(
+        MolgenisQueryException.class,
+        () -> QueryUtils.getAttributePath("child.parent", childEntityType));
+  }
+
+  @Test
+  void testGetAttributePathExpandedExpansionWithIdAttribute() {
+    EntityType grandparentEntityType = mock(EntityType.class);
+    EntityType parentEntityType = mock(EntityType.class);
+    EntityType childEntityType = mock(EntityType.class);
+    Attribute grandparentAttribute = mock(Attribute.class);
+    when(grandparentAttribute.hasRefEntity()).thenReturn(true);
+    when(grandparentAttribute.getRefEntity()).thenReturn(parentEntityType);
+    Attribute parentAttribute = mock(Attribute.class);
+    when(parentAttribute.hasRefEntity()).thenReturn(true);
+    when(parentAttribute.getRefEntity()).thenReturn(childEntityType);
+    Attribute childAttribute = mock(Attribute.class);
+    when(grandparentEntityType.getAttributeByName("grandparent")).thenReturn(grandparentAttribute);
+    when(parentEntityType.getAttributeByName("parent")).thenReturn(parentAttribute);
+    when(childEntityType.getIdAttribute()).thenReturn(childAttribute);
+    assertEquals(
+        ImmutableList.of(grandparentAttribute, parentAttribute, childAttribute),
+        QueryUtils.getAttributePathExpanded("grandparent.parent", grandparentEntityType));
+  }
+
+  @Test
+  void testGetAttributePathExpandedExpansionWithLabelAttribute() {
+    EntityType grandparentEntityType = mock(EntityType.class);
+    EntityType parentEntityType = mock(EntityType.class);
+    EntityType childEntityType = mock(EntityType.class);
+    Attribute grandparentAttribute = mock(Attribute.class);
+    when(grandparentAttribute.hasRefEntity()).thenReturn(true);
+    when(grandparentAttribute.getRefEntity()).thenReturn(parentEntityType);
+    Attribute parentAttribute = mock(Attribute.class);
+    when(parentAttribute.hasRefEntity()).thenReturn(true);
+    when(parentAttribute.getRefEntity()).thenReturn(childEntityType);
+    Attribute childAttribute = mock(Attribute.class);
+    when(grandparentEntityType.getAttributeByName("grandparent")).thenReturn(grandparentAttribute);
+    when(parentEntityType.getAttributeByName("parent")).thenReturn(parentAttribute);
+    when(childEntityType.getLabelAttribute()).thenReturn(childAttribute);
+    assertEquals(
+        ImmutableList.of(grandparentAttribute, parentAttribute, childAttribute),
+        QueryUtils.getAttributePathExpanded("grandparent.parent", grandparentEntityType, true));
+  }
+
+  @Test
+  void testGetAttributePathExpandedNoExpansion() {
+    EntityType grandparentEntityType = mock(EntityType.class);
+    EntityType parentEntityType = mock(EntityType.class);
+    EntityType childEntityType = mock(EntityType.class);
+    Attribute grandparentAttribute = mock(Attribute.class);
+    when(grandparentAttribute.hasRefEntity()).thenReturn(true);
+    when(grandparentAttribute.getRefEntity()).thenReturn(parentEntityType);
+    Attribute parentAttribute = mock(Attribute.class);
+    when(parentAttribute.hasRefEntity()).thenReturn(true);
+    when(parentAttribute.getRefEntity()).thenReturn(childEntityType);
+    Attribute childAttribute = mock(Attribute.class);
+    when(grandparentEntityType.getAttributeByName("grandparent")).thenReturn(grandparentAttribute);
+    when(parentEntityType.getAttributeByName("parent")).thenReturn(parentAttribute);
+    when(childEntityType.getAttributeByName("child")).thenReturn(childAttribute);
+    assertEquals(
+        ImmutableList.of(grandparentAttribute, parentAttribute, childAttribute),
+        QueryUtils.getAttributePathExpanded("grandparent.parent.child", grandparentEntityType));
   }
 }

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/EntityTypeTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/EntityTypeTest.java
@@ -269,6 +269,27 @@ class EntityTypeTest extends AbstractSystemEntityTest {
         () -> entityType.getOwnAttributeById("UnknownAttributeIdentifier"));
   }
 
+  @Test
+  void testGetAttributeByName() {
+    String attributeName = "MyAttributeName";
+    Attribute attribute = mock(Attribute.class);
+    when(attribute.getName()).thenReturn(attributeName);
+
+    Entity entity = mock(Entity.class);
+    EntityType entityType = new EntityType(entity);
+    when(entity.getEntities(ATTRIBUTES, Attribute.class)).thenReturn(singletonList(attribute));
+
+    assertEquals(attribute, entityType.getAttributeByName(attributeName));
+  }
+
+  @Test
+  void testGetAttributeByNameUnknownAttribute() {
+    EntityType entityType = new EntityType(mock(Entity.class));
+    assertThrows(
+        UnknownAttributeException.class,
+        () -> entityType.getAttributeByName("UnknownAttributeName"));
+  }
+
   private EntityType mockEntityTypeMeta() {
     EntityType entityTypeMeta = mock(EntityType.class);
     Attribute intAttr = when(mock(Attribute.class).getDataType()).thenReturn(INT).getMock();


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
