### PR TITLE
M5207 Suppress all "unused" warnings in all (non-meta) entity classes

### DIFF
--- a/.idea/fileTemplates/MolgenisEntityType.java
+++ b/.idea/fileTemplates/MolgenisEntityType.java
@@ -66,6 +66,7 @@ public class $META_CLASS_NAME extends SystemEntityType {
   }
 }
 
+@SuppressWarnings("unused")
 public class $ENTITY_TYPE_NAME extends StaticEntity {
   public $ENTITY_TYPE_NAME(Entity entity) {
     super(entity);

--- a/molgenis-amazon-bucket/src/main/java/org/molgenis/amazon/bucket/meta/AmazonBucketJobExecution.java
+++ b/molgenis-amazon-bucket/src/main/java/org/molgenis/amazon/bucket/meta/AmazonBucketJobExecution.java
@@ -7,6 +7,7 @@ import org.molgenis.data.file.model.FileMeta;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.jobs.model.JobExecution;
 
+@SuppressWarnings("unused")
 public class AmazonBucketJobExecution extends JobExecution {
   public AmazonBucketJobExecution(Entity entity) {
     super(entity);

--- a/molgenis-app-manager/src/main/java/org/molgenis/app/manager/meta/App.java
+++ b/molgenis-app-manager/src/main/java/org/molgenis/app/manager/meta/App.java
@@ -18,6 +18,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class App extends StaticEntity {
   public App(Entity entity) {
     super(entity);

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/config/Beacon.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/config/Beacon.java
@@ -19,6 +19,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Beacon extends StaticEntity {
   public Beacon(Entity entity) {
     super(entity);

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/config/BeaconDataset.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/config/BeaconDataset.java
@@ -12,6 +12,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 import org.molgenis.genomebrowser.meta.GenomeBrowserAttributes;
 
+@SuppressWarnings("unused")
 public class BeaconDataset extends StaticEntity {
   public BeaconDataset(Entity entity) {
     super(entity);

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/config/BeaconOrganization.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/config/BeaconOrganization.java
@@ -15,6 +15,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class BeaconOrganization extends StaticEntity {
   public BeaconOrganization(Entity entity) {
     super(entity);

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/system/core/FreemarkerTemplate.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/system/core/FreemarkerTemplate.java
@@ -8,6 +8,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class FreemarkerTemplate extends StaticEntity {
   public FreemarkerTemplate(Entity entity) {
     super(entity);

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/settings/StaticContent.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/settings/StaticContent.java
@@ -9,6 +9,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class StaticContent extends StaticEntity {
   public StaticContent(Entity entity) {
     super(entity);

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/StyleSheet.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/StyleSheet.java
@@ -5,6 +5,7 @@ import org.molgenis.data.file.model.FileMeta;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class StyleSheet extends StaticEntity {
   public StyleSheet(Entity entity) {
     super(entity);

--- a/molgenis-data-file/src/main/java/org/molgenis/data/file/model/FileMeta.java
+++ b/molgenis-data-file/src/main/java/org/molgenis/data/file/model/FileMeta.java
@@ -12,6 +12,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class FileMeta extends StaticEntity {
   public FileMeta(Entity entity) {
     super(entity);

--- a/molgenis-data-i18n/src/main/java/org/molgenis/data/i18n/model/L10nString.java
+++ b/molgenis-data-i18n/src/main/java/org/molgenis/data/i18n/model/L10nString.java
@@ -13,6 +13,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
 /** Localization string entity, enabling runtime localization. */
+@SuppressWarnings("unused")
 public class L10nString extends StaticEntity {
   public L10nString(Entity entity) {
     super(entity);

--- a/molgenis-data-i18n/src/main/java/org/molgenis/data/i18n/model/Language.java
+++ b/molgenis-data-i18n/src/main/java/org/molgenis/data/i18n/model/Language.java
@@ -5,6 +5,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
 /** Language entity */
+@SuppressWarnings("unused")
 public class Language extends StaticEntity {
   public Language(Entity entity) {
     super(entity);

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportRun.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportRun.java
@@ -21,6 +21,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 import org.molgenis.util.ValueLabel;
 
+@SuppressWarnings("unused")
 public class ImportRun extends StaticEntity {
   private static final List<ValueLabel> status_options;
   private static final List<ValueLabel> notify_options;

--- a/molgenis-data-index/src/main/java/org/molgenis/data/index/meta/IndexAction.java
+++ b/molgenis-data-index/src/main/java/org/molgenis/data/index/meta/IndexAction.java
@@ -14,6 +14,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class IndexAction extends StaticEntity {
   public IndexAction(Entity entity) {
     super(entity);

--- a/molgenis-data-index/src/main/java/org/molgenis/data/index/meta/IndexActionGroup.java
+++ b/molgenis-data-index/src/main/java/org/molgenis/data/index/meta/IndexActionGroup.java
@@ -7,6 +7,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class IndexActionGroup extends StaticEntity {
   public IndexActionGroup(Entity entity) {
     super(entity);

--- a/molgenis-data-plugin/src/main/java/org/molgenis/data/plugin/model/Plugin.java
+++ b/molgenis-data-plugin/src/main/java/org/molgenis/data/plugin/model/Plugin.java
@@ -6,6 +6,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Plugin extends StaticEntity {
   public Plugin(Entity entity) {
     super(entity);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/Group.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/Group.java
@@ -14,6 +14,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Group extends StaticEntity {
   public Group(Entity entity) {
     super(entity);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/MembershipInvitation.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/MembershipInvitation.java
@@ -24,6 +24,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class MembershipInvitation extends StaticEntity {
   public MembershipInvitation(Entity entity) {
     super(entity);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/PasswordResetToken.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/PasswordResetToken.java
@@ -10,18 +10,16 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class PasswordResetToken extends StaticEntity {
-  @SuppressWarnings("unused") // used via reflection
   public PasswordResetToken(Entity entity) {
     super(entity);
   }
 
-  @SuppressWarnings("unused") // used via reflection
   public PasswordResetToken(EntityType entityType) {
     super(entityType);
   }
 
-  @SuppressWarnings("unused") // used via reflection
   public PasswordResetToken(String id, EntityType entityType) {
     super(entityType);
     setId(id);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/Role.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/Role.java
@@ -12,6 +12,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Role extends StaticEntity {
   public Role(Entity entity) {
     super(entity);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/RoleMembership.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/RoleMembership.java
@@ -19,6 +19,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class RoleMembership extends StaticEntity {
   public enum Status {
     FUTURE,

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/Token.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/Token.java
@@ -16,6 +16,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Token extends StaticEntity {
   public Token(Entity entity) {
     super(entity);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/User.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/User.java
@@ -31,6 +31,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class User extends StaticEntity {
   public User(Entity entity) {
     super(entity);

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorConfiguration.java
@@ -10,6 +10,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class DecoratorConfiguration extends StaticEntity {
   public DecoratorConfiguration(Entity entity) {
     super(entity);

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParameters.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DecoratorParameters.java
@@ -8,6 +8,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class DecoratorParameters extends StaticEntity {
   public DecoratorParameters(Entity entity) {
     super(entity);

--- a/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecorator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/decorator/meta/DynamicDecorator.java
@@ -10,6 +10,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
 /** Entity representation of a dynamic decorator */
+@SuppressWarnings("unused")
 public class DynamicDecorator extends StaticEntity {
   public DynamicDecorator(Entity entity) {
     super(entity);

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/Tag.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/Tag.java
@@ -8,6 +8,7 @@ import org.molgenis.data.support.StaticEntity;
 // TODO validate IRI
 // TODO extends typed entity that stores entity and handles get/sets, also apply to other meta data
 // entities
+@SuppressWarnings("unused")
 public class Tag extends StaticEntity {
   public Tag(Entity entity) {
     super(entity);

--- a/molgenis-data/src/test/java/org/molgenis/data/staticentity/TestEntityStatic.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/staticentity/TestEntityStatic.java
@@ -6,6 +6,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class TestEntityStatic extends StaticEntity {
   public TestEntityStatic(Entity entity) {
     super(entity);

--- a/molgenis-data/src/test/java/org/molgenis/data/staticentity/TestRefEntityStatic.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/staticentity/TestRefEntityStatic.java
@@ -5,6 +5,7 @@ import org.molgenis.data.EntityTestHarness;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class TestRefEntityStatic extends StaticEntity {
   public TestRefEntityStatic(Entity entity) {
     super(entity);

--- a/molgenis-data/src/test/java/org/molgenis/data/staticentity/bidirectional/Author.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/staticentity/bidirectional/Author.java
@@ -5,6 +5,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.staticentity.bidirectional.authorbook1.AuthorMetaData1;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Author extends StaticEntity {
   public Author(Entity entity) {
     super(entity);

--- a/molgenis-data/src/test/java/org/molgenis/data/staticentity/bidirectional/Book.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/staticentity/bidirectional/Book.java
@@ -5,6 +5,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.staticentity.bidirectional.authorbook1.BookMetaData1;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Book extends StaticEntity {
   public Book(Entity entity) {
     super(entity);

--- a/molgenis-data/src/test/java/org/molgenis/data/staticentity/bidirectional/Person.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/staticentity/bidirectional/Person.java
@@ -5,6 +5,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.staticentity.bidirectional.person1.PersonMetaData1;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Person extends StaticEntity {
   public Person(Entity entity) {
     super(entity);

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorConfig.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorConfig.java
@@ -10,6 +10,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class NegotiatorConfig extends StaticEntity {
   public NegotiatorConfig(Entity entity) {
     super(entity);

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorEntityConfig.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorEntityConfig.java
@@ -4,6 +4,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class NegotiatorEntityConfig extends StaticEntity {
   public NegotiatorEntityConfig(Entity entity) {
     super(entity);

--- a/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/meta/GenomeBrowserAttributes.java
+++ b/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/meta/GenomeBrowserAttributes.java
@@ -6,6 +6,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class GenomeBrowserAttributes extends StaticEntity
     implements Comparable<GenomeBrowserAttributes> {
   public GenomeBrowserAttributes(Entity entity) {

--- a/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/meta/GenomeBrowserSettings.java
+++ b/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/meta/GenomeBrowserSettings.java
@@ -10,6 +10,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 import org.molgenis.genomebrowser.GenomeBrowserTrack;
 
+@SuppressWarnings("unused")
 public class GenomeBrowserSettings extends StaticEntity {
 
   public GenomeBrowserSettings(Entity entity) {

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/model/JobExecution.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/model/JobExecution.java
@@ -33,6 +33,7 @@ import org.molgenis.data.support.StaticEntity;
  *
  * <p>Do not add abstract identifier to this class, see EntitySerializerTest
  */
+@SuppressWarnings("unused")
 public class JobExecution extends StaticEntity {
   public static final String TRUNCATION_BANNER = "<<< THIS LOG HAS BEEN TRUNCATED >>>";
   /**

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/model/ScheduledJob.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/model/ScheduledJob.java
@@ -17,6 +17,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class ScheduledJob extends StaticEntity {
   public ScheduledJob(Entity entity) {
     super(entity);

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/model/ScheduledJobType.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/model/ScheduledJobType.java
@@ -13,6 +13,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
 /** Describes a schedulable Job type. */
+@SuppressWarnings("unused")
 public class ScheduledJobType extends StaticEntity {
   public ScheduledJobType(Entity entity) {
     super(entity);

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/Ontology.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/Ontology.java
@@ -8,6 +8,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Ontology extends StaticEntity {
   public Ontology(Entity entity) {
     super(entity);

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTerm.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTerm.java
@@ -12,6 +12,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class OntologyTerm extends StaticEntity {
   public OntologyTerm(Entity entity) {
     super(entity);

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTermDynamicAnnotation.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTermDynamicAnnotation.java
@@ -9,6 +9,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class OntologyTermDynamicAnnotation extends StaticEntity {
   public OntologyTermDynamicAnnotation(Entity entity) {
     super(entity);

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTermNodePath.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTermNodePath.java
@@ -9,6 +9,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class OntologyTermNodePath extends StaticEntity {
   public OntologyTermNodePath(Entity entity) {
     super(entity);

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTermSynonym.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/meta/OntologyTermSynonym.java
@@ -7,6 +7,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class OntologyTermSynonym extends StaticEntity {
   public OntologyTermSynonym(Entity entity) {
     super(entity);

--- a/molgenis-questionnaires/src/main/java/org/molgenis/questionnaires/meta/Questionnaire.java
+++ b/molgenis-questionnaires/src/main/java/org/molgenis/questionnaires/meta/Questionnaire.java
@@ -8,6 +8,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Questionnaire extends StaticEntity {
   public Questionnaire(Entity entity) {
     super(entity);

--- a/molgenis-scripts-core/src/main/java/org/molgenis/script/core/Script.java
+++ b/molgenis-scripts-core/src/main/java/org/molgenis/script/core/Script.java
@@ -16,6 +16,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class Script extends StaticEntity {
   public Script(Entity entity) {
     super(entity);

--- a/molgenis-scripts-core/src/main/java/org/molgenis/script/core/ScriptParameter.java
+++ b/molgenis-scripts-core/src/main/java/org/molgenis/script/core/ScriptParameter.java
@@ -6,6 +6,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class ScriptParameter extends StaticEntity {
   public ScriptParameter(Entity entity) {
     super(entity);

--- a/molgenis-scripts-core/src/main/java/org/molgenis/script/core/ScriptType.java
+++ b/molgenis-scripts-core/src/main/java/org/molgenis/script/core/ScriptType.java
@@ -7,6 +7,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
 /** Script type entity */
+@SuppressWarnings("unused")
 public class ScriptType extends StaticEntity {
   public ScriptType(Entity entity) {
     super(entity);

--- a/molgenis-security/src/main/java/org/molgenis/security/oidc/model/OidcClient.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/oidc/model/OidcClient.java
@@ -18,18 +18,16 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
 /** A representation of a client registration with an OpenID Connect 1.0 Provider. */
+@SuppressWarnings("unused")
 public class OidcClient extends StaticEntity {
-  @SuppressWarnings("unused")
   public OidcClient(Entity entity) {
     super(entity);
   }
 
-  @SuppressWarnings("unused")
   public OidcClient(EntityType entityType) {
     super(entityType);
   }
 
-  @SuppressWarnings("unused")
   public OidcClient(String id, EntityType entityType) {
     super(entityType);
     setRegistrationId(id);
@@ -43,7 +41,6 @@ public class OidcClient extends StaticEntity {
     return getString(REGISTRATION_ID);
   }
 
-  @SuppressWarnings("unused")
   public void setClientId(String clientId) {
     set(CLIENT_ID, clientId);
   }
@@ -52,7 +49,6 @@ public class OidcClient extends StaticEntity {
     return getString(CLIENT_ID);
   }
 
-  @SuppressWarnings("unused")
   public void setClientSecret(String clientSecret) {
     set(CLIENT_SECRET, clientSecret);
   }
@@ -61,7 +57,6 @@ public class OidcClient extends StaticEntity {
     return getString(CLIENT_SECRET);
   }
 
-  @SuppressWarnings("unused")
   public void setClientName(String clientName) {
     set(CLIENT_NAME, clientName);
   }
@@ -70,7 +65,6 @@ public class OidcClient extends StaticEntity {
     return getString(CLIENT_NAME);
   }
 
-  @SuppressWarnings("unused")
   public void setClientAuthenticationMethod(String clientAuthenticationMethod) {
     set(CLIENT_AUTHENTICATION_METHOD, clientAuthenticationMethod);
   }
@@ -79,7 +73,6 @@ public class OidcClient extends StaticEntity {
     return getString(CLIENT_AUTHENTICATION_METHOD);
   }
 
-  @SuppressWarnings("unused")
   public void setAuthorizationGrantType(String authorizationGrantType) {
     set(AUTHORIZATION_GRANT_TYPE, authorizationGrantType);
   }
@@ -88,7 +81,6 @@ public class OidcClient extends StaticEntity {
     return getString(AUTHORIZATION_GRANT_TYPE);
   }
 
-  @SuppressWarnings("unused")
   public void setAuthorizationUri(String authorizationUri) {
     set(AUTHORIZATION_URI, authorizationUri);
   }
@@ -97,7 +89,6 @@ public class OidcClient extends StaticEntity {
     return getString(AUTHORIZATION_URI);
   }
 
-  @SuppressWarnings("unused")
   public void setTokenUri(String tokenUri) {
     set(TOKEN_URI, tokenUri);
   }
@@ -106,7 +97,6 @@ public class OidcClient extends StaticEntity {
     return getString(TOKEN_URI);
   }
 
-  @SuppressWarnings("unused")
   public void setJwkSetUri(String jwkSetUri) {
     set(JWK_SET_URI, jwkSetUri);
   }
@@ -115,7 +105,6 @@ public class OidcClient extends StaticEntity {
     return getString(JWK_SET_URI);
   }
 
-  @SuppressWarnings("unused")
   public void setScopes(String[] scopes) {
     set(SCOPES, scopes != null ? String.join(",", scopes) : null);
   }
@@ -125,7 +114,6 @@ public class OidcClient extends StaticEntity {
     return scopeStr != null ? scopeStr.split(",") : new String[0];
   }
 
-  @SuppressWarnings("unused")
   public void setUserInfoUri(String userInfoUri) {
     set(USER_INFO_URI, userInfoUri);
   }
@@ -134,7 +122,6 @@ public class OidcClient extends StaticEntity {
     return getString(USER_INFO_URI);
   }
 
-  @SuppressWarnings("unused")
   public void setUsernameAttributeName(String usernameAttributeName) {
     set(USERNAME_ATTRIBUTE_NAME, usernameAttributeName);
   }

--- a/molgenis-security/src/main/java/org/molgenis/security/oidc/model/OidcUserMapping.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/oidc/model/OidcUserMapping.java
@@ -11,18 +11,16 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.security.auth.User;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class OidcUserMapping extends StaticEntity {
-  @SuppressWarnings("unused")
   public OidcUserMapping(Entity entity) {
     super(entity);
   }
 
-  @SuppressWarnings("unused")
   public OidcUserMapping(EntityType entityType) {
     super(entityType);
   }
 
-  @SuppressWarnings("unused")
   public OidcUserMapping(String id, EntityType entityType) {
     super(entityType);
     setId(id);
@@ -48,7 +46,6 @@ public class OidcUserMapping extends StaticEntity {
     set(OIDC_CLIENT, oidcClient);
   }
 
-  @SuppressWarnings("unused")
   public OidcClient getOidcClient() {
     return getEntity(OIDC_CLIENT, OidcClient.class);
   }
@@ -57,7 +54,6 @@ public class OidcUserMapping extends StaticEntity {
     set(OIDC_USERNAME, oidcUsername);
   }
 
-  @SuppressWarnings("unused")
   public String getOidcUsername() {
     return getString(OIDC_USERNAME);
   }

--- a/molgenis-security/src/main/java/org/molgenis/security/twofactor/model/RecoveryCode.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/twofactor/model/RecoveryCode.java
@@ -4,6 +4,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class RecoveryCode extends StaticEntity {
   public RecoveryCode(Entity entity) {
     super(entity);

--- a/molgenis-security/src/main/java/org/molgenis/security/twofactor/model/UserSecret.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/twofactor/model/UserSecret.java
@@ -5,6 +5,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class UserSecret extends StaticEntity {
   public UserSecret(Entity entity) {
     super(entity);

--- a/molgenis-settings/src/main/java/org/molgenis/settings/mail/JavaMailProperty.java
+++ b/molgenis-settings/src/main/java/org/molgenis/settings/mail/JavaMailProperty.java
@@ -9,6 +9,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.support.StaticEntity;
 
+@SuppressWarnings("unused")
 public class JavaMailProperty extends StaticEntity {
   public JavaMailProperty(Entity entity) {
     super(entity);


### PR DESCRIPTION
Suppresses the "unused declaration" warning on all entity implementations so unused constructors (actually used through reflection) and unused getters/setters are no longer flagged.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
