### PR TITLE
Fix MetadataService.upsertAttributes: use identifier instead of name

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataServiceImpl.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/MetaDataServiceImpl.java
@@ -463,10 +463,10 @@ public class MetaDataServiceImpl implements MetaDataService {
     // analyze both compound and atomic attributes owned by the entity
     Map<String, Attribute> attrsMap =
         stream(entityType.getOwnAllAttributes())
-            .collect(toMap(Attribute::getName, Function.identity()));
+            .collect(toMap(Attribute::getIdentifier, Function.identity()));
     Map<String, Attribute> existingAttrsMap =
         stream(existingEntityType.getOwnAllAttributes())
-            .collect(toMap(Attribute::getName, Function.identity()));
+            .collect(toMap(Attribute::getIdentifier, Function.identity()));
 
     // determine attributes to add, update and delete
     Set<String> addedAttrNames = Sets.difference(attrsMap.keySet(), existingAttrsMap.keySet());

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/MetaDataServiceImplTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/MetaDataServiceImplTest.java
@@ -720,9 +720,13 @@ class MetaDataServiceImplTest extends AbstractMockitoTest {
     when(attrShared1.getIdentifier()).thenReturn(attrShared1Name);
     Attribute attrShared1Updated =
         when(mock(Attribute.class).getName()).thenReturn(attrShared1Name).getMock();
+    when(attrShared1Updated.getIdentifier()).thenReturn(attrShared1Name);
+    when(attrShared1Updated.getLabel()).thenReturn("updated label");
     Attribute attrAdded = when(mock(Attribute.class).getName()).thenReturn(attrAddedName).getMock();
+    when(attrAdded.getIdentifier()).thenReturn(attrAddedName);
     Attribute attrDeleted =
         when(mock(Attribute.class).getName()).thenReturn(attrDeletedName).getMock();
+    when(attrDeleted.getIdentifier()).thenReturn(attrDeletedName);
 
     EntityType existingEntityType =
         when(mock(EntityType.class).getId()).thenReturn(entityTypeId).getMock();
@@ -798,9 +802,13 @@ class MetaDataServiceImplTest extends AbstractMockitoTest {
     when(attrShared1.getIdentifier()).thenReturn(attrShared1Name);
     Attribute attrShared1Updated =
         when(mock(Attribute.class).getName()).thenReturn(attrShared1Name).getMock();
+    when(attrShared1Updated.getIdentifier()).thenReturn(attrShared1Name);
+    when(attrShared1Updated.getLabel()).thenReturn("updated label");
     Attribute attrAdded = when(mock(Attribute.class).getName()).thenReturn(attrAddedName).getMock();
+    when(attrAdded.getIdentifier()).thenReturn(attrAddedName);
     Attribute attrDeleted =
         when(mock(Attribute.class).getName()).thenReturn(attrDeletedName).getMock();
+    when(attrDeleted.getIdentifier()).thenReturn(attrDeletedName);
 
     EntityType existingEntityType = mock(EntityType.class);
     when(existingEntityType.getLabel()).thenReturn("label");
@@ -856,9 +864,13 @@ class MetaDataServiceImplTest extends AbstractMockitoTest {
     when(attrShared1.getIdentifier()).thenReturn(attrShared1Name);
     Attribute attrShared1Updated =
         when(mock(Attribute.class).getName()).thenReturn(attrShared1Name).getMock();
+    when(attrShared1Updated.getIdentifier()).thenReturn(attrShared1Name);
+    when(attrShared1Updated.getLabel()).thenReturn("updated label");
     Attribute attrAdded = when(mock(Attribute.class).getName()).thenReturn(attrAddedName).getMock();
+    when(attrAdded.getIdentifier()).thenReturn(attrAddedName);
     Attribute attrDeleted =
         when(mock(Attribute.class).getName()).thenReturn(attrDeletedName).getMock();
+    when(attrDeleted.getIdentifier()).thenReturn(attrDeletedName);
 
     EntityType existingEntityType = mock(EntityType.class);
     when(existingEntityType.getId()).thenReturn(entityTypeId);
@@ -922,10 +934,14 @@ class MetaDataServiceImplTest extends AbstractMockitoTest {
     when(attrShared1.getIdentifier()).thenReturn(attrShared1Name);
     Attribute attrShared1Updated =
         when(mock(Attribute.class).getName()).thenReturn(attrShared1Name).getMock();
+    when(attrShared1Updated.getIdentifier()).thenReturn(attrShared1Name);
+    when(attrShared1Updated.getLabel()).thenReturn("updated label");
     when(attrShared1Updated.isMappedBy()).thenReturn(false);
     Attribute attrAdded = when(mock(Attribute.class).getName()).thenReturn(attrAddedName).getMock();
+    when(attrAdded.getIdentifier()).thenReturn(attrAddedName);
     Attribute attrDeleted =
         when(mock(Attribute.class).getName()).thenReturn(attrDeletedName).getMock();
+    when(attrDeleted.getIdentifier()).thenReturn(attrDeletedName);
 
     EntityType existingEntityType = mock(EntityType.class);
     when(existingEntityType.getId()).thenReturn(entityTypeId);


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [NA] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
