### PR TITLE
Use java.version instead of maven-compiler-plugin config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,8 @@
   </developers>
 
   <properties>
+    <java.version>11</java.version>
+
     <!-- authentication for release scm plugin -->
     <project.scm.id>github</project.scm.id>
 
@@ -203,13 +205,11 @@
             <configLocation>molgenis_checks.xml</configLocation>
           </configuration>
         </plugin>
-        <!-- use java 1.8 -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven-compiler-plugin.version}</version>
           <configuration>
-            <release>11</release>
             <compilerArgs>
               <arg>-Xlint:all,-deprecation</arg>
             </compilerArgs>


### PR DESCRIPTION
More elegant solution that fixes automatic adjustment of IntelliJ bytecode language level.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
