### PR TITLE
Fix stacktraces when running integration tests

### DIFF
--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/CopyServiceIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/CopyServiceIT.java
@@ -8,6 +8,7 @@ import static java.util.stream.Collectors.toList;
 import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_CONFIGURATION;
+import static org.molgenis.data.meta.model.EntityTypeMetadata.ENTITY_TYPE_META_DATA;
 import static org.molgenis.data.meta.model.PackageMetadata.PACKAGE;
 import static org.molgenis.integrationtest.platform.PlatformIT.waitForWorkToBeFinished;
 import static org.molgenis.security.core.runas.RunAsSystemAspect.runAsSystem;
@@ -300,7 +301,12 @@ class CopyServiceIT extends AbstractMockitoSpringContextTests {
 
   @AfterEach
   void tearDownAfterClass() {
-    runAsSystem(() -> dataService.deleteAll(PACKAGE, Stream.of(PACKAGE_A)));
+    waitForWorkToBeFinished(indexService, LOG);
+    runAsSystem(() -> dataService.delete(ENTITY_TYPE_META_DATA, entityTypeA));
+    runAsSystem(() -> dataService.delete(ENTITY_TYPE_META_DATA, entityTypeB));
+
+    runAsSystem(() -> dataService.delete(PACKAGE, packageB));
+    runAsSystem(() -> dataService.delete(PACKAGE, packageA));
     waitForWorkToBeFinished(indexService, LOG);
   }
 

--- a/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/MetaDataServiceIT.java
+++ b/molgenis-platform-integration-tests/src/test/java/org/molgenis/integrationtest/platform/MetaDataServiceIT.java
@@ -54,6 +54,7 @@ import java.util.Map.Entry;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -127,8 +128,14 @@ public class MetaDataServiceIT extends AbstractMockitoSpringContextTests {
         });
   }
 
+  @BeforeEach
+  void beforeEach(ApplicationContext applicationContext) {
+    waitForAllIndicesStable(applicationContext);
+  }
+
   @AfterAll
   public static void tearDownAfterAll(ApplicationContext applicationContext) {
+    waitForAllIndicesStable(applicationContext);
     runAsSystem(
         () -> {
           depopulate(applicationContext);
@@ -243,7 +250,7 @@ public class MetaDataServiceIT extends AbstractMockitoSpringContextTests {
         metaDataService
             .getEntityType(ENTITY_TYPE_ID)
             .orElseThrow(() -> new UnknownEntityTypeException(ENTITY_TYPE_ID));
-    ;
+
     updatedEntityType.getAttribute(ATTR_COMPOUND_CHILD_INT).setDataType(DATE_TIME);
     Exception exception =
         assertThrows(


### PR DESCRIPTION
Only remaining stacktrace (missing index) is by design: this is caused by the deleteIndex test, in the code we catch the elasticsearch exception and log it, which is what you see in the test logging.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
