### PR TITLE
[CHORE] Fetch PR target branch in jenkins build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,6 +53,8 @@ pipeline {
                             sh "mvn -q -B versions:set -DnewVersion=${PREVIEW_VERSION} -DgenerateBackupPoms=false"
                             sh "mvn -q -B clean install -Dmaven.test.redirectTestOutputToFile=true -DskipITs -T4"
                             sh "curl -s https://codecov.io/bash | bash -s - -c -F unit -K -C ${GIT_COMMIT}"
+                            // Fetch the target branch, sonar likes to take a look at it
+                            sh "git fetch --no-tags origin ${CHANGE_TARGET}:refs/remotes/origin/${CHANGE_TARGET}"
                             sh "mvn -q -B sonar:sonar -Dsonar.login=${env.SONAR_TOKEN} -Dsonar.github.oauth=${env.GITHUB_TOKEN} -Dsonar.pullrequest.base=${CHANGE_TARGET} -Dsonar.pullrequest.branch=${BRANCH_NAME} -Dsonar.pullrequest.key=${env.CHANGE_ID} -Dsonar.pullrequest.provider=GitHub -Dsonar.pullrequest.github.repository=molgenis/molgenis -Dsonar.ws.timeout=120"
                         }
                     }


### PR DESCRIPTION
Sonar pull request analysis likes to have the PR target branch present.

The Jenkins multi branch GitHub plugin does a sparse checkout of the PR code because a full clone from GitHub contains a LOT of references with all pull requests ever created.

This checkout is so sparse that it doesn't even contain the target branch.
We've already configured the a checkout behavior that checks out the target branch, but it looks like the plugins do not play nice together and that configuration is ignored.

Warning message is gone in https://sonarcloud.io/dashboard?id=org.molgenis%3Amolgenis&pullRequest=8633 . Compare https://sonarcloud.io/dashboard?id=org.molgenis%3Amolgenis&pullRequest=8632 (2 warnings versus 1)

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
