### PR TITLE
Fix cargo-maven2-plugin to prevent download errors

### DIFF
--- a/molgenis-api-tests/pom.xml
+++ b/molgenis-api-tests/pom.xml
@@ -196,7 +196,11 @@
           <skip>${skipITs}</skip>
           <container>
             <containerId>tomcat9x</containerId>
-            <embedded>true</embedded>
+            <zipUrlInstaller>
+              <url>
+                https://maven-central.storage-download.googleapis.com/maven2/org/apache/tomcat/tomcat/${tomcat.version}/tomcat-${tomcat.version}.zip
+              </url>
+            </zipUrlInstaller>
             <systemProperties>
               <molgenis.home>${project.build.testOutputDirectory}/home</molgenis.home>
             </systemProperties>

--- a/molgenis-api-tests/pom.xml
+++ b/molgenis-api-tests/pom.xml
@@ -196,11 +196,7 @@
           <skip>${skipITs}</skip>
           <container>
             <containerId>tomcat9x</containerId>
-            <zipUrlInstaller>
-              <url>
-                http://repo1.maven.org/maven2/org/apache/tomcat/tomcat/${tomcat.version}/tomcat-${tomcat.version}.zip
-              </url>
-            </zipUrlInstaller>
+            <embedded>true</embedded>
             <systemProperties>
               <molgenis.home>${project.build.testOutputDirectory}/home</molgenis.home>
             </systemProperties>


### PR DESCRIPTION
Related to 0eeaa84cbc001be9c86996be9a172ef1d08bad28

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [NA] Code unit/integration/system tested
- [NA] Migration step added in case of breaking change
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
