### PR TITLE
Fix squid:S3415 Assertion args should be passed in the correct order

### DIFF
--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/permission/PermissionSetUtilsTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/permission/PermissionSetUtilsTest.java
@@ -16,27 +16,27 @@ class PermissionSetUtilsTest {
 
   @Test
   void testParamValueToPermissionSetRead() {
-    assertEquals(paramValueToPermissionSet("read"), READ);
+    assertEquals(READ, paramValueToPermissionSet("read"));
   }
 
   @Test
   void testParamValueToPermissionSetWrite() {
-    assertEquals(paramValueToPermissionSet("write"), WRITE);
+    assertEquals(WRITE, paramValueToPermissionSet("write"));
   }
 
   @Test
   void testParamValueToPermissionSetWritemeta() {
-    assertEquals(paramValueToPermissionSet("writemeta"), WRITEMETA);
+    assertEquals(WRITEMETA, paramValueToPermissionSet("writemeta"));
   }
 
   @Test
   void testParamValueToPermissionSetReadmeta() {
-    assertEquals(paramValueToPermissionSet("readmeta"), READMETA);
+    assertEquals(READMETA, paramValueToPermissionSet("readmeta"));
   }
 
   @Test
   void testParamValueToPermissionSetCount() {
-    assertEquals(paramValueToPermissionSet("count"), COUNT);
+    assertEquals(COUNT, paramValueToPermissionSet("count"));
   }
 
   @Test

--- a/molgenis-data/src/test/java/org/molgenis/data/FetchTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/FetchTest.java
@@ -3,6 +3,7 @@ package org.molgenis.data;
 import static com.google.common.collect.Sets.newHashSet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Iterator;
@@ -18,21 +19,21 @@ class FetchTest {
 
   @Test
   void equalsFalse() {
-    assertFalse(new Fetch().field("field0").equals(new Fetch().field("field1")));
+    assertNotEquals(new Fetch().field("field0"), new Fetch().field("field1"));
   }
 
   @Test
   void equalsSubFetchTrue() {
     String field = "field";
     Fetch subFetch = new Fetch();
-    assertTrue(new Fetch().field(field, subFetch).equals(new Fetch().field(field, subFetch)));
+    assertEquals(new Fetch().field(field, subFetch), new Fetch().field(field, subFetch));
   }
 
   @Test
   void equalsSubFetchFalse() {
     String field = "field";
     Fetch subFetch = new Fetch();
-    assertFalse(new Fetch().field(field, subFetch).equals(new Fetch().field(field)));
+    assertNotEquals(new Fetch().field(field, subFetch), new Fetch().field(field));
   }
 
   @Test
@@ -73,11 +74,11 @@ class FetchTest {
 
     Iterator<Entry<String, Fetch>> it = fetch.iterator();
     assertTrue(it.hasNext());
-    assertEquals(it.next().getKey(), "field0");
+    assertEquals("field0", it.next().getKey());
     assertTrue(it.hasNext());
-    assertEquals(it.next().getKey(), "field1");
+    assertEquals("field1", it.next().getKey());
     assertTrue(it.hasNext());
-    assertEquals(it.next().getKey(), "field2");
+    assertEquals("field2", it.next().getKey());
     assertFalse(it.hasNext());
   }
 }

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/OneClickImporterServiceTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/service/OneClickImporterServiceTest.java
@@ -88,8 +88,8 @@ class OneClickImporterServiceTest {
     DataCollection expected = DataCollection.create("Sheet1", newArrayList(c1, c2));
     assertEquals(expected, actual);
 
-    assertEquals(c1.getDataValues().size(), 6);
-    assertEquals(c2.getDataValues().size(), 6);
+    assertEquals(6, c1.getDataValues().size());
+    assertEquals(6, c2.getDataValues().size());
   }
 
   @Test

--- a/molgenis-ontology/src/test/java/org/molgenis/ontology/sorta/controller/SortaControllerTest.java
+++ b/molgenis-ontology/src/test/java/org/molgenis/ontology/sorta/controller/SortaControllerTest.java
@@ -108,7 +108,7 @@ class SortaControllerTest extends AbstractMockitoTest {
         .thenReturn(Stream.of(sortaJobExecution));
 
     Model model = mock(Model.class);
-    assertEquals(sortaController.init(model), "sorta-match-view");
+    assertEquals("sorta-match-view", sortaController.init(model));
     verify(model).addAttribute("existingTasks", singletonList(sortaJobExecution));
   }
 
@@ -132,7 +132,7 @@ class SortaControllerTest extends AbstractMockitoTest {
     List<Ontology> ontologies = singletonList(mock(Ontology.class));
     when(ontologyService.getOntologies()).thenReturn(ontologies);
     Model model = mock(Model.class);
-    assertEquals(sortaController.matchTask(model), "sorta-match-view");
+    assertEquals("sorta-match-view", sortaController.matchTask(model));
     verify(model).addAttribute("ontologies", ontologies);
   }
 }

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/DynamicDecoratorIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/DynamicDecoratorIT.java
@@ -151,8 +151,8 @@ public class DynamicDecoratorIT extends AbstractMockitoSpringContextTests {
     Entity entity = dataService.findOneById(entityTypeDynamic.getId(), "0");
     dataService.update(entityTypeDynamic.getId(), entity);
     entity = dataService.findOneById(entityTypeDynamic.getId(), "0");
-    assertEquals(entity.getString("string_attr"), "string1_TEST");
-    assertEquals(entity.getInt("int_attr").intValue(), 11);
+    assertEquals("string1_TEST", entity.getString("string_attr"));
+    assertEquals(11, entity.getInt("int_attr").intValue());
 
     // remove second decorator
     decoratorConfiguration.setDecoratorParameters(Stream.of(addingDecoratorParameters));
@@ -162,9 +162,9 @@ public class DynamicDecoratorIT extends AbstractMockitoSpringContextTests {
     dataService.update(entityTypeDynamic.getId(), entity);
     entity = dataService.findOneById(entityTypeDynamic.getId(), "0");
     // stayed the same since the postfix decorator was removed
-    assertEquals(entity.getString("string_attr"), "string1_TEST");
+    assertEquals("string1_TEST", entity.getString("string_attr"));
     // added 1
-    assertEquals(entity.getInt("int_attr").intValue(), 12);
+    assertEquals(12, entity.getInt("int_attr").intValue());
   }
 
   @AfterAll

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/OneToManyIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/OneToManyIT.java
@@ -196,7 +196,7 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
           dataService.findOneById(
               authorsAndBooks.getAuthorMetaData().getId(), author1.getIdValue());
       assertEquals(
-          newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)), emptyList());
+          emptyList(), newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)));
 
       Entity author2Retrieved =
           dataService.findOneById(
@@ -231,7 +231,7 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
           dataService.findOneById(
               authorsAndBooks.getAuthorMetaData().getId(), author1.getIdValue());
       assertEquals(
-          newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)), emptyList());
+          emptyList(), newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)));
 
       Entity author2Retrieved =
           dataService.findOneById(
@@ -263,7 +263,7 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
           dataService.findOneById(
               authorsAndBooks.getAuthorMetaData().getId(), author1.getIdValue());
       assertEquals(
-          newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)), emptyList());
+          emptyList(), newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)));
     } finally {
       dataService.deleteAll(authorsAndBooks.getBookMetaData().getId());
       dataService.deleteAll(authorsAndBooks.getAuthorMetaData().getId());
@@ -285,7 +285,7 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
           dataService.findOneById(
               authorsAndBooks.getAuthorMetaData().getId(), author1.getIdValue());
       assertEquals(
-          newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)), emptyList());
+          emptyList(), newArrayList(author1RetrievedAgain.getEntities(AuthorMetaData1.ATTR_BOOKS)));
     } finally {
       dataService.deleteAll(authorsAndBooks.getBookMetaData().getId());
       dataService.deleteAll(authorsAndBooks.getAuthorMetaData().getId());

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/SidUtilsTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/SidUtilsTest.java
@@ -80,6 +80,6 @@ class SidUtilsTest {
 
   @Test
   void testCreateRoleAuthority() {
-    assertEquals(createRoleAuthority("NAME"), "ROLE_NAME");
+    assertEquals("ROLE_NAME", createRoleAuthority("NAME"));
   }
 }

--- a/molgenis-security/src/test/java/org/molgenis/security/twofactor/service/TwoFactorAuthenticationServiceImplTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/twofactor/service/TwoFactorAuthenticationServiceImplTest.java
@@ -1,6 +1,5 @@
 package org.molgenis.security.twofactor.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.RETURNS_SELF;
@@ -90,7 +89,7 @@ class TwoFactorAuthenticationServiceImplTest {
 
     when(userSecret.getSecret()).thenReturn("secretKey");
     boolean isConfigured = twoFactorAuthenticationServiceImpl.isConfiguredForUser();
-    assertEquals(isConfigured, true);
+    assertTrue(isConfigured);
   }
 
   @Test

--- a/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/algorithmgenerator/rules/impl/MissingCategoryRuleTest.java
+++ b/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/algorithmgenerator/rules/impl/MissingCategoryRuleTest.java
@@ -44,7 +44,7 @@ class MissingCategoryRuleTest {
   void removeIllegalChars() {
     assertEquals("dont", rule.removeIllegalChars("don`t"));
     assertEquals("dont", rule.removeIllegalChars("don&%$t"));
-    assertNotEquals(rule.removeIllegalChars("don1t"), "dont");
+    assertNotEquals("dont", rule.removeIllegalChars("don1t"));
   }
 
   @Test

--- a/molgenis-swagger/src/test/java/org/molgenis/swagger/controller/SwaggerControllerTest.java
+++ b/molgenis-swagger/src/test/java/org/molgenis/swagger/controller/SwaggerControllerTest.java
@@ -50,7 +50,7 @@ class SwaggerControllerTest extends AbstractMockitoSpringContextTests {
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
     when(tokenService.generateAndStoreToken("user", "For Swagger UI")).thenReturn("ABCDEFG");
-    assertEquals(swaggerController.init(model), "view-swagger-ui");
+    assertEquals("view-swagger-ui", swaggerController.init(model));
     verify(model).addAttribute("molgenisUrl", "http://localhost/plugin/swagger/swagger.yml");
     verify(model).addAttribute("baseUrl", "http://localhost");
     verify(model).addAttribute("token", "ABCDEFG");
@@ -62,7 +62,7 @@ class SwaggerControllerTest extends AbstractMockitoSpringContextTests {
     MockHttpServletRequest request = new MockHttpServletRequest();
     RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-    assertEquals(swaggerController.init(model), "view-swagger-ui");
+    assertEquals("view-swagger-ui", swaggerController.init(model));
     verify(model).addAttribute("molgenisUrl", "http://localhost/plugin/swagger/swagger.yml");
     verify(model).addAttribute("baseUrl", "http://localhost");
     verifyNoMoreInteractions(model);
@@ -77,7 +77,7 @@ class SwaggerControllerTest extends AbstractMockitoSpringContextTests {
     when(type2.getId()).thenReturn("abc_EntityType1ëæ");
     when(metaDataService.getEntityTypes()).thenReturn(Stream.of(type1, type2));
 
-    assertEquals(swaggerController.swagger(model, response), "view-swagger");
+    assertEquals("view-swagger", swaggerController.swagger(model, response));
 
     verify(model).addAttribute("scheme", "http");
     verify(model).addAttribute("host", "localhost");
@@ -100,7 +100,7 @@ class SwaggerControllerTest extends AbstractMockitoSpringContextTests {
 
     when(metaDataService.getEntityTypes()).thenReturn(Stream.empty());
 
-    assertEquals(swaggerController.swagger(model, response), "view-swagger");
+    assertEquals("view-swagger", swaggerController.swagger(model, response));
 
     verify(model).addAttribute("scheme", "http");
     verify(model).addAttribute("host", "localhost:8080");

--- a/molgenis-util/src/test/java/org/molgenis/util/ListEscapeUtilsTest.java
+++ b/molgenis-util/src/test/java/org/molgenis/util/ListEscapeUtilsTest.java
@@ -46,32 +46,32 @@ class ListEscapeUtilsTest {
 
   @Test
   void toStringList() {
-    assertEquals(ListEscapeUtils.toString(singletonList("a")), "a");
-    assertEquals(ListEscapeUtils.toString(asList("a", "b", "c")), "a,b,c");
+    assertEquals("a", ListEscapeUtils.toString(singletonList("a")));
+    assertEquals("a,b,c", ListEscapeUtils.toString(asList("a", "b", "c")));
 
-    assertEquals(ListEscapeUtils.toString(singletonList(",")), "\\,");
-    assertEquals(ListEscapeUtils.toString(singletonList("a,b")), "a\\,b");
+    assertEquals("\\,", ListEscapeUtils.toString(singletonList(",")));
+    assertEquals("a\\,b", ListEscapeUtils.toString(singletonList("a,b")));
 
-    assertEquals(ListEscapeUtils.toString(singletonList("\\")), "\\\\");
-    assertEquals(ListEscapeUtils.toString(singletonList("a\\b")), "a\\\\b");
+    assertEquals("\\\\", ListEscapeUtils.toString(singletonList("\\")));
+    assertEquals("a\\\\b", ListEscapeUtils.toString(singletonList("a\\b")));
 
-    assertEquals(ListEscapeUtils.toString(asList("a", "b", "")), "a,b,");
-    assertEquals(ListEscapeUtils.toString(asList("a", "", "c")), "a,,c");
-    assertEquals(ListEscapeUtils.toString(asList("", "b", "c")), ",b,c");
+    assertEquals("a,b,", ListEscapeUtils.toString(asList("a", "b", "")));
+    assertEquals("a,,c", ListEscapeUtils.toString(asList("a", "", "c")));
+    assertEquals(",b,c", ListEscapeUtils.toString(asList("", "b", "c")));
 
-    assertEquals(ListEscapeUtils.toString(asList("a", "b", null)), "a,b,");
-    assertEquals(ListEscapeUtils.toString(asList("a", null, "c")), "a,,c");
-    assertEquals(ListEscapeUtils.toString(asList(null, "b", "c")), ",b,c");
+    assertEquals("a,b,", ListEscapeUtils.toString(asList("a", "b", null)));
+    assertEquals("a,,c", ListEscapeUtils.toString(asList("a", null, "c")));
+    assertEquals(",b,c", ListEscapeUtils.toString(asList(null, "b", "c")));
 
-    assertEquals(ListEscapeUtils.toString(emptyList()), "");
-    assertEquals(ListEscapeUtils.toString(null), null);
+    assertEquals("", ListEscapeUtils.toString(emptyList()), "");
+    assertNull(ListEscapeUtils.toString(null));
   }
 
   @Test
   void toStringListcharchar() {
-    assertEquals(ListEscapeUtils.toString(asList("a", "b", "c"), ',', '/'), "a,b,c");
-    assertEquals(ListEscapeUtils.toString(singletonList("a,b,c"), ',', '/'), "a/,b/,c");
-    assertEquals(ListEscapeUtils.toString(singletonList("/"), ',', '/'), "//");
+    assertEquals("a,b,c", ListEscapeUtils.toString(asList("a", "b", "c"), ',', '/'));
+    assertEquals("a/,b/,c", ListEscapeUtils.toString(singletonList("a,b,c"), ',', '/'));
+    assertEquals("//", ListEscapeUtils.toString(singletonList("/"), ',', '/'));
   }
 
   @Test

--- a/molgenis-util/src/test/java/org/molgenis/util/mail/JavaMailSenderFactoryTest.java
+++ b/molgenis-util/src/test/java/org/molgenis/util/mail/JavaMailSenderFactoryTest.java
@@ -92,6 +92,6 @@ class JavaMailSenderFactoryTest extends AbstractMockitoTest {
         assertThrows(
             IllegalStateException.class,
             () -> javaMailSenderFactory.validateConnection(mailSettings));
-    assertEquals(exception.getMessage(), "Unable to ping to host");
+    assertEquals("Unable to ping to host", exception.getMessage());
   }
 }

--- a/molgenis-util/src/test/java/org/molgenis/util/stream/MapCollectorsTest.java
+++ b/molgenis-util/src/test/java/org/molgenis/util/stream/MapCollectorsTest.java
@@ -31,6 +31,6 @@ class MapCollectorsTest {
                 Stream.of("a1", "a2")
                     .collect(
                         MapCollectors.toLinkedMap(str -> str.charAt(0), str -> str.charAt(1))));
-    assertEquals(exception.getMessage(), "Duplicate key detected with values '1' and '2'");
+    assertEquals("Duplicate key detected with values '1' and '2'", exception.getMessage());
   }
 }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
