### PR TITLE
Fix #6508 #8426 google analytics optout link

### DIFF
--- a/molgenis-core-ui/src/main/resources/templates/molgenis-footer.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/molgenis-footer.ftl
@@ -35,6 +35,22 @@
                 <p class="text-muted text-center small ga-opted-out hidden">
                     <em>You have opted out of Google Analytics.</em>
                 </p>
+                <script>
+                    // Set to the same value as the web property used on the site
+                    const gaProperty = '${app_settings.footer?string}' || '${app_settings.footer?string}';
+
+                    // Disable tracking if the opt-out cookie exists.
+                    const disableStr = 'ga-disable-' + gaProperty;
+                    if (document.cookie.indexOf(disableStr + '=true') > -1) {
+                        window[disableStr] = true;
+                    }
+
+                    // Opt-out function
+                    function gaOptout() {
+                        document.cookie = disableStr + '=true; expires=Thu, 31 Dec 2099 23:59:59 UTC; path=/';
+                        window[disableStr] = true;
+                    }
+                </script>
             </#if>
         </div>
     </div>

--- a/molgenis-core-ui/src/main/resources/templates/molgenis-footer.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/molgenis-footer.ftl
@@ -78,6 +78,8 @@
                   <#if molgenis_version??>version: '${molgenis_version}', </#if>
                   <#if molgenis_build_date??>buildDate: '${molgenis_build_date}', </#if>
                   <#if molgenis_app_version??>appVersion: '${molgenis_app_version}', </#if>
+                  <#if app_settings.googleAnalyticsTrackingId??>googleAnalyticsTrackingId: '${app_settings.googleAnalyticsTrackingId}', </#if>
+                  <#if app_settings.googleAnalyticsTrackingIdMolgenis??>googleAnalyticsTrackingIdMolgenis: '${app_settings.googleAnalyticsTrackingIdMolgenis}', </#if>
                 }
               }
             };


### PR DESCRIPTION
Fix the analytics optout link in bootstrap 3 pages #8426

Needs to be combined with PR https://github.com/molgenis/molgenis-ui-context/pull/71
to add analytics text and optout link to bootstrap 4 pages

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
