### PR TITLE
Upgrade Elasticsearch 5.5.1 to 5.5.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <skipUTs>${skipTests}</skipUTs>
 
     <!-- override dependency versions managed by parent pom -->
-    <elasticsearch.version>5.5.1</elasticsearch.version>
+    <elasticsearch.version>5.5.3</elasticsearch.version>
     <testng.version>6.8</testng.version>
     <guava.version>25.0-jre</guava.version>
     <mockito.version>3.0.0</mockito.version>


### PR DESCRIPTION
... because 5.5.3 is the version used in production.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
