### PR TITLE
Fix #8426 Remove broken footer ga text

### DIFF
--- a/molgenis-core-ui/src/main/resources/templates/molgenis-footer.ftl
+++ b/molgenis-core-ui/src/main/resources/templates/molgenis-footer.ftl
@@ -19,23 +19,11 @@
                    software</a><#if molgenis_version?has_content>
                     <span>version ${molgenis_version!?html}</span></#if><#if molgenis_build_date?has_content><span> built
                     on ${molgenis_build_date!?html}</span></#if>.<br>Please cite <a
-		    	href="https://www.ncbi.nlm.nih.gov/pubmed/30165396">Van der Velde et al (2018)</a>, <a
+                        href="https://www.ncbi.nlm.nih.gov/pubmed/30165396">Van der Velde et al (2018)</a>, <a
                         href="http://www.ncbi.nlm.nih.gov/pubmed/21210979">Swertz et al (2010)</a> or <a
                         href="http://www.ncbi.nlm.nih.gov/pubmed/17297480">Swertz &amp; Jansen (2007)</a> on use.
                 </em>
             </p>
-
-            <#if app_settings.googleAnalyticsTrackingId?? || app_settings.googleAnalyticsTrackingIdMolgenis??>
-                <p class="text-muted text-center small ga-opt-out">
-                    <em>We use Google Analytics to review this site's usage and improve our services.<br/>
-                        To optimally protect your privacy we have signed the Data Processing Amendment, masked parts of
-                        your IP address and disabled data sharing with other Google services.</em><br/>
-                    <em>Click <a href="javascript:gaOptout()">here</a> to opt-out of Google Analytics.</em>
-                </p>
-                <p class="text-muted text-center small ga-opted-out hidden">
-                    <em>You have opted out of Google Analytics.</em>
-                </p>
-            </#if>
         </div>
     </div>
   <#if !(authenticated!false)>


### PR DESCRIPTION
Fix #8426
Fix #6508

- Removed broken GA footer optout text in favor of cookiewall
- Changed a line that used mixed tab's and spaces as indentation ( i don't want to join the tabs vs spaces debate, but let's at least not use both in the same line )

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [N.A.] Code unit/integration/system tested
- [N.A.] Migration step added in case of breaking change
- [ ] User documentation updated
- [N.A.] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [x] Clean commits
- [ ] Added Feature/Fix to release notes
