### PR TITLE
fix(security): don't expand unknown roles

### DIFF
--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/CachedRoleHierarchyImpl.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/CachedRoleHierarchyImpl.java
@@ -1,5 +1,6 @@
 package org.molgenis.data.security.auth;
 
+import static java.util.Collections.singleton;
 import static java.util.Objects.requireNonNull;
 import static org.molgenis.security.core.runas.RunAsSystemAspect.runAsSystem;
 
@@ -8,7 +9,6 @@ import com.google.common.collect.ImmutableMap.Builder;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collection;
 import org.molgenis.data.security.DataserviceRoleHierarchy;
-import org.molgenis.data.security.exception.UnknownRoleException;
 import org.molgenis.data.transaction.TransactionListener;
 import org.molgenis.data.transaction.TransactionManager;
 import org.springframework.security.core.GrantedAuthority;
@@ -71,7 +71,7 @@ public class CachedRoleHierarchyImpl implements TransactionListener, CachedRoleH
     Collection<GrantedAuthority> reachableGrantedAuthorities =
         cachedReachableAuthoritiesMap.get(grantedAuthority);
     if (reachableGrantedAuthorities == null) {
-      throw new UnknownRoleException(grantedAuthority.getAuthority());
+      return singleton(grantedAuthority);
     }
     return reachableGrantedAuthorities;
   }

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/CachedRoleHierarchyImplTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/CachedRoleHierarchyImplTest.java
@@ -5,7 +5,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.when;
 
@@ -15,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.molgenis.data.security.DataserviceRoleHierarchy;
-import org.molgenis.data.security.exception.UnknownRoleException;
 import org.molgenis.data.transaction.TransactionManager;
 import org.molgenis.test.AbstractMockitoTest;
 import org.springframework.security.core.GrantedAuthority;
@@ -102,8 +100,8 @@ class CachedRoleHierarchyImplTest extends AbstractMockitoTest {
 
     GrantedAuthority unknownAuthority = new SimpleGrantedAuthority("ROLE_UNKNOWN");
     when(dataserviceRoleHierarchy.getAllGrantedAuthorityInclusions()).thenReturn(ImmutableMap.of());
-    assertThrows(
-        UnknownRoleException.class,
-        () -> cachedRoleHierarchyImpl.getReachableGrantedAuthorities(singleton(unknownAuthority)));
+    assertEquals(
+        singleton(unknownAuthority),
+        cachedRoleHierarchyImpl.getReachableGrantedAuthorities(singleton(unknownAuthority)));
   }
 }


### PR DESCRIPTION
When expanding roles, the RoleHierarchy now ignores unknown roles
instead of throwing an exception.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] Migration step added in case of breaking change
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
