### PR TITLE
Updated step order in documentation

### DIFF
--- a/docs/guide-using-an-ide-for-backend.md
+++ b/docs/guide-using-an-ide-for-backend.md
@@ -180,11 +180,11 @@ CATALINA_OPTS=-Xmx4g -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled
 ```
 * Deployment: Select `+` -> `artifact` -> `molgenis-app:war exploded`
 * Application context: Select `/`
-* Select the OpenJDK 11 JRE in the 'JRE' property
 * Go back to the first tab, you should now have more options in the update and frame deactivation pulldowns.
 * Select On Update: Redeploy, don't ask (This is the action that will triggered when you press the blue reload button in the run view)
 * Select On frame deactivation: Update resources (This is the action that will be triggered whenever you tab out of IntelliJ)
 (If you get update classes and resources to work, let us know!!)
+* Select the OpenJDK 11 JRE in the 'JRE' property
 * Select your favorite browser in the pulldown.
 * Save the configuration
 * In the tool bar, select the `molgenis-app [exploded]` configuration and press the play button.


### PR DESCRIPTION
You can't select "OpenJDK 11 JRE" in the "Deployment" tab
Placed this stap after "Go back to the first tab" in a more logical order

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
