### PR TITLE
Fix squid:S5164 ThreadLocal memory leak in UniqueId

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/util/UniqueId.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/util/UniqueId.java
@@ -22,8 +22,6 @@ public class UniqueId {
         (byte) ((CLOCK_SEQ_AND_NODE >> 8) & 0xff),
         (byte) ((CLOCK_SEQ_AND_NODE) & 0xff),
       };
-  private final ThreadLocal<ByteBuffer> tlbb =
-      ThreadLocal.withInitial(() -> ByteBuffer.allocate(16));
 
   private volatile int seq;
   private volatile long lastTimestamp;
@@ -44,8 +42,7 @@ public class UniqueId {
         seq = 0;
       }
       seq++;
-      ByteBuffer bb = tlbb.get();
-      bb.rewind();
+      ByteBuffer bb = ByteBuffer.allocate(16);
       bb.putLong(time);
       bb.put(NODE);
       bb.putShort((short) seq);


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
