### PR TITLE
chore(Jenkinsfile): use JENKINS_AGENT_WORKDIR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,20 +16,20 @@ pipeline {
             steps {
                 container('vault') {
                     script {
-                        sh "mkdir /home/jenkins/.m2"
-                        sh "mkdir /home/jenkins/.rancher"
-                        sh(script: 'vault read -field=value secret/ops/jenkins/rancher/cli2.json > /home/jenkins/.rancher/cli2.json')
-                        sh(script: 'vault read -field=value secret/ops/jenkins/maven/settings.xml > /home/jenkins/.m2/settings.xml')
+                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
+                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
+                        sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}.rancher/cli2.json")
+                        sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}.m2/settings.xml")
                         env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
                         env.GITHUB_TOKEN = sh(script: 'vault read -field=value secret/ops/token/github', returnStdout: true)
                         env.PGP_PASSPHRASE = 'literal:' + sh(script: 'vault read -field=passphrase secret/ops/certificate/pgp/molgenis-ci', returnStdout: true)
                         env.GITHUB_USER = sh(script: 'vault read -field=username secret/ops/token/github', returnStdout: true)
                     }
                 }
-                dir('/home/jenkins/.m2') {
+                dir("${JENKINS_AGENT_WORKDIR}/.m2") {
                     stash includes: 'settings.xml', name: 'maven-settings'
                 }
-                dir('/home/jenkins/.rancher') {
+                dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
                     stash includes: 'cli2.json', name: 'rancher-config'
                 }
             }
@@ -140,7 +140,7 @@ pipeline {
             stages {
                 stage('Build [ x.x ]') {
                     steps {
-                        dir('/home/jenkins/.m2') {
+                        dir("${JENKINS_AGENT_WORKDIR}/.m2") {
                             unstash 'maven-settings'
                         }
                         container('maven') {
@@ -196,11 +196,11 @@ pipeline {
                 stage('Deploy to test [ x.x ]') {
                     steps {
                         milestone(ordinal: 100, label: 'deploy to latest.test.molgenis.org')
-                        dir('/home/jenkins/.rancher') {
+                        dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
                             unstash 'rancher-config'
                         }
                         container('rancher') {
-//                            sh "rancher context switch test-molgenis"
+                            sh "rancher context switch test-molgenis"
                             sh "rancher apps upgrade --set image.tag=${TAG} latest ${CHART_VERSION}"
                         }
                     }
@@ -214,8 +214,8 @@ pipeline {
                     steps {
                         container('vault') {
                             script {
-                                env.PGP_SECRETKEY = "keyfile:/home/jenkins/key.asc"
-                                sh(script: 'vault read -field=secret.asc secret/ops/certificate/pgp/molgenis-ci > /home/jenkins/key.asc')
+                                env.PGP_SECRETKEY = "keyfile:${JENKINS_AGENT_WORKDIR}/key.asc"
+                                sh(script: "vault read -field=secret.asc secret/ops/certificate/pgp/molgenis-ci > ${JENKINS_AGENT_WORKDIR}/key.asc")
                             }
                         }
                         container('maven') {


### PR DESCRIPTION
Instead of explicitly writing `/home/jenkins`, use the environment variable.
In newer versions of the kubernetes plugin, the workdir changes from
`/home/jenkins` to `/home/jenkins/agent`

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
-(If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
