### PR TITLE
Fix #8740: menu returned by context api is not filtered

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/UiContextController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/UiContextController.java
@@ -2,8 +2,6 @@ package org.molgenis.core.ui.controller;
 
 import static java.util.Objects.requireNonNull;
 
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiResponse;
@@ -11,6 +9,8 @@ import io.swagger.annotations.ApiResponses;
 import org.molgenis.core.ui.cookiewall.CookieWallService;
 import org.molgenis.security.core.utils.SecurityUtils;
 import org.molgenis.settings.AppSettings;
+import org.molgenis.web.menu.MenuReaderService;
+import org.molgenis.web.menu.model.Menu;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
@@ -31,16 +31,19 @@ public class UiContextController {
 
   private final AppSettings appSettings;
   private final CookieWallService cookieWallService;
+  private final MenuReaderService menuReaderService;
   private final String molgenisVersion;
   private final String molgenisBuildDate;
 
   public UiContextController(
       AppSettings appSettings,
       CookieWallService cookieWallService,
+      MenuReaderService menuReaderService,
       @Value("${molgenis.version}") String molgenisVersion,
       @Value("${molgenis.build.date}") String molgenisBuildDate) {
     this.appSettings = requireNonNull(appSettings);
     this.cookieWallService = requireNonNull(cookieWallService);
+    this.menuReaderService = requireNonNull(menuReaderService);
     this.molgenisVersion = requireNonNull(molgenisVersion);
     this.molgenisBuildDate = requireNonNull(molgenisBuildDate);
   }
@@ -55,12 +58,7 @@ public class UiContextController {
   @GetMapping("/**")
   @ResponseBody
   public UiContextResponse getContext() {
-
-    JsonObject menu =
-        appSettings.getMenu() != null
-            ? new JsonParser().parse(appSettings.getMenu()).getAsJsonObject()
-            : new JsonObject();
-
+    Menu menu = menuReaderService.getMenu().orElseThrow();
     boolean authenticated = SecurityUtils.currentUserIsAuthenticated();
     boolean showCookieWall = cookieWallService.showCookieWall();
 

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/UiContextResponse.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/UiContextResponse.java
@@ -1,9 +1,9 @@
 package org.molgenis.core.ui.controller;
 
 import com.google.auto.value.AutoValue;
-import com.google.gson.JsonObject;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import org.molgenis.web.menu.model.Menu;
 
 @AutoValue
 @SuppressWarnings("squid:S1610")
@@ -19,7 +19,7 @@ public abstract class UiContextResponse {
   @CheckForNull
   public abstract String getNavBarLogo();
 
-  public abstract JsonObject getMenu();
+  public abstract Menu getMenu();
 
   public abstract String getloginHref();
 
@@ -58,7 +58,7 @@ public abstract class UiContextResponse {
 
     public abstract Builder setHelpLink(String helpLink);
 
-    public abstract Builder setMenu(JsonObject menu);
+    public abstract Builder setMenu(Menu menu);
 
     public abstract Builder setAuthenticated(Boolean authenticated);
 


### PR DESCRIPTION
The service filters the menu based upon current user's permissions

Fixes #8740

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
