### PR TITLE
Fix #8695 Slow performance retrieving data for non-superusers

### DIFF
--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/RestControllerV2.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/RestControllerV2.java
@@ -153,6 +153,7 @@ public class RestControllerV2 {
   /** @deprecated replaced with a call to '/api' with method 'OPTIONS' */
   @Autowired
   @Deprecated
+  @Transactional(readOnly = true)
   @GetMapping("/version")
   public Map<String, String> getVersion(
       @Value("${molgenis.version:@null}") String molgenisVersion,
@@ -174,6 +175,7 @@ public class RestControllerV2 {
    * Retrieve an entity instance by id, optionally specify which attributes to include in the
    * response.
    */
+  @Transactional(readOnly = true)
   @GetMapping("/{entityTypeId}/{id}")
   public Map<String, Object> retrieveEntity(
       @PathVariable("entityTypeId") String entityTypeId,
@@ -185,6 +187,7 @@ public class RestControllerV2 {
   }
 
   /** Tunnel retrieveEntity through a POST request */
+  @Transactional(readOnly = true)
   @PostMapping(value = "/{entityTypeId}/{id}", params = "_method=GET")
   public Map<String, Object> retrieveEntityPost(
       @PathVariable("entityTypeId") String entityTypeId,
@@ -250,6 +253,7 @@ public class RestControllerV2 {
   /**
    * Retrieve an entity collection, optionally specify which attributes to include in the response.
    */
+  @Transactional(readOnly = true)
   @GetMapping("/{entityTypeId}")
   public EntityCollectionResponseV2 retrieveEntityCollection(
       @PathVariable("entityTypeId") String entityTypeId,
@@ -260,6 +264,7 @@ public class RestControllerV2 {
     return createEntityCollectionResponse(entityTypeId, request, httpRequest, includeCategories);
   }
 
+  @Transactional(readOnly = true)
   @PostMapping(value = "/{entityTypeId}", params = "_method=GET")
   public EntityCollectionResponseV2 retrieveEntityCollectionPost(
       @PathVariable("entityTypeId") String entityTypeId,
@@ -271,6 +276,7 @@ public class RestControllerV2 {
   }
 
   /** Retrieve attribute meta data */
+  @Transactional(readOnly = true)
   @GetMapping(value = "/{entityTypeId}/meta/{attributeName}", produces = APPLICATION_JSON_VALUE)
   public AttributeResponseV2 retrieveEntityAttributeMeta(
       @PathVariable("entityTypeId") String entityTypeId,
@@ -278,6 +284,7 @@ public class RestControllerV2 {
     return createAttributeResponse(entityTypeId, attributeName);
   }
 
+  @Transactional(readOnly = true)
   @PostMapping(
       value = "/{entityTypeId}/meta/{attributeName}",
       params = "_method=GET",
@@ -424,6 +431,7 @@ public class RestControllerV2 {
    * @param response HttpServletResponse
    */
   @SuppressWarnings("squid:S2259") // getEntities is guaranteed to be not empty
+  @Transactional
   @PutMapping("/{entityTypeId}")
   public synchronized void updateEntities(
       @PathVariable("entityTypeId") String entityTypeId,
@@ -452,12 +460,32 @@ public class RestControllerV2 {
   }
 
   /**
+   * Get all l10n resource strings in the language of the current user
+   *
+   * @deprecated use /api/v2/sys_L10nString endpoints
+   */
+  @Deprecated
+  @Transactional(readOnly = true)
+  @GetMapping(value = "/i18n", produces = APPLICATION_JSON_VALUE)
+  public Map<String, String> getL10nStrings() {
+    Map<String, String> translations = new HashMap<>();
+
+    ResourceBundle bundle = LanguageService.getBundle();
+    for (String key : localizationService.getAllMessageIds()) {
+      translations.put(key, bundle.getString(key));
+    }
+
+    return translations;
+  }
+
+  /**
    * @param entityTypeId The name of the entity to update
    * @param attributeName The name of the attribute to update
    * @param request EntityCollectionBatchRequestV2
    * @param response HttpServletResponse
    */
   @SuppressWarnings("squid:S2259") // getEntities is guaranteed to be not empty
+  @Transactional
   @PutMapping("/{entityTypeId}/{attributeName}")
   @ResponseStatus(OK)
   public synchronized void updateAttribute(
@@ -513,31 +541,13 @@ public class RestControllerV2 {
   }
 
   /**
-   * Get all l10n resource strings in the language of the current user
-   *
-   * @deprecated use /api/v2/sys_L10nString endpoints
-   */
-  @Deprecated
-  @GetMapping(value = "/i18n", produces = APPLICATION_JSON_VALUE)
-  @Transactional(readOnly = true)
-  public Map<String, String> getL10nStrings() {
-    Map<String, String> translations = new HashMap<>();
-
-    ResourceBundle bundle = LanguageService.getBundle();
-    for (String key : localizationService.getAllMessageIds()) {
-      translations.put(key, bundle.getString(key));
-    }
-
-    return translations;
-  }
-
-  /**
    * Get the localization resource strings for a specific language and namespace. Will *not* provide
    * fallback values if the specified language is not available.
    *
    * @deprecated use /api/v2/sys_L10nString endpoints
    */
   @Deprecated
+  @Transactional(readOnly = true)
   @GetMapping(
       value = "/i18n/{namespace}/{language}",
       produces = APPLICATION_JSON_VALUE + ";charset=UTF-8")
@@ -552,6 +562,7 @@ public class RestControllerV2 {
    * @deprecated use /api/v2/sys_L10nString endpoints
    */
   @Deprecated
+  @Transactional(readOnly = true)
   @GetMapping(
       value = "/i18n/{namespace}_{language}.properties",
       produces = TEXT_PLAIN_VALUE + ";charset=UTF-8 ")
@@ -573,6 +584,7 @@ public class RestControllerV2 {
    * @deprecated use /api/v2/sys_L10nString endpoints
    */
   @Deprecated
+  @Transactional
   @PostMapping("/i18n/{namespace}")
   @ResponseStatus(CREATED)
   public void registerMissingResourceStrings(
@@ -587,6 +599,7 @@ public class RestControllerV2 {
 
   /** @deprecated use /api/v2/sys_L10nString endpoints */
   @Deprecated
+  @Transactional
   @DeleteMapping("/i18n/{namespace}")
   @ResponseStatus(NO_CONTENT)
   public void deleteNamespace(@PathVariable String namespace) {

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisMenuController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisMenuController.java
@@ -25,6 +25,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -73,6 +74,7 @@ public class MolgenisMenuController {
    * Forwards to the first plugin of the first menu that the user can read since no menu path is
    * provided.
    */
+  @Transactional(readOnly = true)
   @SuppressWarnings("squid:S3752") // multiple methods required
   @RequestMapping(method = {RequestMethod.GET, RequestMethod.POST})
   public String forwardDefaultMenuDefaultPlugin(Model model) {

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisWebAppConfig.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisWebAppConfig.java
@@ -63,6 +63,7 @@ import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.GsonHttpMessageConverter;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.security.task.DelegatingSecurityContextAsyncTaskExecutor;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.multipart.MultipartResolver;
 import org.springframework.web.multipart.support.StandardServletMultipartResolver;
@@ -95,6 +96,8 @@ public abstract class MolgenisWebAppConfig implements WebMvcConfigurer {
   @Autowired private MessageSource messageSource;
 
   @Autowired private UserPermissionEvaluator userPermissionEvaluator;
+
+  @Autowired private PlatformTransactionManager transactionManager;
 
   @Override
   public void configureAsyncSupport(AsyncSupportConfigurer configurer) {
@@ -224,7 +227,8 @@ public abstract class MolgenisWebAppConfig implements WebMvcConfigurer {
         authenticationSettings,
         environment,
         messageSource,
-        gson);
+        gson,
+        transactionManager);
   }
 
   @Bean

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/AbstractStaticContentController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/AbstractStaticContentController.java
@@ -4,6 +4,7 @@ import org.molgenis.web.PluginController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +27,7 @@ public abstract class AbstractStaticContentController extends PluginController {
     this.uniqueReference = uniqueReference;
   }
 
+  @Transactional(readOnly = true)
   @GetMapping
   public String init(final Model model) {
     try {

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/StaticContentServiceImpl.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/StaticContentServiceImpl.java
@@ -58,6 +58,7 @@ public class StaticContentServiceImpl implements StaticContentService {
     }
   }
 
+  @Transactional(readOnly = true)
   @Override
   public boolean isCurrentUserCanEdit(String pluginId) {
     if (!permissionService.hasPermission(new EntityTypeIdentity(STATIC_CONTENT), READ_DATA)) {
@@ -72,6 +73,7 @@ public class StaticContentServiceImpl implements StaticContentService {
     }
   }
 
+  @Transactional(readOnly = true)
   @Override
   public String getContent(String key) {
     StaticContent staticContent =

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/jobs/JobsController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/jobs/JobsController.java
@@ -26,6 +26,7 @@ import org.molgenis.web.PluginController;
 import org.molgenis.web.menu.MenuReaderService;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -85,6 +86,7 @@ public class JobsController extends PluginController {
     return "view-job";
   }
 
+  @Transactional(readOnly = true)
   @GetMapping(value = "/latest", produces = MediaType.APPLICATION_JSON_VALUE)
   @ResponseBody
   public List<Entity> findLastJobs() {

--- a/molgenis-data-cache/src/test/java/org/molgenis/data/cache/l2/L2CacheRepositoryDecoratorTest.java
+++ b/molgenis-data-cache/src/test/java/org/molgenis/data/cache/l2/L2CacheRepositoryDecoratorTest.java
@@ -1,6 +1,7 @@
 package org.molgenis.data.cache.l2;
 
 import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Stream.of;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -8,6 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.RepositoryCapability.CACHEABLE;
 import static org.molgenis.data.RepositoryCapability.WRITABLE;
@@ -36,6 +39,7 @@ import org.molgenis.data.transaction.TransactionInformation;
 import org.molgenis.data.util.EntityUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ContextConfiguration(classes = TestHarnessConfig.class)
@@ -68,8 +72,7 @@ class L2CacheRepositoryDecoratorTest extends AbstractMolgenisSpringTest {
     when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(false);
     when(transactionInformation.isEntityDirty(EntityKey.create(emd, "0"))).thenReturn(false);
     when(l2Cache.get(delegateRepository, "0")).thenReturn(entities.get(0));
-    assertEquals(
-        entities.get(0), l2CacheRepositoryDecorator.findOneById("0", new Fetch().field("id")));
+    assertEquals(entities.get(0), l2CacheRepositoryDecorator.findOneById("0"));
   }
 
   @Test
@@ -96,7 +99,95 @@ class L2CacheRepositoryDecoratorTest extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void testFindAllSplitsIdsOnTransactionInformation() {
+  void testFindOneByIdFetchNotDirtyCacheableAndPresent() {
+    when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(false);
+    when(transactionInformation.isEntityDirty(EntityKey.create(emd, "0"))).thenReturn(false);
+    Fetch fetch = new Fetch().field("id");
+    when(l2Cache.get(delegateRepository, "0", fetch)).thenReturn(entities.get(0));
+    assertEquals(entities.get(0), l2CacheRepositoryDecorator.findOneById("0", fetch));
+  }
+
+  @Test
+  void testFindOneByIdFetchNotDirtyCacheableNotPresent() {
+    when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(false);
+    when(transactionInformation.isEntityDirty(EntityKey.create(emd, "0"))).thenReturn(false);
+    Fetch fetch = new Fetch().field("id");
+    when(l2Cache.get(delegateRepository, "abcde", fetch)).thenReturn(null);
+    assertNull(l2CacheRepositoryDecorator.findOneById("abcde", fetch));
+  }
+
+  @Test
+  void testFindOneByIdFetchDirty() {
+    when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(false);
+    when(transactionInformation.isEntityDirty(EntityKey.create(emd, "0"))).thenReturn(true);
+    Fetch fetch = new Fetch().field("id");
+    when(delegateRepository.findOneById("0", fetch)).thenReturn(entities.get(0));
+    assertEquals(entities.get(0), l2CacheRepositoryDecorator.findOneById("0", fetch));
+  }
+
+  @Test
+  void testFindOneByIdFetchEntireRepositoryDirty() {
+    when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(true);
+    Fetch fetch = new Fetch().field("id");
+    when(delegateRepository.findOneById("0", fetch)).thenReturn(entities.get(0));
+    assertEquals(entities.get(0), l2CacheRepositoryDecorator.findOneById("0", fetch));
+  }
+
+  @Test
+  void testFindAllEntireRepositoryDirty() {
+    when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(true);
+    Stream<Object> ids = Stream.of("0", "1", "2", "3");
+    l2CacheRepositoryDecorator.findAll(ids);
+    verify(delegateRepository).findAll(repoIdCaptor.capture());
+    assertEquals(
+        Stream.of("0", "1", "2", "3").collect(toList()), repoIdCaptor.getValue().collect(toList()));
+  }
+
+  @Test
+  void testFindAllTransactionReadonly() {
+    boolean previousReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+    try {
+      TransactionSynchronizationManager.setCurrentTransactionReadOnly(true);
+
+      List<Object> ids = asList("0", "1", "2");
+      List<Entity> entities = asList(mock(Entity.class), mock(Entity.class), mock(Entity.class));
+      when(l2Cache.getBatch(delegateRepository, ids)).thenReturn(entities);
+      assertEquals(entities, l2CacheRepositoryDecorator.findAll(ids.stream()).collect(toList()));
+    } finally {
+      TransactionSynchronizationManager.setCurrentTransactionReadOnly(previousReadOnly);
+    }
+  }
+
+  @Test
+  void testFindAllFetchEntireRepositoryDirty() {
+    when(transactionInformation.isEntireRepositoryDirty(emd)).thenReturn(true);
+    Stream<Object> ids = Stream.of("0", "1", "2", "3");
+    Fetch fetch = new Fetch().field("id");
+    l2CacheRepositoryDecorator.findAll(ids, fetch);
+    verify(delegateRepository).findAll(repoIdCaptor.capture(), eq(fetch));
+    assertEquals(
+        Stream.of("0", "1", "2", "3").collect(toList()), repoIdCaptor.getValue().collect(toList()));
+  }
+
+  @Test
+  void testFindAllFetchTransactionReadonly() {
+    boolean previousReadOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+    try {
+      TransactionSynchronizationManager.setCurrentTransactionReadOnly(true);
+
+      Fetch fetch = mock(Fetch.class);
+      List<Object> ids = asList("0", "1", "2");
+      List<Entity> entities = asList(mock(Entity.class), mock(Entity.class), mock(Entity.class));
+      when(l2Cache.getBatch(delegateRepository, ids, fetch)).thenReturn(entities);
+      assertEquals(
+          entities, l2CacheRepositoryDecorator.findAll(ids.stream(), fetch).collect(toList()));
+    } finally {
+      TransactionSynchronizationManager.setCurrentTransactionReadOnly(previousReadOnly);
+    }
+  }
+
+  @Test
+  void testFindAllFetchSplitsIdsOnTransactionInformation() {
     // repository is clean
 
     // 0: Dirty, not present in repo
@@ -110,12 +201,15 @@ class L2CacheRepositoryDecoratorTest extends AbstractMolgenisSpringTest {
     when(transactionInformation.isEntityDirty(EntityKey.create(emd, "2"))).thenReturn(false);
     when(transactionInformation.isEntityDirty(EntityKey.create(emd, "3"))).thenReturn(false);
 
+    Fetch fetch = new Fetch().field("id");
     Stream<Object> ids = Lists.<Object>newArrayList("0", "1", "2", "3").stream();
-    when(l2Cache.getBatch(eq(delegateRepository), cacheIdCaptor.capture()))
+    when(l2Cache.getBatch(eq(delegateRepository), cacheIdCaptor.capture(), eq(fetch)))
         .thenReturn(newArrayList(entities.get(3)));
-    when(delegateRepository.findAll(repoIdCaptor.capture())).thenReturn(of(entities.get(1)));
+    when(delegateRepository.findAll(repoIdCaptor.capture(), eq(fetch)))
+        .thenReturn(of(entities.get(1)));
 
-    List<Entity> retrievedEntities = l2CacheRepositoryDecorator.findAll(ids).collect(toList());
+    List<Entity> retrievedEntities =
+        l2CacheRepositoryDecorator.findAll(ids, fetch).collect(toList());
 
     List<Object> decoratedRepoIds = repoIdCaptor.getValue().collect(toList());
     assertEquals(newArrayList("0", "1"), decoratedRepoIds);

--- a/molgenis-data-cache/src/test/java/org/molgenis/data/cache/l2/L2CacheTest.java
+++ b/molgenis-data-cache/src/test/java/org/molgenis/data/cache/l2/L2CacheTest.java
@@ -33,6 +33,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.EntityKey;
 import org.molgenis.data.EntityManager;
 import org.molgenis.data.EntityTestHarness;
+import org.molgenis.data.Fetch;
 import org.molgenis.data.MolgenisDataException;
 import org.molgenis.data.Repository;
 import org.molgenis.data.TestHarnessConfig;
@@ -40,6 +41,7 @@ import org.molgenis.data.cache.utils.EntityHydration;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.DynamicEntity;
 import org.molgenis.data.support.EntityWithComputedAttributes;
+import org.molgenis.data.support.PartialEntity;
 import org.molgenis.data.transaction.TransactionInformation;
 import org.molgenis.data.transaction.TransactionManager;
 import org.molgenis.data.util.EntityUtils;
@@ -176,6 +178,27 @@ class L2CacheTest extends AbstractMolgenisSpringTest {
   }
 
   @Test
+  void testGetFetchStringIdCachesLoadedData() {
+    Fetch fetch = new Fetch().field(EntityTestHarness.ATTR_ID);
+    when(entityManager.createFetch(emd, fetch))
+        .thenAnswer(
+            invocation ->
+                new EntityWithComputedAttributes(
+                    new PartialEntity(new DynamicEntity(emd), fetch, entityManager)));
+
+    Entity entity2 = testEntities.get(2);
+    when(repository.findOneById("2")).thenReturn(entity2);
+
+    Entity result = l2Cache.get(repository, "2", fetch);
+    assertEquals("2", result.getIdValue());
+
+    result = l2Cache.get(repository, "2", fetch);
+    assertEquals("2", result.getIdValue());
+
+    verify(repository, times(1)).findOneById("2");
+  }
+
+  @Test
   void testGetStringIdLoaderThrowsException() {
     when(repository.findOneById("2"))
         .thenThrow(new MolgenisDataException("Table is missing for entity TestEntity"));
@@ -193,13 +216,31 @@ class L2CacheTest extends AbstractMolgenisSpringTest {
   }
 
   @Test
-  void testFindAll() {
+  void testGetBatch() {
     when(repository.findAll(idStreamCaptor.capture())).thenReturn(testEntities.stream());
     List<Entity> result = l2Cache.getBatch(repository, newArrayList("0", "1", "2", "3"));
     Map<Object, Entity> retrievedEntities =
         result.stream().collect(toMap(Entity::getIdValue, e -> e));
     assertEquals(4, retrievedEntities.size());
     assertTrue(EntityUtils.equals(retrievedEntities.get("1"), testEntities.get(1)));
+    assertEquals(newArrayList("0", "1", "2", "3"), idStreamCaptor.getValue().collect(toList()));
+  }
+
+  @Test
+  void testGetBatchFetch() {
+    Fetch fetch = new Fetch().field(EntityTestHarness.ATTR_ID);
+    when(entityManager.createFetch(emd, fetch))
+        .thenAnswer(
+            invocation ->
+                new EntityWithComputedAttributes(
+                    new PartialEntity(new DynamicEntity(emd), fetch, entityManager)));
+
+    when(repository.findAll(idStreamCaptor.capture())).thenReturn(testEntities.stream());
+    List<Entity> result = l2Cache.getBatch(repository, newArrayList("0", "1", "2", "3"), fetch);
+    Map<Object, Entity> retrievedEntities =
+        result.stream().collect(toMap(Entity::getIdValue, e -> e));
+    assertEquals(4, retrievedEntities.size());
+    assertEquals(testEntities.get(1).getIdValue(), retrievedEntities.get("1").getIdValue());
     assertEquals(newArrayList("0", "1", "2", "3"), idStreamCaptor.getValue().collect(toList()));
   }
 

--- a/molgenis-data-index/src/main/java/org/molgenis/data/index/IndexDependencyModel.java
+++ b/molgenis-data-index/src/main/java/org/molgenis/data/index/IndexDependencyModel.java
@@ -3,7 +3,6 @@ package org.molgenis.data.index;
 import static com.google.common.collect.Maps.uniqueIndex;
 import static com.google.common.collect.Streams.stream;
 import static java.util.Collections.emptySet;
-import static org.molgenis.data.meta.model.AttributeMetadata.REF_ENTITY_TYPE;
 import static org.molgenis.data.meta.model.EntityTypeMetadata.ATTRIBUTES;
 import static org.molgenis.data.meta.model.EntityTypeMetadata.EXTENDS;
 import static org.molgenis.data.meta.model.EntityTypeMetadata.ID;
@@ -17,6 +16,7 @@ import java.util.Set;
 import java.util.stream.Stream;
 import org.molgenis.data.Fetch;
 import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.AttributeMetadata;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.util.GenericDependencyResolver;
 
@@ -36,7 +36,11 @@ class IndexDependencyModel {
           .field(IS_ABSTRACT)
           .field(INDEXING_DEPTH)
           .field(EXTENDS, new Fetch().field(ID))
-          .field(ATTRIBUTES, new Fetch().field(REF_ENTITY_TYPE, new Fetch().field(ID)));
+          .field(
+              ATTRIBUTES,
+              new Fetch()
+                  .field(AttributeMetadata.ID)
+                  .field(AttributeMetadata.REF_ENTITY_TYPE, new Fetch().field(ID)));
 
   /**
    * Creates an IndexDependencyModel for a list of EntityTypes.

--- a/molgenis-data-platform/src/main/java/org/molgenis/data/platform/decorators/MolgenisRepositoryDecoratorFactory.java
+++ b/molgenis-data-platform/src/main/java/org/molgenis/data/platform/decorators/MolgenisRepositoryDecoratorFactory.java
@@ -30,6 +30,7 @@ import org.molgenis.data.transaction.TransactionInformation;
 import org.molgenis.data.transaction.TransactionalRepositoryDecorator;
 import org.molgenis.data.validation.DefaultValueReferenceValidator;
 import org.molgenis.data.validation.EntityAttributesValidator;
+import org.molgenis.data.validation.FetchValidator;
 import org.molgenis.data.validation.QueryValidationRepositoryDecorator;
 import org.molgenis.data.validation.QueryValidator;
 import org.molgenis.data.validation.RepositoryValidationDecorator;
@@ -56,6 +57,7 @@ public class MolgenisRepositoryDecoratorFactory implements RepositoryDecoratorFa
   private final L3Cache l3Cache;
   private final PlatformTransactionManager transactionManager;
   private final QueryValidator queryValidator;
+  private final FetchValidator fetchValidator;
   private final DefaultValueReferenceValidator defaultValueReferenceValidator;
   private final UserPermissionEvaluator permissionService;
   private final RowLevelSecurityRepositoryDecoratorFactory
@@ -78,6 +80,7 @@ public class MolgenisRepositoryDecoratorFactory implements RepositoryDecoratorFa
       L3Cache l3Cache,
       PlatformTransactionManager transactionManager,
       QueryValidator queryValidator,
+      FetchValidator fetchValidator,
       DefaultValueReferenceValidator defaultValueReferenceValidator,
       UserPermissionEvaluator permissionService,
       RowLevelSecurityRepositoryDecoratorFactory rowLevelSecurityRepositoryDecoratorFactory) {
@@ -98,6 +101,7 @@ public class MolgenisRepositoryDecoratorFactory implements RepositoryDecoratorFa
     this.l3Cache = requireNonNull(l3Cache);
     this.transactionManager = requireNonNull(transactionManager);
     this.queryValidator = requireNonNull(queryValidator);
+    this.fetchValidator = requireNonNull(fetchValidator);
     this.defaultValueReferenceValidator = requireNonNull(defaultValueReferenceValidator);
     this.permissionService = requireNonNull(permissionService);
     this.rowLevelSecurityRepositoryDecoratorFactory =
@@ -165,7 +169,8 @@ public class MolgenisRepositoryDecoratorFactory implements RepositoryDecoratorFa
 
     // 1. query validation decorator
     decoratedRepository =
-        new QueryValidationRepositoryDecorator<>(decoratedRepository, queryValidator);
+        new QueryValidationRepositoryDecorator<>(
+            decoratedRepository, queryValidator, fetchValidator);
 
     // 0. Dynamic decorators
     decoratedRepository = dynamicRepositoryDecoratorRegistry.decorate(decoratedRepository);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/DataserviceRoleHierarchy.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/DataserviceRoleHierarchy.java
@@ -5,6 +5,7 @@ import static com.google.common.collect.Sets.difference;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
+import static org.molgenis.data.security.auth.RoleMetadata.ID;
 import static org.molgenis.data.security.auth.RoleMetadata.INCLUDES;
 import static org.molgenis.data.security.auth.RoleMetadata.NAME;
 import static org.molgenis.data.security.auth.RoleMetadata.ROLE;
@@ -108,8 +109,9 @@ public class DataserviceRoleHierarchy implements RoleHierarchy {
     Query<Role> query = QueryImpl.query();
     Fetch fetch = new Fetch();
     Fetch childFetch = new Fetch();
+    childFetch.field(ID);
     childFetch.field(NAME);
-    fetch.field(NAME).field(INCLUDES, childFetch);
+    fetch.field(ID).field(NAME).field(INCLUDES, childFetch);
     query.fetch(fetch);
     query.pageSize(PAGE_SIZE);
     query.offset(offSet);

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/FetchValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/FetchValidator.java
@@ -1,0 +1,15 @@
+package org.molgenis.data.validation;
+
+import org.molgenis.data.Fetch;
+import org.molgenis.data.meta.model.EntityType;
+
+public interface FetchValidator {
+  /**
+   * Validates the fetch and fixes invalid fetches.
+   *
+   * @param fetch fetch to validate
+   * @param entityType entity type
+   * @return new valid fetch
+   */
+  Fetch validateFetch(Fetch fetch, EntityType entityType);
+}

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/FetchValidatorImpl.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/FetchValidatorImpl.java
@@ -1,0 +1,33 @@
+package org.molgenis.data.validation;
+
+import org.molgenis.data.Fetch;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FetchValidatorImpl implements FetchValidator {
+
+  @Override
+  public Fetch validateFetch(Fetch fetch, EntityType entityType) {
+    Fetch validatedFetch = new Fetch();
+    Attribute idAttribute = entityType.getIdAttribute();
+    if (idAttribute != null && !fetch.hasField(idAttribute)) {
+      validatedFetch.field(idAttribute.getName());
+    }
+    fetch
+        .getFields()
+        .forEach(
+            field -> {
+              Fetch subFetch = fetch.getFetch(field);
+              if (subFetch != null) {
+                Fetch validatedSubFetch =
+                    validateFetch(subFetch, entityType.getAttribute(field).getRefEntity());
+                validatedFetch.field(field, validatedSubFetch);
+              } else {
+                validatedFetch.field(field);
+              }
+            });
+    return validatedFetch;
+  }
+}

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/QueryValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/QueryValidator.java
@@ -18,6 +18,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 import org.molgenis.data.Entity;
 import org.molgenis.data.EntityManager;
+import org.molgenis.data.Fetch;
 import org.molgenis.data.Query;
 import org.molgenis.data.QueryRule;
 import org.molgenis.data.QueryRule.Operator;
@@ -41,9 +42,11 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class QueryValidator {
+  private final FetchValidator fetchValidator;
   private final EntityManager entityManager;
 
-  public QueryValidator(EntityManager entityManager) {
+  public QueryValidator(FetchValidator fetchValidator, EntityManager entityManager) {
+    this.fetchValidator = requireNonNull(fetchValidator);
     this.entityManager = requireNonNull(entityManager);
   }
 
@@ -57,6 +60,11 @@ public class QueryValidator {
    */
   public void validate(Query<? extends Entity> query, EntityType entityType) {
     query.getRules().forEach(queryRule -> validateQueryRule(queryRule, entityType));
+    Fetch fetch = query.getFetch();
+    if (fetch != null) {
+      Fetch validatedFetch = fetchValidator.validateFetch(fetch, entityType);
+      query.setFetch(validatedFetch);
+    }
   }
 
   private void validateQueryRule(QueryRule queryRule, EntityType entityType) {

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/FetchValidatorImplTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/FetchValidatorImplTest.java
@@ -1,0 +1,43 @@
+package org.molgenis.data.validation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.molgenis.data.Fetch;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoTest;
+
+class FetchValidatorTest extends AbstractMockitoTest {
+  private FetchValidatorImpl fetchValidatorImpl;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    fetchValidatorImpl = new FetchValidatorImpl();
+  }
+
+  @Test
+  void validateFetch() {
+    Fetch fetch = new Fetch().field("label").field("ref", new Fetch().field("refLabel"));
+    EntityType entityType = mock(EntityType.class);
+    Attribute idAttribute = mock(Attribute.class);
+    when(idAttribute.getName()).thenReturn("id");
+    when(entityType.getIdAttribute()).thenReturn(idAttribute);
+    Attribute refAttribute = mock(Attribute.class);
+    EntityType refEntityType = mock(EntityType.class);
+    Attribute refIdAttribute = mock(Attribute.class);
+    when(refIdAttribute.getName()).thenReturn("refId");
+    when(refEntityType.getIdAttribute()).thenReturn(refIdAttribute);
+    when(refAttribute.getRefEntity()).thenReturn(refEntityType);
+    when(entityType.getAttribute("ref")).thenReturn(refAttribute);
+    Fetch expectedFetch =
+        new Fetch()
+            .field("id")
+            .field("label")
+            .field("ref", new Fetch().field("refId").field("refLabel"));
+    assertEquals(expectedFetch, fetchValidatorImpl.validateFetch(fetch, entityType));
+  }
+}

--- a/molgenis-data-validation/src/test/java/org/molgenis/data/validation/QueryValidationRepositoryDecoratorTest.java
+++ b/molgenis-data-validation/src/test/java/org/molgenis/data/validation/QueryValidationRepositoryDecoratorTest.java
@@ -20,6 +20,7 @@ class QueryValidationRepositoryDecoratorTest {
   private EntityType entityType;
   private Repository<Entity> delegateRepository;
   private QueryValidator queryValidator;
+  private FetchValidator fetchValidator;
 
   @SuppressWarnings("unchecked")
   @BeforeEach
@@ -28,14 +29,17 @@ class QueryValidationRepositoryDecoratorTest {
     entityType = mock(EntityType.class);
     when(delegateRepository.getEntityType()).thenReturn(entityType);
     queryValidator = mock(QueryValidator.class);
+    fetchValidator = mock(FetchValidator.class);
     queryValidationRepositoryDecorator =
-        new QueryValidationRepositoryDecorator<>(delegateRepository, queryValidator);
+        new QueryValidationRepositoryDecorator<>(
+            delegateRepository, queryValidator, fetchValidator);
   }
 
   @Test
   void testQueryValidationRepositoryDecorator() {
     assertThrows(
-        NullPointerException.class, () -> new QueryValidationRepositoryDecorator<>(null, null));
+        NullPointerException.class,
+        () -> new QueryValidationRepositoryDecorator<>(null, null, null));
   }
 
   @Test

--- a/molgenis-data/src/main/java/org/molgenis/data/support/DataServiceImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/DataServiceImpl.java
@@ -48,26 +48,31 @@ public class DataServiceImpl implements DataService {
     return metaDataService.getEntityTypes().map(EntityType::getId);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public long count(String entityTypeId) {
     return getRepository(entityTypeId).count();
   }
 
+  @Transactional(readOnly = true)
   @Override
   public long count(String entityTypeId, Query<Entity> q) {
     return getRepository(entityTypeId).count(q);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public Stream<Entity> findAll(String entityTypeId) {
     return findAll(entityTypeId, query(entityTypeId));
   }
 
+  @Transactional(readOnly = true)
   @Override
   public Stream<Entity> findAll(String entityTypeId, Query<Entity> q) {
     return getRepository(entityTypeId).findAll(q);
   }
 
+  @Transactional(readOnly = true)
   @Nullable
   @CheckForNull
   @Override
@@ -75,6 +80,7 @@ public class DataServiceImpl implements DataService {
     return getRepository(entityTypeId).findOneById(id);
   }
 
+  @Transactional(readOnly = true)
   @Nullable
   @CheckForNull
   @Override
@@ -160,19 +166,21 @@ public class DataServiceImpl implements DataService {
 
   @Override
   public Query<Entity> query(String entityTypeId) {
-    return new QueryImpl<>(getRepository(entityTypeId));
+    return new QueryImpl<>(this, entityTypeId);
   }
 
   @Override
   public <E extends Entity> Query<E> query(String entityTypeId, Class<E> entityClass) {
-    return new QueryImpl<>(getRepository(entityTypeId, entityClass));
+    return new QueryImpl<>(this, entityTypeId, entityClass);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public <E extends Entity> Stream<E> findAll(String entityTypeId, Query<E> q, Class<E> clazz) {
     return getRepository(entityTypeId, clazz).findAll(q);
   }
 
+  @Transactional(readOnly = true)
   @Nullable
   @CheckForNull
   @Override
@@ -180,6 +188,7 @@ public class DataServiceImpl implements DataService {
     return getRepository(entityTypeId, clazz).findOneById(id);
   }
 
+  @Transactional(readOnly = true)
   @Nullable
   @CheckForNull
   @Override
@@ -187,11 +196,13 @@ public class DataServiceImpl implements DataService {
     return getRepository(entityTypeId, clazz).findOne(q);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public <E extends Entity> Stream<E> findAll(String entityTypeId, Class<E> clazz) {
     return findAll(entityTypeId, query(entityTypeId, clazz), clazz);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public AggregateResult aggregate(String entityTypeId, AggregateQuery aggregateQuery) {
     return getRepository(entityTypeId).aggregate(aggregateQuery);
@@ -212,6 +223,7 @@ public class DataServiceImpl implements DataService {
     return getRepository(repositoryName).getCapabilities();
   }
 
+  @Transactional(readOnly = true)
   @Nullable
   @CheckForNull
   @Override
@@ -219,6 +231,7 @@ public class DataServiceImpl implements DataService {
     return getRepository(entityTypeId).findOneById(id, fetch);
   }
 
+  @Transactional(readOnly = true)
   @Nullable
   @CheckForNull
   @Override
@@ -227,22 +240,26 @@ public class DataServiceImpl implements DataService {
     return getRepository(entityTypeId, clazz).findOneById(id, fetch);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public Stream<Entity> findAll(String entityTypeId, Stream<Object> ids) {
     return getRepository(entityTypeId).findAll(ids);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public <E extends Entity> Stream<E> findAll(
       String entityTypeId, Stream<Object> ids, Class<E> clazz) {
     return getRepository(entityTypeId, clazz).findAll(ids);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public Stream<Entity> findAll(String entityTypeId, Stream<Object> ids, Fetch fetch) {
     return getRepository(entityTypeId).findAll(ids, fetch);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public <E extends Entity> Stream<E> findAll(
       String entityTypeId, Stream<Object> ids, Fetch fetch, Class<E> clazz) {

--- a/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/DataExplorerControllerTest.java
+++ b/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/DataExplorerControllerTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.RepositoryCapability.WRITABLE;
 import static org.molgenis.data.meta.AttributeType.STRING;
+import static org.molgenis.data.meta.model.EntityTypeMetadata.IS_ABSTRACT;
 import static org.molgenis.data.security.EntityTypePermission.READ_DATA;
 import static org.molgenis.data.security.PackagePermission.ADD_ENTITY_TYPE;
 import static org.molgenis.dataexplorer.controller.DataExplorerController.NAVIGATOR;
@@ -37,11 +39,13 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Entity;
+import org.molgenis.data.Query;
 import org.molgenis.data.Repository;
 import org.molgenis.data.UnknownEntityTypeException;
 import org.molgenis.data.meta.MetaDataService;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.meta.model.EntityTypeMetadata;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.security.EntityTypeIdentity;
 import org.molgenis.data.security.EntityTypePermission;
@@ -151,7 +155,11 @@ class DataExplorerControllerTest extends AbstractMockitoSpringContextTests {
   @Test
   void initSortEntitiesByLabel() {
     MetaDataService metaDataService = mock(MetaDataService.class);
-    when(dataService.getMeta()).thenReturn(metaDataService);
+    Query<EntityType> query = mock(Query.class, RETURNS_DEEP_STUBS);
+    when(query.eq(IS_ABSTRACT, false)).thenReturn(query);
+    when(query.fetch(any())).thenReturn(query);
+    when(dataService.query(EntityTypeMetadata.ENTITY_TYPE_META_DATA, EntityType.class))
+        .thenReturn(query);
 
     EntityType entity1 = mock(EntityType.class);
     when(entity1.getId()).thenReturn("1");
@@ -162,7 +170,7 @@ class DataExplorerControllerTest extends AbstractMockitoSpringContextTests {
     when(entity2.getLabel()).thenReturn("aaa");
 
     Stream<EntityType> entityStream = Stream.of(entity1, entity2);
-    when(metaDataService.getEntityTypes()).thenReturn(entityStream);
+    when(query.findAll()).thenReturn(entityStream);
 
     controller.init(null, null, model);
 

--- a/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/service/GenomeBrowserService.java
+++ b/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/service/GenomeBrowserService.java
@@ -26,6 +26,7 @@ import org.molgenis.genomebrowser.meta.GenomeBrowserSettings;
 import org.molgenis.genomebrowser.meta.GenomeBrowserSettingsMetadata;
 import org.molgenis.security.core.UserPermissionEvaluator;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -46,11 +47,12 @@ public class GenomeBrowserService {
     this.userPermissionEvaluator = requireNonNull(userPermissionEvaluator);
   }
 
+  @Transactional(readOnly = true)
   @GetMapping(value = "/tracks", produces = APPLICATION_JSON_VALUE)
   @ResponseBody
   public List<String> getGenomeBrowserTracksAsString(@RequestParam String entityTypeId) {
     EntityType entityType = dataService.getEntityType(entityTypeId);
-    return getTracksString(getGenomeBrowserTracks(entityType));
+    return getTracksStringInternal(getGenomeBrowserTracks(entityType));
   }
 
   public Map<String, GenomeBrowserTrack> getGenomeBrowserTracks(EntityType entityType) {
@@ -61,7 +63,12 @@ public class GenomeBrowserService {
   }
 
   /** Get readable genome entities */
+  @Transactional(readOnly = true)
   public List<String> getTracksString(Map<String, GenomeBrowserTrack> entityTracks) {
+    return getTracksStringInternal(entityTracks);
+  }
+
+  private List<String> getTracksStringInternal(Map<String, GenomeBrowserTrack> entityTracks) {
     List<String> results = new ArrayList<>();
     if (hasPermission()) {
       Map<String, GenomeBrowserTrack> allTracks = new HashMap<>(entityTracks);

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/DataServiceIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/DataServiceIT.java
@@ -234,7 +234,7 @@ public class DataServiceIT extends AbstractMockitoSpringContextTests {
   @Order(11)
   public void testQuery() {
     assertNotNull(dataService.query(entityType.getId()));
-    assertThrows(UnknownEntityTypeException.class, () -> dataService.query("bogus"));
+    assertThrows(UnknownEntityTypeException.class, () -> dataService.query("bogus").count());
   }
 
   @WithMockUser(username = USERNAME_READ)

--- a/molgenis-security/src/main/java/org/molgenis/security/twofactor/auth/TwoFactorAuthenticationFilter.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/twofactor/auth/TwoFactorAuthenticationFilter.java
@@ -45,8 +45,8 @@ public class TwoFactorAuthenticationFilter extends OncePerRequestFilter {
       HttpServletResponse httpServletResponse,
       FilterChain filterChain)
       throws ServletException, IOException {
-    if (isUserShouldTwoFactorAuthenticate()
-        && currentUserIsAuthenticated()
+    if (currentUserIsAuthenticated()
+        && isUserShouldTwoFactorAuthenticate()
         && isNotProtected(httpServletRequest.getRequestURI())
         && isInsufficientlyAuthenticated()) {
       redirectToTwoFactorAuthenticationController(httpServletRequest, httpServletResponse);

--- a/molgenis-security/src/test/java/org/molgenis/security/twofactor/auth/TwoFactorAuthenticationFilterTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/twofactor/auth/TwoFactorAuthenticationFilterTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.molgenis.security.twofactor.auth.TwoFactorAuthenticationSetting.DISABLED;
 import static org.molgenis.security.twofactor.auth.TwoFactorAuthenticationSetting.ENFORCED;
 
 import java.io.IOException;
@@ -96,8 +95,6 @@ class TwoFactorAuthenticationFilterTest extends AbstractMockitoSpringContextTest
   @Test
   void testDoFilterInternalNotAuthenticated() throws IOException, ServletException {
     request.setRequestURI("/login");
-    when(authenticationSettings.getTwoFactorAuthentication()).thenReturn(DISABLED);
-
     filter.doFilterInternal(request, response, chain);
     verify(chain).doFilter(request, response);
   }
@@ -112,7 +109,6 @@ class TwoFactorAuthenticationFilterTest extends AbstractMockitoSpringContextTest
       testContext.setAuthentication(new RecoveryAuthenticationToken("recovery"));
 
       request.setRequestURI("/menu/main/dataexplorer");
-      when(authenticationSettings.getTwoFactorAuthentication()).thenReturn(ENFORCED);
 
       filter.doFilterInternal(request, response, chain);
       verify(chain).doFilter(request, response);

--- a/molgenis-web/src/main/java/org/molgenis/web/i18n/UserLocaleResolverImpl.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/i18n/UserLocaleResolverImpl.java
@@ -7,6 +7,7 @@ import org.molgenis.data.security.auth.User;
 import org.molgenis.data.security.user.UnknownUserException;
 import org.molgenis.data.security.user.UserService;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class UserLocaleResolverImpl implements UserLocaleResolver {
@@ -18,6 +19,7 @@ public class UserLocaleResolverImpl implements UserLocaleResolver {
     this.fallbackLocaleSupplier = requireNonNull(fallbackLocaleSupplier);
   }
 
+  @Transactional(readOnly = true)
   @Override
   public Locale resolveLocale(String username) {
     User user = userService.getUser(username);


### PR DESCRIPTION
- Fixed transaction boundaries
- Do not execute molgenis interceptor and plugin interceptor for forwarded views
- Increase L2 cache performance for read-only transactions
- Increase L2 cache performance for partial entity retrieval
- Automatically fix fetches that are missing id attribute and/or referenced entity id attributes
- Fix query: do not retrieve repository during query building, only when calling a terminal operation
- Fix 2fa: first check whether first-factor authentication was completed before other checks

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
