### PR TITLE
Fix #8665: L1 cache can return invalid one-to-many values

### DIFF
--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/CopyServiceIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/CopyServiceIT.java
@@ -23,7 +23,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/OneToManyIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/OneToManyIT.java
@@ -44,7 +44,6 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -151,7 +150,6 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
             .getIdValue());
   }
 
-  @Disabled // see https://github.com/molgenis/molgenis/issues/8665
   @WithMockUser(username = USERNAME)
   @ParameterizedTest
   @MethodSource("allTestCaseDataProvider")
@@ -325,7 +323,6 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
         stream(updatedAuthor2.getEntities(ATTR_BOOKS)).map(Entity::getIdValue).collect(toSet()));
   }
 
-  @Disabled // see https://github.com/molgenis/molgenis/issues/8665
   @WithMockUser(username = USERNAME)
   @ParameterizedTest
   @MethodSource("allTestCaseDataProvider")
@@ -418,7 +415,6 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
     assertEquals(0, size(updatedAuthor3.getEntities(ATTR_BOOKS)));
   }
 
-  @Disabled // see https://github.com/molgenis/molgenis/issues/8665
   @WithMockUser(username = USERNAME)
   @Test
   public void testUpdateParentOrderAscending() {
@@ -446,7 +442,6 @@ public class OneToManyIT extends AbstractMockitoSpringContextTests {
     assertEquals(0, size(updatedPerson2.getEntities(ATTR_CHILDREN)));
   }
 
-  @Disabled // see https://github.com/molgenis/molgenis/issues/8665
   @WithMockUser(username = USERNAME)
   @Test
   public void testUpdateParentOrderDescending() {


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
