### PR TITLE
Update Sonar rule identifiers

### DIFF
--- a/molgenis-amazon-bucket/src/test/java/org/molgenis/amazon/bucket/meta/AmazonBucketJobExecutionTest.java
+++ b/molgenis-amazon-bucket/src/test/java/org/molgenis/amazon/bucket/meta/AmazonBucketJobExecutionTest.java
@@ -47,7 +47,7 @@ public class AmazonBucketJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/CopyEntityRequestV2.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/CopyEntityRequestV2.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_CopyEntityRequestV2.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class CopyEntityRequestV2 {
   @NotNull
   public abstract String getNewEntityName();

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/EntityCollectionBatchRequestV2.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/EntityCollectionBatchRequestV2.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EntityCollectionBatchRequestV2.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EntityCollectionBatchRequestV2 {
   @NotEmpty(message = "Please provide at least one entity in the entities property.")
   @Size(

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/EntityCollectionDeleteRequestV2.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/EntityCollectionDeleteRequestV2.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EntityCollectionDeleteRequestV2.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EntityCollectionDeleteRequestV2 {
   @NotEmpty(message = "Please provide at least one entity in the entityIds property.")
   @Size(

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/ResourcesResponseV2.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/ResourcesResponseV2.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ResourcesResponseV2.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ResourcesResponseV2 {
   @NotNull
   public abstract String getHref();

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/RestControllerV2.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v2/RestControllerV2.java
@@ -303,7 +303,7 @@ public class RestControllerV2 {
    * @param response HttpServletResponse
    * @return EntityCollectionCreateResponseBodyV2
    */
-  @SuppressWarnings("squid:S2259") // getEntities is guaranteed to be not empty
+  @SuppressWarnings("java:S2259") // getEntities is guaranteed to be not empty
   @Transactional
   @PostMapping(value = "/{entityTypeId}", produces = APPLICATION_JSON_VALUE)
   public EntityCollectionBatchCreateResponseBodyV2 createEntities(
@@ -428,7 +428,7 @@ public class RestControllerV2 {
    * @param request EntityCollectionCreateRequestV2
    * @param response HttpServletResponse
    */
-  @SuppressWarnings("squid:S2259") // getEntities is guaranteed to be not empty
+  @SuppressWarnings("java:S2259") // getEntities is guaranteed to be not empty
   @Transactional
   @PutMapping("/{entityTypeId}")
   public synchronized void updateEntities(
@@ -481,7 +481,7 @@ public class RestControllerV2 {
    * @param request EntityCollectionBatchRequestV2
    * @param response HttpServletResponse
    */
-  @SuppressWarnings("squid:S2259") // getEntities is guaranteed to be not empty
+  @SuppressWarnings("java:S2259") // getEntities is guaranteed to be not empty
   @Transactional
   @PutMapping("/{entityTypeId}/{attributeName}")
   @ResponseStatus(OK)

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/Entities.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/Entities.java
@@ -19,7 +19,7 @@ abstract class Entities {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/EntityCollection.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/EntityCollection.java
@@ -22,7 +22,7 @@ abstract class EntityCollection {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   abstract static class Builder {
 
@@ -72,7 +72,7 @@ abstract class EntityCollection {
     }
 
     @SuppressWarnings(
-        "squid:S1610") // Abstract classes without fields should be converted to interfaces
+        "java:S1610") // Abstract classes without fields should be converted to interfaces
     @AutoValue.Builder
     abstract static class Builder {
 

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/UnsupportedAttributeTypeException.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/UnsupportedAttributeTypeException.java
@@ -4,7 +4,7 @@ import org.molgenis.data.meta.AttributeType;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnsupportedAttributeTypeException extends BadRequestException {
   private static final String ERROR_CODE = "DAPI01";
 

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/UnsupportedAttributeTypeException.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/UnsupportedAttributeTypeException.java
@@ -4,7 +4,7 @@ import org.molgenis.data.meta.AttributeType;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnsupportedAttributeTypeException extends BadRequestException {
   private static final String ERROR_CODE = "DAPI01";
 

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/model/EntitiesResponse.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/model/EntitiesResponse.java
@@ -37,7 +37,7 @@ public abstract class EntitiesResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/model/EntityResponse.java
+++ b/molgenis-api-data/src/main/java/org/molgenis/api/data/v3/model/EntityResponse.java
@@ -26,7 +26,7 @@ public abstract class EntityResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/AddGroupMemberCommand.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/AddGroupMemberCommand.java
@@ -5,7 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AddGroupMemberCommand.class)
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class AddGroupMemberCommand {
   public abstract String getUsername();
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/GroupCommand.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/GroupCommand.java
@@ -5,7 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_GroupCommand.class)
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class GroupCommand {
   public abstract String getName();
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/GroupMemberResponse.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/GroupMemberResponse.java
@@ -4,7 +4,7 @@ import com.google.auto.value.AutoValue;
 import org.molgenis.data.security.auth.RoleMembership;
 
 @AutoValue
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class GroupMemberResponse {
   public abstract UserResponse getUser();
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/GroupResponse.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/GroupResponse.java
@@ -4,7 +4,7 @@ import com.google.auto.value.AutoValue;
 import org.molgenis.data.security.auth.Group;
 
 @AutoValue
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class GroupResponse {
   public abstract String getName();
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/IdentitiesApiController.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/IdentitiesApiController.java
@@ -50,7 +50,7 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 public class IdentitiesApiController {
   public static final String USER = "/user";
 
-  @SuppressWarnings("squid:S1075") // URIs should not be hardcoded
+  @SuppressWarnings("java:S1075") // URIs should not be hardcoded
   private static final String SECURITY_API_PATH = ApiNamespace.API_PATH + "/identities";
 
   static final String GROUP_END_POINT = SECURITY_API_PATH + "/group";

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/RoleResponse.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/RoleResponse.java
@@ -4,8 +4,7 @@ import com.google.auto.value.AutoValue;
 import org.molgenis.data.security.auth.Role;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class RoleResponse {
   public abstract String getRoleName();
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/UpdateGroupMemberCommand.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/UpdateGroupMemberCommand.java
@@ -5,7 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_UpdateGroupMemberCommand.class)
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class UpdateGroupMemberCommand {
   public abstract String getRoleName();
 

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/UpdateIncludeCommand.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/UpdateIncludeCommand.java
@@ -5,7 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_UpdateIncludeCommand.class)
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class UpdateIncludeCommand {
 
   public abstract String getRole();

--- a/molgenis-api-identities/src/main/java/org/molgenis/api/identities/UserResponse.java
+++ b/molgenis-api-identities/src/main/java/org/molgenis/api/identities/UserResponse.java
@@ -4,8 +4,7 @@ import com.google.auto.value.AutoValue;
 import org.molgenis.data.security.auth.User;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class UserResponse {
   public abstract String getId();
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/Attributes.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/Attributes.java
@@ -19,7 +19,7 @@ abstract class Attributes {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/EntityTypeCollection.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/EntityTypeCollection.java
@@ -17,7 +17,7 @@ abstract class EntityTypeCollection {
   abstract @Nullable @CheckForNull String getEntityId();
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   abstract static class Builder {
 
@@ -59,7 +59,7 @@ abstract class EntityTypeCollection {
     }
 
     @SuppressWarnings(
-        "squid:S1610") // Abstract classes without fields should be converted to interfaces
+        "java:S1610") // Abstract classes without fields should be converted to interfaces
     @AutoValue.Builder
     abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/EntityTypeRequestMapperImpl.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/EntityTypeRequestMapperImpl.java
@@ -95,7 +95,7 @@ public class EntityTypeRequestMapperImpl implements EntityTypeRequestMapper {
   }
 
   @SuppressWarnings({
-    "squid:S1192"
+    "java:S1192"
   }) // ATTRIBUTES constant in this class is not related to the one in this switch
   private void updateEntityType(EntityType entityType, Entry<String, Object> entry) {
     switch (entry.getKey()) {

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/EntityTypes.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/EntityTypes.java
@@ -19,7 +19,7 @@ abstract class EntityTypes {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/EmptyAttributesException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/EmptyAttributesException.java
@@ -2,7 +2,7 @@ package org.molgenis.api.metadata.v3.exception;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class EmptyAttributesException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI02";
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/EmptyAttributesException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/EmptyAttributesException.java
@@ -2,7 +2,7 @@ package org.molgenis.api.metadata.v3.exception;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class EmptyAttributesException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI02";
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/IdModificationException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/IdModificationException.java
@@ -2,7 +2,7 @@ package org.molgenis.api.metadata.v3.exception;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class IdModificationException extends BadRequestException {
 
   private static final String ERROR_CODE = "MAPI03";

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/IdModificationException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/IdModificationException.java
@@ -2,7 +2,7 @@ package org.molgenis.api.metadata.v3.exception;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class IdModificationException extends BadRequestException {
 
   private static final String ERROR_CODE = "MAPI03";

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/InvalidKeyException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/InvalidKeyException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class InvalidKeyException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI04";
   private final String target;

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/InvalidKeyException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/InvalidKeyException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class InvalidKeyException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI04";
   private final String target;

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/ReadOnlyFieldException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/ReadOnlyFieldException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ReadOnlyFieldException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI07";
   private final String field;

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/ReadOnlyFieldException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/ReadOnlyFieldException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ReadOnlyFieldException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI07";
   private final String field;

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnknownLookupAttributesException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnknownLookupAttributesException.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownLookupAttributesException extends BadRequestException {
 
   private static final String ERROR_CODE = "MAPI05";

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnknownLookupAttributesException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnknownLookupAttributesException.java
@@ -8,7 +8,7 @@ import org.apache.logging.log4j.util.Strings;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownLookupAttributesException extends BadRequestException {
 
   private static final String ERROR_CODE = "MAPI05";

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnsupportedFieldException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnsupportedFieldException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnsupportedFieldException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI06";
   private final String field;

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnsupportedFieldException.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/exception/UnsupportedFieldException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnsupportedFieldException extends BadRequestException {
   private static final String ERROR_CODE = "MAPI06";
   private final String field;

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/job/SerializableAttribute.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/job/SerializableAttribute.java
@@ -106,7 +106,7 @@ abstract class SerializableAttribute {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/job/SerializableEntityType.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/job/SerializableEntityType.java
@@ -45,7 +45,7 @@ abstract class SerializableEntityType {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/AttributeResponse.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/AttributeResponse.java
@@ -27,7 +27,7 @@ public abstract class AttributeResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/AttributeResponseData.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/AttributeResponseData.java
@@ -96,7 +96,7 @@ public abstract class AttributeResponseData implements MetadataResponseData {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to Integererfaces
+      "java:S1610") // Abstract classes without fields should be converted to Integererfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/AttributesResponse.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/AttributesResponse.java
@@ -37,7 +37,7 @@ public abstract class AttributesResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/Category.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/Category.java
@@ -17,7 +17,7 @@ public abstract class Category {
   }
 
   // Abstract classes without fields should be converted to interfaces
-  @SuppressWarnings("squid:S1610")
+  @SuppressWarnings("java:S1610")
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/CreateAttributeRequest.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/CreateAttributeRequest.java
@@ -158,7 +158,7 @@ public abstract class CreateAttributeRequest {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/CreateEntityTypeRequest.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/CreateEntityTypeRequest.java
@@ -57,7 +57,7 @@ public abstract class CreateEntityTypeRequest {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/EntityTypeResponse.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/EntityTypeResponse.java
@@ -26,7 +26,7 @@ public abstract class EntityTypeResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setLinks(LinksResponse newLinks);

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/EntityTypeResponseData.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/EntityTypeResponseData.java
@@ -39,7 +39,7 @@ public abstract class EntityTypeResponseData implements MetadataResponseData {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/EntityTypesResponse.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/EntityTypesResponse.java
@@ -37,7 +37,7 @@ public abstract class EntityTypesResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/I18nValue.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/I18nValue.java
@@ -29,7 +29,7 @@ public abstract class I18nValue {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/PackageResponse.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/PackageResponse.java
@@ -18,7 +18,7 @@ public abstract class PackageResponse {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setLinks(LinksResponse newLinks);

--- a/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/Range.java
+++ b/molgenis-api-metadata/src/main/java/org/molgenis/api/metadata/v3/model/Range.java
@@ -25,7 +25,7 @@ public abstract class Range {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Range.Builder setMin(Long min);

--- a/molgenis-api-metadata/src/test/java/org/molgenis/api/metadata/v3/MetadataApiJobServiceImplTest.java
+++ b/molgenis-api-metadata/src/test/java/org/molgenis/api/metadata/v3/MetadataApiJobServiceImplTest.java
@@ -21,7 +21,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.jobs.JobExecutor;
 import org.molgenis.test.AbstractMockitoTest;
 
-@SuppressWarnings("squid:S1192") // string literals should not be duplicated
+@SuppressWarnings("java:S1192") // string literals should not be duplicated
 class MetadataApiJobServiceImplTest extends AbstractMockitoTest {
 
   @Mock MetadataUpsertJobExecutionFactory metadataUpsertJobExecutionFactory;

--- a/molgenis-api-metadata/src/test/java/org/molgenis/api/metadata/v3/job/MetadataDeleteJobExecutionTest.java
+++ b/molgenis-api-metadata/src/test/java/org/molgenis/api/metadata/v3/job/MetadataDeleteJobExecutionTest.java
@@ -54,7 +54,7 @@ public class MetadataDeleteJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   public void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-api-metadata/src/test/java/org/molgenis/api/metadata/v3/job/MetadataUpsertJobExecutionTest.java
+++ b/molgenis-api-metadata/src/test/java/org/molgenis/api/metadata/v3/job/MetadataUpsertJobExecutionTest.java
@@ -53,7 +53,7 @@ public class MetadataUpsertJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   public void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/PermissionQueryParseException.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/PermissionQueryParseException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import cz.jirutka.rsql.parser.RSQLParserException;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class PermissionQueryParseException extends BadRequestException {
   private static final String ERROR_CODE = "PRM07";
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/PermissionQueryParseException.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/PermissionQueryParseException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import cz.jirutka.rsql.parser.RSQLParserException;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class PermissionQueryParseException extends BadRequestException {
   private static final String ERROR_CODE = "PRM07";
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnknownPermissionQueryParamException.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnknownPermissionQueryParamException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownPermissionQueryParamException extends BadRequestException {
   private static final String ERROR_CODE = "PRM01";
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnknownPermissionQueryParamException.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnknownPermissionQueryParamException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownPermissionQueryParamException extends BadRequestException {
   private static final String ERROR_CODE = "PRM01";
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnsupportedPermissionQueryOperatorException.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnsupportedPermissionQueryOperatorException.java
@@ -2,7 +2,7 @@ package org.molgenis.api.permissions.exceptions.rsql;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnsupportedPermissionQueryOperatorException extends BadRequestException {
   private static final String ERROR_CODE = "PRM02";
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnsupportedPermissionQueryOperatorException.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/exceptions/rsql/UnsupportedPermissionQueryOperatorException.java
@@ -2,7 +2,7 @@ package org.molgenis.api.permissions.exceptions.rsql;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnsupportedPermissionQueryOperatorException extends BadRequestException {
   private static final String ERROR_CODE = "PRM02";
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/DeletePermissionRequest.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/DeletePermissionRequest.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_DeletePermissionRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class DeletePermissionRequest {
 
   public abstract String getUser();

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/ObjectPermissionsRequest.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/ObjectPermissionsRequest.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ObjectPermissionsRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ObjectPermissionsRequest {
   public abstract String getObjectId();
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/PermissionRequest.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/PermissionRequest.java
@@ -11,8 +11,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_PermissionRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PermissionRequest {
   @Nullable
   @CheckForNull

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/SetObjectPermissionRequest.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/SetObjectPermissionRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_SetObjectPermissionRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class SetObjectPermissionRequest {
 
   @NotEmpty

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/SetTypePermissionsRequest.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/SetTypePermissionsRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_SetTypePermissionsRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class SetTypePermissionsRequest {
 
   @NotEmpty

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/TypePermissionsRequest.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/request/TypePermissionsRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_TypePermissionsRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class TypePermissionsRequest {
   public abstract String getTypeId();
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/AllPermissionsResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/AllPermissionsResponse.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AllPermissionsResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AllPermissionsResponse {
   public abstract Set<LabelledPermissionResponse> getPermissions();
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/LabelledPermissionResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/LabelledPermissionResponse.java
@@ -11,8 +11,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_LabelledPermissionResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class LabelledPermissionResponse {
   @Nullable
   @CheckForNull

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/ObjectPermissionResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/ObjectPermissionResponse.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ObjectPermissionResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ObjectPermissionResponse {
   public abstract String getId();
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/ObjectResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/ObjectResponse.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ObjectResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ObjectResponse {
   public abstract String getId();
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/PermissionResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/PermissionResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_PermissionResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PermissionResponse {
 
   @Nullable

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/TypePermissionsResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/TypePermissionsResponse.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_TypePermissionsResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class TypePermissionsResponse {
   public abstract String getId();
 

--- a/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/TypeResponse.java
+++ b/molgenis-api-permissions/src/main/java/org/molgenis/api/permissions/model/response/TypeResponse.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_TypeResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class TypeResponse {
   public abstract String getId();
 

--- a/molgenis-api/src/main/java/org/molgenis/api/ApiNamespace.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/ApiNamespace.java
@@ -3,6 +3,6 @@ package org.molgenis.api;
 public class ApiNamespace {
   private ApiNamespace() {}
 
-  @SuppressWarnings("squid:S1075")
+  @SuppressWarnings("java:S1075")
   public static final String API_PATH = "/api";
 }

--- a/molgenis-api/src/main/java/org/molgenis/api/convert/QueryParseException.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/convert/QueryParseException.java
@@ -20,7 +20,7 @@ public class QueryParseException extends CodedRuntimeException {
     return format("parseException: %s", parseException.getMessage());
   }
 
-  @SuppressWarnings("squid:S1872")
+  @SuppressWarnings("java:S1872")
   @Override
   protected Object[] getLocalizedMessageArguments() {
     Throwable cause = parseException.getCause();

--- a/molgenis-api/src/main/java/org/molgenis/api/model/Order.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/Order.java
@@ -32,7 +32,7 @@ public abstract class Order {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api/src/main/java/org/molgenis/api/model/Query.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/Query.java
@@ -71,7 +71,7 @@ public abstract class Query implements Serializable {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api/src/main/java/org/molgenis/api/model/Sort.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/Sort.java
@@ -32,7 +32,7 @@ public abstract class Sort {
   }
 
   @SuppressWarnings(
-      "squid:S1610") // Abstract classes without fields should be converted to interfaces
+      "java:S1610") // Abstract classes without fields should be converted to interfaces
   @AutoValue.Builder
   public abstract static class Builder {
 

--- a/molgenis-api/src/main/java/org/molgenis/api/model/response/ApiResponse.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/response/ApiResponse.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ApiResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ApiResponse {
 
   public abstract Object getData();

--- a/molgenis-api/src/main/java/org/molgenis/api/model/response/AppVersionResponse.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/response/AppVersionResponse.java
@@ -6,7 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AppVersionResponse.class)
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class AppVersionResponse {
   public abstract String getVersion();
 

--- a/molgenis-api/src/main/java/org/molgenis/api/model/response/LinksResponse.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/response/LinksResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_LinksResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class LinksResponse {
   @Nullable
   @CheckForNull

--- a/molgenis-api/src/main/java/org/molgenis/api/model/response/OptionsResponse.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/response/OptionsResponse.java
@@ -5,7 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_OptionsResponse.class)
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class OptionsResponse {
   public abstract AppVersionResponse getApp();
 

--- a/molgenis-api/src/main/java/org/molgenis/api/model/response/PageResponse.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/response/PageResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_PageResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PageResponse {
   /** Returns the requested size of the page. */
   public abstract int getSize();

--- a/molgenis-api/src/main/java/org/molgenis/api/model/response/PagedApiResponse.java
+++ b/molgenis-api/src/main/java/org/molgenis/api/model/response/PagedApiResponse.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_PagedApiResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PagedApiResponse {
   @Nullable
   @CheckForNull

--- a/molgenis-app-manager/src/main/java/org/molgenis/app/manager/exception/IllegalAppNameException.java
+++ b/molgenis-app-manager/src/main/java/org/molgenis/app/manager/exception/IllegalAppNameException.java
@@ -8,7 +8,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Thrown when an app name contains illegal characters */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class IllegalAppNameException extends CodedRuntimeException {
   private static final String ERROR_CODE = "AM10";
 

--- a/molgenis-app-manager/src/main/java/org/molgenis/app/manager/exception/IllegalAppNameException.java
+++ b/molgenis-app-manager/src/main/java/org/molgenis/app/manager/exception/IllegalAppNameException.java
@@ -8,7 +8,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Thrown when an app name contains illegal characters */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class IllegalAppNameException extends CodedRuntimeException {
   private static final String ERROR_CODE = "AM10";
 

--- a/molgenis-app-manager/src/main/java/org/molgenis/app/manager/model/AppResponse.java
+++ b/molgenis-app-manager/src/main/java/org/molgenis/app/manager/model/AppResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AppResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AppResponse {
   public abstract String getId();
 

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconAlleleRequest.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconAlleleRequest.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 /** Query for information about a specific allele. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_BeaconAlleleRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class BeaconAlleleRequest {
   /**
    * Reference name (chromosome).

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconAlleleResponse.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconAlleleResponse.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 /** BeaconResponse's response to a query for information about a specific allele. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_BeaconAlleleResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class BeaconAlleleResponse {
   /** Identifier of the beacon, as defined in @{@link Beacon}. */
   public abstract String getBeaconId();

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconDatasetResponse.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconDatasetResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 /** Dataset of a beacon. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_BeaconDatasetResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class BeaconDatasetResponse {
   /** Unique identifier of the dataset. */
   public abstract String getId();

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconError.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconError.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 /** BeaconResponse-specific error representing an unexpected problem. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_BeaconError.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class BeaconError {
   /** Numeric error code. */
   public abstract Integer getErrorCode();

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconOrganizationResponse.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconOrganizationResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 /** Organization owning a beacon. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_BeaconOrganizationResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class BeaconOrganizationResponse {
   /** Unique identifier of the organization. */
   public abstract String getId();

--- a/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconResponse.java
+++ b/molgenis-beacon/src/main/java/org/molgenis/beacon/controller/model/BeaconResponse.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 /** A Beacon */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_BeaconResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class BeaconResponse {
   /** Unique identifier of the beacon. */
   public abstract String getId();

--- a/molgenis-beacon/src/test/java/org/molgenis/beacon/config/BeaconDatasetTest.java
+++ b/molgenis-beacon/src/test/java/org/molgenis/beacon/config/BeaconDatasetTest.java
@@ -19,7 +19,7 @@ class BeaconDatasetTest extends AbstractSystemEntityTest {
   @Autowired BeaconDatasetMetadata metadata;
   @Autowired BeaconDatasetFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   public void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-beacon/src/test/java/org/molgenis/beacon/config/BeaconOrganizationTest.java
+++ b/molgenis-beacon/src/test/java/org/molgenis/beacon/config/BeaconOrganizationTest.java
@@ -18,7 +18,7 @@ class BeaconOrganizationTest extends AbstractSystemEntityTest {
   @Autowired BeaconOrganizationMetadata metadata;
   @Autowired BeaconOrganizationFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   public void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/AppDataRootInitializer.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/AppDataRootInitializer.java
@@ -42,7 +42,7 @@ public class AppDataRootInitializer {
     AppDataRootProvider.setAppDataRoot(appDataRoot);
   }
 
-  @SuppressWarnings("java:S2083") // MOLGENIS_HOME is trusted
+  @SuppressWarnings("javasecurity:S2083") // MOLGENIS_HOME is trusted
   private static Path getAppDataRoot() {
     LOG.debug("Trying to retrieve app data root from Java system property '{}'", MOLGENIS_HOME);
     String appDataRootPathname = System.getProperty(MOLGENIS_HOME);

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/AppDataRootInitializer.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/AppDataRootInitializer.java
@@ -42,7 +42,7 @@ public class AppDataRootInitializer {
     AppDataRootProvider.setAppDataRoot(appDataRoot);
   }
 
-  @SuppressWarnings("squid:S2083") // MOLGENIS_HOME is trusted
+  @SuppressWarnings("java:S2083") // MOLGENIS_HOME is trusted
   private static Path getAppDataRoot() {
     LOG.debug("Trying to retrieve app data root from Java system property '{}'", MOLGENIS_HOME);
     String appDataRootPathname = System.getProperty(MOLGENIS_HOME);

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisMenuController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisMenuController.java
@@ -75,7 +75,7 @@ public class MolgenisMenuController {
    * provided.
    */
   @Transactional(readOnly = true)
-  @SuppressWarnings("squid:S3752") // multiple methods required
+  @SuppressWarnings("java:S3752") // multiple methods required
   @RequestMapping(method = {RequestMethod.GET, RequestMethod.POST})
   public String forwardDefaultMenuDefaultPlugin(Model model) {
     Menu menu =
@@ -118,7 +118,7 @@ public class MolgenisMenuController {
    *
    * @param menuId ID of the menu or plugin
    */
-  @SuppressWarnings("squid:S3752") // multiple methods required
+  @SuppressWarnings("java:S3752") // multiple methods required
   @RequestMapping(
       method = {RequestMethod.GET, RequestMethod.POST},
       value = "/{menuId}")
@@ -151,7 +151,7 @@ public class MolgenisMenuController {
    * @param menuId ID of the menu parent of the pluginID
    * @param pluginId ID of the plugin
    */
-  @SuppressWarnings("squid:S3752") // multiple methods required
+  @SuppressWarnings("java:S3752") // multiple methods required
   @RequestMapping("/{menuId}/{pluginId}/**")
   public String forwardMenuPlugin(
       HttpServletRequest request,
@@ -216,7 +216,7 @@ public class MolgenisMenuController {
 
   /** Controller used to render an empty page if the user has no permissions to view anything. */
   @Controller
-  @SuppressWarnings("squid:S3752") // multiple methods required
+  @SuppressWarnings("java:S3752") // multiple methods required
   @RequestMapping(
       method = {RequestMethod.GET, RequestMethod.POST},
       value = VoidPluginController.URI)

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisRootController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/MolgenisRootController.java
@@ -8,7 +8,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
 @Controller
 @RequestMapping("/")
 public class MolgenisRootController {
-  @SuppressWarnings("squid:S3752") // multiple methods required
+  @SuppressWarnings("java:S3752") // multiple methods required
   @RequestMapping(method = {RequestMethod.GET, RequestMethod.POST})
   public String index() {
     return "forward:" + MolgenisMenuController.URI;

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/admin/permission/PermissionResponse.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/admin/permission/PermissionResponse.java
@@ -4,7 +4,7 @@ import com.google.auto.value.AutoValue;
 import org.molgenis.security.core.Permission;
 
 @AutoValue
-@SuppressWarnings("squid:S1610") // Autovalue needs an abstract class
+@SuppressWarnings("java:S1610") // Autovalue needs an abstract class
 public abstract class PermissionResponse {
   public abstract String getType();
 

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/admin/permission/PermissionSetResponse.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/admin/permission/PermissionSetResponse.java
@@ -10,7 +10,7 @@ import org.molgenis.security.core.Permission;
 import org.molgenis.security.core.PermissionSet;
 
 @AutoValue
-@SuppressWarnings("squid:S1610") // Autovalue needs an abstract class
+@SuppressWarnings("java:S1610") // Autovalue needs an abstract class
 public abstract class PermissionSetResponse {
   public abstract String getName();
 

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/FeedbackController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/FeedbackController.java
@@ -105,7 +105,7 @@ public class FeedbackController extends AbstractStaticContentController {
   }
 
   /** Creates a MimeMessage based on a FeedbackForm. */
-  @SuppressWarnings("squid:S3457") // do not use platform specific line ending
+  @SuppressWarnings("java:S3457") // do not use platform specific line ending
   private SimpleMailMessage createFeedbackMessage(FeedbackForm form) {
     SimpleMailMessage message = new SimpleMailMessage();
     message.setTo(userService.getSuEmailAddresses().toArray(new String[] {}));

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/UiContextResponse.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/controller/UiContextResponse.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 import org.molgenis.web.menu.model.Menu;
 
 @AutoValue
-@SuppressWarnings("squid:S1610")
+@SuppressWarnings("java:S1610")
 public abstract class UiContextResponse {
 
   @Nullable

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/ImportWizardController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/ImportWizardController.java
@@ -2,7 +2,7 @@ package org.molgenis.core.ui.data.importer.wizard;
 
 import static org.apache.commons.io.FilenameUtils.getBaseName;
 import static org.apache.commons.io.FilenameUtils.getExtension;
-import static org.molgenis.core.ui.data.importer.wizard.ImportWizardController.URI; // NOSONAR
+import static org.molgenis.core.ui.data.importer.wizard.ImportWizardController.URI;
 import static org.springframework.http.MediaType.TEXT_PLAIN;
 
 import java.io.File;
@@ -143,7 +143,7 @@ public class ImportWizardController extends AbstractWizardController {
    *
    * @param url URL from which a file is downloaded
    */
-  @SuppressWarnings("squid:S2083")
+  @SuppressWarnings("java:S2083")
   @PostMapping("/importByUrl")
   @ResponseBody
   public ResponseEntity<String> importFileByUrl(
@@ -223,12 +223,12 @@ public class ImportWizardController extends AbstractWizardController {
     return ResponseEntity.created(new java.net.URI(href)).contentType(TEXT_PLAIN).body(href);
   }
 
-  @SuppressWarnings({"squid:S2083", "squid:S5144"})
+  @SuppressWarnings({"java:S2083", "java:S5144"})
   private File fileLocationToStoredRenamedFile(String fileLocation, String entityTypeId)
       throws IOException, URISyntaxException {
     String filename = fileLocation.substring(fileLocation.lastIndexOf('/') + 1);
 
-    // Fix vulnerability reported by sonar: squid:S5144
+    // Fix vulnerability reported by sonar: java:S5144
     URL url = UriValidator.getSafeUri(fileLocation).toURL();
 
     try (InputStream is = url.openStream()) {

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/ImportWizardController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/ImportWizardController.java
@@ -143,7 +143,7 @@ public class ImportWizardController extends AbstractWizardController {
    *
    * @param url URL from which a file is downloaded
    */
-  @SuppressWarnings("java:S2083")
+  @SuppressWarnings("javasecurity:S2083")
   @PostMapping("/importByUrl")
   @ResponseBody
   public ResponseEntity<String> importFileByUrl(
@@ -223,12 +223,12 @@ public class ImportWizardController extends AbstractWizardController {
     return ResponseEntity.created(new java.net.URI(href)).contentType(TEXT_PLAIN).body(href);
   }
 
-  @SuppressWarnings({"java:S2083", "java:S5144"})
+  @SuppressWarnings({"javasecurity:S2083", "javasecurity:S5144"})
   private File fileLocationToStoredRenamedFile(String fileLocation, String entityTypeId)
       throws IOException, URISyntaxException {
     String filename = fileLocation.substring(fileLocation.lastIndexOf('/') + 1);
 
-    // Fix vulnerability reported by sonar: java:S5144
+    // Fix vulnerability reported by sonar: javasecurity:S5144
     URL url = UriValidator.getSafeUri(fileLocation).toURL();
 
     try (InputStream is = url.openStream()) {

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/OptionsWizardPage.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/OptionsWizardPage.java
@@ -60,7 +60,7 @@ public class OptionsWizardPage extends AbstractWizardPage {
     return "Options";
   }
 
-  @SuppressWarnings("java:S2083")
+  @SuppressWarnings("javasecurity:S2083")
   @Override
   public String handleRequest(HttpServletRequest request, BindingResult result, Wizard wizard) {
     ImportWizardUtil.validateImportWizard(wizard);
@@ -73,7 +73,7 @@ public class OptionsWizardPage extends AbstractWizardPage {
     if (importWizard.getMustChangeEntityName()) {
       // userGivenName will be validated by the NameValidator and can't contain any
       // characters that have special meaning for the file system
-      @SuppressWarnings("java:S2083")
+      @SuppressWarnings("javasecurity:S2083")
       String userGivenName = request.getParameter("name");
       if (StringUtils.isEmpty(userGivenName)) {
         result.addError(new ObjectError("wizard", "Please enter an entity name"));

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/OptionsWizardPage.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/data/importer/wizard/OptionsWizardPage.java
@@ -60,7 +60,7 @@ public class OptionsWizardPage extends AbstractWizardPage {
     return "Options";
   }
 
-  @SuppressWarnings("squid:S2083")
+  @SuppressWarnings("java:S2083")
   @Override
   public String handleRequest(HttpServletRequest request, BindingResult result, Wizard wizard) {
     ImportWizardUtil.validateImportWizard(wizard);
@@ -73,7 +73,7 @@ public class OptionsWizardPage extends AbstractWizardPage {
     if (importWizard.getMustChangeEntityName()) {
       // userGivenName will be validated by the NameValidator and can't contain any
       // characters that have special meaning for the file system
-      @SuppressWarnings("squid:S2083")
+      @SuppressWarnings("java:S2083")
       String userGivenName = request.getParameter("name");
       if (StringUtils.isEmpty(userGivenName)) {
         result.addError(new ObjectError("wizard", "Please enter an entity name"));

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/Style.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/Style.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Style.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Style {
   public abstract String getName();
 

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/wizard/AbstractWizardController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/wizard/AbstractWizardController.java
@@ -91,7 +91,7 @@ public abstract class AbstractWizardController extends PluginController {
     return VIEW_NAME;
   }
 
-  @SuppressWarnings("squid:S3752") // backward compatibility: multiple methods required
+  @SuppressWarnings("java:S3752") // backward compatibility: multiple methods required
   @RequestMapping(
       method = {RequestMethod.GET, RequestMethod.POST},
       value = "/restart")

--- a/molgenis-core-ui/src/test/java/org/molgenis/core/ui/data/system/core/FreemarkerTemplateTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/core/ui/data/system/core/FreemarkerTemplateTest.java
@@ -25,7 +25,7 @@ class FreemarkerTemplateTest extends AbstractSystemEntityTest {
   @Autowired FreemarkerTemplateMetadata metadata;
   @Autowired FreemarkerTemplateFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-core-ui/src/test/java/org/molgenis/core/ui/settings/StaticContentTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/core/ui/settings/StaticContentTest.java
@@ -13,7 +13,7 @@ public class StaticContentTest extends AbstractSystemEntityTest {
   @Autowired StaticContentMetadata metadata;
   @Autowired StaticContentFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-core-ui/src/test/java/org/molgenis/core/ui/style/StyleSheetTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/core/ui/style/StyleSheetTest.java
@@ -21,7 +21,7 @@ public class StyleSheetTest extends AbstractSystemEntityTest {
   @Autowired StyleSheetMetadata metadata;
   @Autowired StyleSheetFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-cache/src/main/java/org/molgenis/data/cache/l2/L2Cache.java
+++ b/molgenis-data-cache/src/main/java/org/molgenis/data/cache/l2/L2Cache.java
@@ -183,7 +183,7 @@ public class L2Cache implements TransactionListener {
    *     id of the repository is used to look up the existing cache
    * @return the LoadingCache for the repository
    */
-  @SuppressWarnings("squid:S2201") // ignore return values
+  @SuppressWarnings("java:S2201") // ignore return values
   private LoadingCache<Object, Optional<Map<String, Object>>> getEntityCache(
       Repository<Entity> repository) {
     String id = repository.getEntityType().getId();

--- a/molgenis-data-cache/src/main/java/org/molgenis/data/cache/l3/L3Cache.java
+++ b/molgenis-data-cache/src/main/java/org/molgenis/data/cache/l3/L3Cache.java
@@ -64,7 +64,7 @@ public class L3Cache implements TransactionListener {
     return cache.getUnchecked(fetchlessQuery);
   }
 
-  @SuppressWarnings("squid:S2201") // ignore return values
+  @SuppressWarnings("java:S2201") // ignore return values
   private LoadingCache<Query<Entity>, List<Object>> getQueryCache(Repository<Entity> repository) {
     String id = repository.getEntityType().getId();
     if (!caches.containsKey(id)) {

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/model/SearchHit.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/model/SearchHit.java
@@ -3,8 +3,7 @@ package org.molgenis.data.elasticsearch.client.model;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class SearchHit {
   public abstract String getId();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/model/SearchHits.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/model/SearchHits.java
@@ -4,8 +4,7 @@ import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class SearchHits {
   public abstract long getTotalHits();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Document.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Document.java
@@ -6,8 +6,7 @@ import javax.annotation.Nullable;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Document {
   public abstract String getId();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/DocumentAction.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/DocumentAction.java
@@ -3,8 +3,7 @@ package org.molgenis.data.elasticsearch.generator.model;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class DocumentAction {
   public enum Operation {
     INDEX,

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/FieldMapping.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/FieldMapping.java
@@ -6,8 +6,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class FieldMapping {
   public abstract String getName();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Index.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Index.java
@@ -3,8 +3,7 @@ package org.molgenis.data.elasticsearch.generator.model;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Index {
   public abstract String getName();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/IndexSettings.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/IndexSettings.java
@@ -3,8 +3,7 @@ package org.molgenis.data.elasticsearch.generator.model;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class IndexSettings {
   private static final int DEFAULT_NUMBER_OF_SHARDS = 1;
   private static final int DEFAULT_NUMBER_OF_REPLICAS = 0;

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Mapping.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Mapping.java
@@ -6,8 +6,7 @@ import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Mapping {
   public abstract String getType();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Sort.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/Sort.java
@@ -4,8 +4,7 @@ import com.google.auto.value.AutoValue;
 import java.util.List;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Sort {
   public abstract List<SortOrder> getOrders();
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/SortOrder.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/SortOrder.java
@@ -3,8 +3,7 @@ package org.molgenis.data.elasticsearch.generator.model;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class SortOrder {
   public abstract String getField();
 

--- a/molgenis-data-excel/src/main/java/org/molgenis/data/excel/xlsx/XlsxWriter.java
+++ b/molgenis-data-excel/src/main/java/org/molgenis/data/excel/xlsx/XlsxWriter.java
@@ -114,7 +114,7 @@ public class XlsxWriter implements AutoCloseable {
   }
 
   /** package-private for testability */
-  @SuppressWarnings("squid:S2259") // Null pointers should not be dereferenced
+  @SuppressWarnings("java:S2259") // Null pointers should not be dereferenced
   void setCellValue(Cell cell, Object value) {
     if (value instanceof Boolean) {
       cell.setCellValue(toBoolean(value));

--- a/molgenis-data-file/src/main/java/org/molgenis/data/file/BlobMetadata.java
+++ b/molgenis-data-file/src/main/java/org/molgenis/data/file/BlobMetadata.java
@@ -16,7 +16,7 @@ public abstract class BlobMetadata {
     return new AutoValue_BlobMetadata.Builder();
   }
 
-  @SuppressWarnings("squid:S1610") // Autovalue needs an abstract class
+  @SuppressWarnings("java:S1610") // Autovalue needs an abstract class
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setId(String newId);

--- a/molgenis-data-file/src/main/java/org/molgenis/data/file/CodedUnzipException.java
+++ b/molgenis-data-file/src/main/java/org/molgenis/data/file/CodedUnzipException.java
@@ -8,7 +8,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Thrown when unzipping a file fails. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class CodedUnzipException extends CodedRuntimeException {
   private static final String ERROR_CODE = "DF01";
 

--- a/molgenis-data-file/src/main/java/org/molgenis/data/file/CodedUnzipException.java
+++ b/molgenis-data-file/src/main/java/org/molgenis/data/file/CodedUnzipException.java
@@ -8,7 +8,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Thrown when unzipping a file fails. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class CodedUnzipException extends CodedRuntimeException {
   private static final String ERROR_CODE = "DF01";
 

--- a/molgenis-data-file/src/test/java/org/molgenis/data/file/model/FileMetaTest.java
+++ b/molgenis-data-file/src/test/java/org/molgenis/data/file/model/FileMetaTest.java
@@ -13,7 +13,7 @@ public class FileMetaTest extends AbstractSystemEntityTest {
   @Autowired FileMetaMetadata metadata;
   @Autowired FileMetaFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-i18n/src/test/java/org/molgenis/data/i18n/model/L10nStringTest.java
+++ b/molgenis-data-i18n/src/test/java/org/molgenis/data/i18n/model/L10nStringTest.java
@@ -13,7 +13,7 @@ public class L10nStringTest extends AbstractSystemEntityTest {
   @Autowired L10nStringMetadata metadata;
   @Autowired L10nStringFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-i18n/src/test/java/org/molgenis/data/i18n/model/LanguageTest.java
+++ b/molgenis-data-i18n/src/test/java/org/molgenis/data/i18n/model/LanguageTest.java
@@ -19,7 +19,7 @@ public class LanguageTest extends AbstractSystemEntityTest {
   @Autowired LanguageMetadata metadata;
   @Autowired LanguageFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-icd10/src/test/java/org/molgenis/data/icd10/CollectionsQueryTransformerImplTest.java
+++ b/molgenis-data-icd10/src/test/java/org/molgenis/data/icd10/CollectionsQueryTransformerImplTest.java
@@ -26,8 +26,8 @@ import org.molgenis.data.Query;
 import org.molgenis.data.support.QueryImpl;
 import org.molgenis.test.AbstractMockitoTest;
 
-// squids: nested code blocks should be extracted & using the same literal string multiple times
-@SuppressWarnings({"squid:S1199", "squid:S1192"})
+// javas: nested code blocks should be extracted & using the same literal string multiple times
+@SuppressWarnings({"java:S1199", "java:S1192"})
 class CollectionsQueryTransformerImplTest extends AbstractMockitoTest {
   @Mock private DataService dataService;
 
@@ -60,7 +60,7 @@ class CollectionsQueryTransformerImplTest extends AbstractMockitoTest {
   }
 
   @SuppressWarnings("UnnecessaryLocalVariable")
-  // squids: nested code blocks should be extracted & using the same literal string multiple times
+  // javas: nested code blocks should be extracted & using the same literal string multiple times
   static Iterator<Object[]> nonTransformableQueryProvider() {
     setExpandedDiseaseEntities();
 

--- a/molgenis-data-icd10/src/test/java/org/molgenis/data/icd10/Icd10ClassExpanderImplTest.java
+++ b/molgenis-data-icd10/src/test/java/org/molgenis/data/icd10/Icd10ClassExpanderImplTest.java
@@ -25,7 +25,7 @@ class Icd10ClassExpanderImplTest {
     icd10ClassExpanderImpl = new Icd10ClassExpanderImpl();
   }
 
-  @SuppressWarnings("squid:S1192") // using literal string multiple times
+  @SuppressWarnings("java:S1192") // using literal string multiple times
   static Iterator<Object[]> testExpandClassesProvider() {
     Entity entityA = createEntity("A");
     Entity entityB = createEntity("B");

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/EntitiesValidationReportImpl.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/EntitiesValidationReportImpl.java
@@ -63,7 +63,7 @@ public class EntitiesValidationReportImpl implements EntitiesValidationReport {
     return importOrder;
   }
 
-  @SuppressWarnings("squid:S2178") // Short-circuit logic should be used in boolean contexts
+  @SuppressWarnings("java:S2178") // Short-circuit logic should be used in boolean contexts
   @Override
   public boolean valid() {
     // determine if validation succeeded

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportRunService.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/ImportRunService.java
@@ -106,7 +106,7 @@ public class ImportRunService {
    * @param importRun the ImportRun to describe, it should have non-null start and end dates.
    * @return String containing the mail message.
    */
-  @SuppressWarnings("squid:S3457")
+  @SuppressWarnings("java:S3457")
   // do not use platform specific line ending
   String createEnglishMailText(ImportRun importRun, ZoneId zone) {
     ZonedDateTime start = importRun.getStartDate().atZone(zone);

--- a/molgenis-data-import/src/main/java/org/molgenis/data/importer/PersistResult.java
+++ b/molgenis-data-import/src/main/java/org/molgenis/data/importer/PersistResult.java
@@ -4,8 +4,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableMap;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PersistResult {
   public abstract ImmutableMap<String, Long> getNrPersistedEntitiesMap();
 

--- a/molgenis-data-import/src/test/java/org/molgenis/data/importer/ImportRunTest.java
+++ b/molgenis-data-import/src/test/java/org/molgenis/data/importer/ImportRunTest.java
@@ -41,7 +41,7 @@ class ImportRunTest extends AbstractSystemEntityTest {
     assertTrue(importRun.getNotify());
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-index/src/main/java/org/molgenis/data/index/Impact.java
+++ b/molgenis-data-index/src/main/java/org/molgenis/data/index/Impact.java
@@ -7,8 +7,7 @@ import org.molgenis.data.EntityKey;
 
 /** Value object to store the impact of changes. */
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Impact {
   public abstract String getEntityTypeId();
 

--- a/molgenis-data-index/src/main/java/org/molgenis/data/index/IndexDependencyModel.java
+++ b/molgenis-data-index/src/main/java/org/molgenis/data/index/IndexDependencyModel.java
@@ -87,7 +87,7 @@ class IndexDependencyModel {
     return result.build();
   }
 
-  @SuppressWarnings("squid:S2259") // getExtends() doesn't return null here
+  @SuppressWarnings("java:S2259") // getExtends() doesn't return null here
   private boolean extendsFrom(EntityType candidateEntityType, String entityTypeId) {
     return candidateEntityType.getExtends() != null
         && entityTypeId.equals(candidateEntityType.getExtends().getId());

--- a/molgenis-data-index/src/test/java/org/molgenis/data/index/job/IndexJobExecutionTest.java
+++ b/molgenis-data-index/src/test/java/org/molgenis/data/index/job/IndexJobExecutionTest.java
@@ -47,7 +47,7 @@ public class IndexJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-index/src/test/java/org/molgenis/data/index/meta/IndexActionGroupTest.java
+++ b/molgenis-data-index/src/test/java/org/molgenis/data/index/meta/IndexActionGroupTest.java
@@ -18,7 +18,7 @@ public class IndexActionGroupTest extends AbstractSystemEntityTest {
   @Autowired IndexActionGroupMetadata metadata;
   @Autowired IndexActionGroupFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-index/src/test/java/org/molgenis/data/index/meta/IndexActionTest.java
+++ b/molgenis-data-index/src/test/java/org/molgenis/data/index/meta/IndexActionTest.java
@@ -35,7 +35,7 @@ public class IndexActionTest extends AbstractSystemEntityTest {
     return map;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-plugin/src/main/java/org/molgenis/data/plugin/model/PluginPermissionDeniedException.java
+++ b/molgenis-data-plugin/src/main/java/org/molgenis/data/plugin/model/PluginPermissionDeniedException.java
@@ -8,7 +8,7 @@ import org.molgenis.data.security.exception.PermissionDeniedException;
 /** Thrown when user has insufficient PluginPermission. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class PluginPermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DP01";
 

--- a/molgenis-data-plugin/src/main/java/org/molgenis/data/plugin/model/PluginPermissionDeniedException.java
+++ b/molgenis-data-plugin/src/main/java/org/molgenis/data/plugin/model/PluginPermissionDeniedException.java
@@ -8,7 +8,7 @@ import org.molgenis.data.security.exception.PermissionDeniedException;
 /** Thrown when user has insufficient PluginPermission. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class PluginPermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DP01";
 

--- a/molgenis-data-plugin/src/test/java/org/molgenis/data/plugin/model/PluginTest.java
+++ b/molgenis-data-plugin/src/test/java/org/molgenis/data/plugin/model/PluginTest.java
@@ -13,7 +13,7 @@ class PluginTest extends AbstractSystemEntityTest {
   @Autowired PluginMetadata metadata;
   @Autowired PluginFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/identifier/AttributeDescription.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/identifier/AttributeDescription.java
@@ -3,8 +3,7 @@ package org.molgenis.data.postgresql.identifier;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AttributeDescription {
   public abstract String getName();
 

--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/identifier/EntityTypeDescription.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/identifier/EntityTypeDescription.java
@@ -5,8 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EntityTypeDescription {
   public abstract String getId();
 

--- a/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/transaction/PostgreSqlTransactionManager.java
+++ b/molgenis-data-postgresql/src/main/java/org/molgenis/data/postgresql/transaction/PostgreSqlTransactionManager.java
@@ -30,7 +30,7 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
  *
  * <p>Each transaction is given a unique transaction id.
  */
-@SuppressWarnings("squid:S1948") // The transactionmanager will never be serialized
+@SuppressWarnings("java:S1948") // The transactionmanager will never be serialized
 public class PostgreSqlTransactionManager extends DataSourceTransactionManager
     implements TransactionManager {
   private static final long serialVersionUID = 1L;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/GroupService.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/GroupService.java
@@ -44,7 +44,7 @@ public class GroupService {
 
   public static final Set<String> DEFAULT_ROLES = ImmutableSet.of(MANAGER, EDITOR, VIEWER);
 
-  @SuppressWarnings("java:S00107")
+  @SuppressWarnings("java:S107")
   GroupService(
       PackageFactory packageFactory,
       DataService dataService,

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/GroupService.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/GroupService.java
@@ -44,7 +44,7 @@ public class GroupService {
 
   public static final Set<String> DEFAULT_ROLES = ImmutableSet.of(MANAGER, EDITOR, VIEWER);
 
-  @SuppressWarnings("squid:S00107")
+  @SuppressWarnings("java:S00107")
   GroupService(
       PackageFactory packageFactory,
       DataService dataService,

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/PasswordResetTokenMetadata.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/PasswordResetTokenMetadata.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class PasswordResetTokenMetadata extends SystemEntityType {
   private static final String SIMPLE_NAME = "PasswordResetToken";
 
-  @SuppressWarnings("squid:S2068") // this is not a hardcoded password
+  @SuppressWarnings("java:S2068") // this is not a hardcoded password
   public static final String PASSWORD_RESET_TOKEN =
       PACKAGE_SECURITY + PACKAGE_SEPARATOR + SIMPLE_NAME;
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/UserMetadata.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/auth/UserMetadata.java
@@ -25,7 +25,7 @@ public class UserMetadata extends SystemEntityType {
   public static final String USERNAME = "username";
   public static final String SUPERUSER = "superuser";
 
-  @SuppressWarnings("squid:S2068") // this is not a hardcoded password
+  @SuppressWarnings("java:S2068") // this is not a hardcoded password
   public static final String PASSWORD = "password_";
 
   public static final String TWO_FACTOR_AUTHENTICATION = "use2fa";
@@ -34,7 +34,7 @@ public class UserMetadata extends SystemEntityType {
   public static final String ACTIVATIONCODE = "activationCode";
   public static final String ACTIVE = "active";
 
-  @SuppressWarnings("squid:S2068") // this is not a hardcoded password
+  @SuppressWarnings("java:S2068") // this is not a hardcoded password
   public static final String CHANGE_PASSWORD = "changePassword";
 
   public static final String FIRSTNAME = "FirstName";

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclAlreadyExistsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclAlreadyExistsException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.DataAlreadyExistsException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class AclAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "DS35";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclAlreadyExistsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclAlreadyExistsException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.DataAlreadyExistsException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class AclAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "DS35";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclClassAlreadyExistsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclClassAlreadyExistsException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.DataAlreadyExistsException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class AclClassAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "DS29";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclClassAlreadyExistsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/AclClassAlreadyExistsException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.DataAlreadyExistsException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class AclClassAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "DS29";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/DuplicatePermissionException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/DuplicatePermissionException.java
@@ -7,7 +7,7 @@ import org.molgenis.data.DataAlreadyExistsException;
 import org.springframework.security.acls.model.ObjectIdentity;
 import org.springframework.security.acls.model.Sid;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class DuplicatePermissionException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "DS27";
   private final ObjectIdentity objectIdentity;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/DuplicatePermissionException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/DuplicatePermissionException.java
@@ -7,7 +7,7 @@ import org.molgenis.data.DataAlreadyExistsException;
 import org.springframework.security.acls.model.ObjectIdentity;
 import org.springframework.security.acls.model.Sid;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class DuplicatePermissionException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "DS27";
   private final ObjectIdentity objectIdentity;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityPermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityPermissionDeniedException.java
@@ -4,7 +4,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.security.EntityPermission;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class EntityPermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS06";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityPermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityPermissionDeniedException.java
@@ -4,7 +4,7 @@ import org.molgenis.data.Entity;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.security.EntityPermission;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class EntityPermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS06";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityTypePermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityTypePermissionDeniedException.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.security.EntityTypePermission;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class EntityTypePermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS04";
   private static final String ERROR_CODE_WITHOUT_LABEL = "DS04a";

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityTypePermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/EntityTypePermissionDeniedException.java
@@ -6,7 +6,7 @@ import java.util.Objects;
 import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.data.security.EntityTypePermission;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class EntityTypePermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS04";
   private static final String ERROR_CODE_WITHOUT_LABEL = "DS04a";

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupNameNotAvailableException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupNameNotAvailableException.java
@@ -2,7 +2,7 @@ package org.molgenis.data.security.exception;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class GroupNameNotAvailableException extends BadRequestException {
   private static final String ERROR_CODE = "DS16";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupNameNotAvailableException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupNameNotAvailableException.java
@@ -2,7 +2,7 @@ package org.molgenis.data.security.exception;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class GroupNameNotAvailableException extends BadRequestException {
   private static final String ERROR_CODE = "DS16";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupPermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupPermissionDeniedException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.security.auth.GroupPermission;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class GroupPermissionDeniedException extends PermissionDeniedException {
   public static final String ERROR_CODE = "DS10";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupPermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/GroupPermissionDeniedException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.security.auth.GroupPermission;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class GroupPermissionDeniedException extends PermissionDeniedException {
   public static final String ERROR_CODE = "DS10";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientInheritancePermissionsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientInheritancePermissionsException.java
@@ -1,6 +1,6 @@
 package org.molgenis.data.security.exception;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class InsufficientInheritancePermissionsException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS28";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientInheritancePermissionsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientInheritancePermissionsException.java
@@ -1,6 +1,6 @@
 package org.molgenis.data.security.exception;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class InsufficientInheritancePermissionsException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS28";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientPermissionsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientPermissionsException.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.security.acls.model.ObjectIdentity;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class InsufficientPermissionsException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS26";
   private final String identifier;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientPermissionsException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InsufficientPermissionsException.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.security.acls.model.ObjectIdentity;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class InsufficientPermissionsException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS26";
   private final String identifier;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InvalidTypeIdException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InvalidTypeIdException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class InvalidTypeIdException extends BadRequestException {
   private static final String ERROR_CODE = "DS22";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InvalidTypeIdException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/InvalidTypeIdException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class InvalidTypeIdException extends BadRequestException {
   private static final String ERROR_CODE = "DS22";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PackagePermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PackagePermissionDeniedException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.security.PackagePermission;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class PackagePermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS01";
   private final PackagePermission permission;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PackagePermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PackagePermissionDeniedException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.security.PackagePermission;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class PackagePermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS01";
   private final PackagePermission permission;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ParentPackagePermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ParentPackagePermissionDeniedException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.security.PackagePermission;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ParentPackagePermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS08";
   private final PackagePermission permission;
@@ -17,7 +17,7 @@ public class ParentPackagePermissionDeniedException extends PermissionDeniedExce
     this.pack = requireNonNull(pack);
   }
 
-  @SuppressWarnings("squid:S2259")
+  @SuppressWarnings("java:S2259")
   @Override
   public String getMessage() {
     return String.format(

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ParentPackagePermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ParentPackagePermissionDeniedException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.molgenis.data.meta.model.Package;
 import org.molgenis.data.security.PackagePermission;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ParentPackagePermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS08";
   private final PackagePermission permission;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PermissionNotSuitableException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PermissionNotSuitableException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class PermissionNotSuitableException extends BadRequestException {
   private static final String ERROR_CODE = "DS23";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PermissionNotSuitableException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/PermissionNotSuitableException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class PermissionNotSuitableException extends BadRequestException {
   private static final String ERROR_CODE = "DS23";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ReadPermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ReadPermissionDeniedException.java
@@ -2,7 +2,7 @@ package org.molgenis.data.security.exception;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ReadPermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS24";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ReadPermissionDeniedException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/ReadPermissionDeniedException.java
@@ -2,7 +2,7 @@ package org.molgenis.data.security.exception;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ReadPermissionDeniedException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS24";
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SidPermissionException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SidPermissionException.java
@@ -2,7 +2,7 @@ package org.molgenis.data.security.exception;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class SidPermissionException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS25";
   private final String sids;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SidPermissionException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SidPermissionException.java
@@ -2,7 +2,7 @@ package org.molgenis.data.security.exception;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class SidPermissionException extends PermissionDeniedException {
   private static final String ERROR_CODE = "DS25";
   private final String sids;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SystemRlsModificationException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SystemRlsModificationException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.ForbiddenException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class SystemRlsModificationException extends ForbiddenException {
   private static final String ERROR_CODE = "DS34";
   private final String entityType;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SystemRlsModificationException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/SystemRlsModificationException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.util.exception.ForbiddenException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class SystemRlsModificationException extends ForbiddenException {
   private static final String ERROR_CODE = "DS34";
   private final String entityType;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownAceException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownAceException.java
@@ -7,7 +7,7 @@ import org.molgenis.data.UnknownDataException;
 import org.springframework.security.acls.model.ObjectIdentity;
 import org.springframework.security.acls.model.Sid;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownAceException extends UnknownDataException {
   private static final String ERROR_CODE = "DS31";
   private final ObjectIdentity objectIdentity;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownAceException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownAceException.java
@@ -7,7 +7,7 @@ import org.molgenis.data.UnknownDataException;
 import org.springframework.security.acls.model.ObjectIdentity;
 import org.springframework.security.acls.model.Sid;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownAceException extends UnknownDataException {
   private static final String ERROR_CODE = "DS31";
   private final ObjectIdentity objectIdentity;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownRoleException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownRoleException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.UnknownDataException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownRoleException extends UnknownDataException {
   private static final String ERROR_CODE = "DS21";
   private final String name;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownRoleException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownRoleException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.UnknownDataException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownRoleException extends UnknownDataException {
   private static final String ERROR_CODE = "DS21";
   private final String name;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownTypeException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownTypeException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.UnknownDataException;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownTypeException extends UnknownDataException {
   private static final String ERROR_CODE = "DS33";
   private final String type;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownTypeException.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/exception/UnknownTypeException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.UnknownDataException;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownTypeException extends UnknownDataException {
   private static final String ERROR_CODE = "DS33";
   private final String type;

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledObject.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledObject.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_LabelledObject.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class LabelledObject {
   public abstract String getId();
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledObjectIdentity.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledObjectIdentity.java
@@ -6,8 +6,7 @@ import org.springframework.security.acls.model.ObjectIdentity;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_LabelledObjectIdentity.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class LabelledObjectIdentity implements ObjectIdentity {
 
   public abstract String getEntityTypeId();

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledPermission.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledPermission.java
@@ -9,8 +9,7 @@ import org.springframework.security.acls.model.Sid;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_LabelledPermission.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class LabelledPermission {
   @Nullable
   public abstract Sid getSid();

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledType.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/LabelledType.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_LabelledType.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class LabelledType {
   public abstract String getId();
 

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/Permission.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/model/Permission.java
@@ -8,8 +8,7 @@ import org.springframework.security.acls.model.Sid;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Permission.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Permission {
   public abstract ObjectIdentity getObjectIdentity();
 

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/GroupTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/GroupTest.java
@@ -12,7 +12,7 @@ class GroupTest extends AbstractSystemEntityTest {
   @Autowired GroupMetadata metadata;
   @Autowired GroupFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/MembershipInvitationTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/MembershipInvitationTest.java
@@ -28,7 +28,7 @@ public class MembershipInvitationTest extends AbstractSystemEntityTest {
     return map;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/PasswordResetTokenTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/PasswordResetTokenTest.java
@@ -20,7 +20,7 @@ public class PasswordResetTokenTest extends AbstractSystemEntityTest {
   @Autowired PasswordResetTokenMetadata metadata;
   @Autowired PasswordResetTokenFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/RoleMembershipTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/RoleMembershipTest.java
@@ -12,7 +12,7 @@ public class RoleMembershipTest extends AbstractSystemEntityTest {
   @Autowired RoleMembershipMetadata metadata;
   @Autowired RoleMembershipFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/RoleTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/RoleTest.java
@@ -12,7 +12,7 @@ public class RoleTest extends AbstractSystemEntityTest {
   @Autowired RoleMetadata metadata;
   @Autowired RoleFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/TokenTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/TokenTest.java
@@ -19,7 +19,7 @@ class TokenTest extends AbstractSystemEntityTest {
   @Autowired TokenMetadata metadata;
   @Autowired TokenFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/UserTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/auth/UserTest.java
@@ -12,7 +12,7 @@ public class UserTest extends AbstractSystemEntityTest {
   @Autowired UserMetadata metadata;
   @Autowired UserFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/QueryValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/QueryValidator.java
@@ -451,7 +451,7 @@ public class QueryValidator {
     return value.toString();
   }
 
-  @SuppressWarnings("squid:S2447") // Null should not be returned from a "Boolean" method
+  @SuppressWarnings("java:S2447") // Null should not be returned from a "Boolean" method
   @Nullable
   @CheckForNull
   private static Boolean convertBool(Attribute attr, Object value) {

--- a/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/NameValidator.java
+++ b/molgenis-data-validation/src/main/java/org/molgenis/data/validation/meta/NameValidator.java
@@ -7,7 +7,7 @@ import org.molgenis.data.MolgenisDataException;
 /** Validates if metadata is internally consistent and correct. */
 public class NameValidator {
   // some words are reserved for the RestAPI and default packages/entities/attributes, etc.
-  @SuppressWarnings("squid:S2386") // false positive: Mutable fields should not be "public static"
+  @SuppressWarnings("java:S2386") // false positive: Mutable fields should not be "public static"
   public static final Set<String> KEYWORDS =
       ImmutableSet.of("login", "logout", "csv", "base", "exist", "meta", "_idValue");
 

--- a/molgenis-data/src/main/java/org/molgenis/data/DataAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DataAlreadyExistsException.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
  *
  * @see EntityAlreadyExistsException
  */
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public abstract class DataAlreadyExistsException extends ErrorCodedDataAccessException {
   public DataAlreadyExistsException(String errorCode) {
     super(errorCode);

--- a/molgenis-data/src/main/java/org/molgenis/data/DataAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DataAlreadyExistsException.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
  *
  * @see EntityAlreadyExistsException
  */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public abstract class DataAlreadyExistsException extends ErrorCodedDataAccessException {
   public DataAlreadyExistsException(String errorCode) {
     super(errorCode);

--- a/molgenis-data/src/main/java/org/molgenis/data/DataConstraintViolationException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DataConstraintViolationException.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  * @see ValueReferencedException
  * @see ValueRequiredException
  */
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public abstract class DataConstraintViolationException extends ErrorCodedDataAccessException {
   protected DataConstraintViolationException(
       String errorCode, @Nullable @CheckForNull Throwable cause) {

--- a/molgenis-data/src/main/java/org/molgenis/data/DataConstraintViolationException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DataConstraintViolationException.java
@@ -18,7 +18,7 @@ import javax.annotation.Nullable;
  * @see ValueReferencedException
  * @see ValueRequiredException
  */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public abstract class DataConstraintViolationException extends ErrorCodedDataAccessException {
   protected DataConstraintViolationException(
       String errorCode, @Nullable @CheckForNull Throwable cause) {

--- a/molgenis-data/src/main/java/org/molgenis/data/DataConverter.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DataConverter.java
@@ -161,7 +161,7 @@ public class DataConverter {
    * @return true, false or null
    * @throws DataConversionException if conversion failed
    */
-  @SuppressWarnings("squid:S2447") // null is a valid return value
+  @SuppressWarnings("java:S2447") // null is a valid return value
   @Nullable
   @CheckForNull
   public static Boolean toBoolean(@Nullable @CheckForNull Object source) {

--- a/molgenis-data/src/main/java/org/molgenis/data/DuplicateValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DuplicateValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class DuplicateValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/DuplicateValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/DuplicateValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class DuplicateValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityAlreadyExistsException.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 public class EntityAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "D09";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityAlreadyExistsException.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 public class EntityAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "D09";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityKey.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityKey.java
@@ -5,8 +5,7 @@ import org.molgenis.data.meta.model.EntityType;
 
 /** Value object to store Entity name / Entity ID combinations for a single entity instance. */
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EntityKey {
   public abstract String getEntityTypeId();
 

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityStream.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityStream.java
@@ -144,7 +144,7 @@ public class EntityStream implements Stream<Entity> {
     return stream.sorted(comparator);
   }
 
-  @SuppressWarnings("squid:S3864") // "Stream.peek" should not be used
+  @SuppressWarnings("java:S3864") // "Stream.peek" should not be used
   @Override
   public Stream<Entity> peek(Consumer<? super Entity> action) {
     return stream.peek(action);

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityTypeReferencedException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityTypeReferencedException.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class EntityTypeReferencedException extends DataConstraintViolationException {
   private static final String ERROR_CODE = "D19";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/EntityTypeReferencedException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/EntityTypeReferencedException.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class EntityTypeReferencedException extends DataConstraintViolationException {
   private static final String ERROR_CODE = "D19";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ErrorCodedDataAccessException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ErrorCodedDataAccessException.java
@@ -10,7 +10,7 @@ import org.molgenis.util.i18n.MessageSourceHolder;
 import org.springframework.context.i18n.LocaleContextHolder;
 
 /** {@link org.springframework.dao.DataAccessException} with error code and without message. */
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public abstract class ErrorCodedDataAccessException
     extends org.springframework.dao.DataAccessException implements ErrorCoded {
   private final String errorCode;

--- a/molgenis-data/src/main/java/org/molgenis/data/ErrorCodedDataAccessException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ErrorCodedDataAccessException.java
@@ -10,7 +10,7 @@ import org.molgenis.util.i18n.MessageSourceHolder;
 import org.springframework.context.i18n.LocaleContextHolder;
 
 /** {@link org.springframework.dao.DataAccessException} with error code and without message. */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public abstract class ErrorCodedDataAccessException
     extends org.springframework.dao.DataAccessException implements ErrorCoded {
   private final String errorCode;

--- a/molgenis-data/src/main/java/org/molgenis/data/ExistingNullValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ExistingNullValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ExistingNullValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ExistingNullValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ExistingNullValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ExistingNullValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/InvalidValueTypeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/InvalidValueTypeException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class InvalidValueTypeException extends DataConstraintViolationException {
   private static final String ERROR_CODE = "D20";
   private final String value;

--- a/molgenis-data/src/main/java/org/molgenis/data/InvalidValueTypeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/InvalidValueTypeException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class InvalidValueTypeException extends DataConstraintViolationException {
   private static final String ERROR_CODE = "D20";
   private final String value;

--- a/molgenis-data/src/main/java/org/molgenis/data/ListValueAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ListValueAlreadyExistsException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ListValueAlreadyExistsException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ListValueAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ListValueAlreadyExistsException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ListValueAlreadyExistsException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ReadonlyValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ReadonlyValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ReadonlyValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ReadonlyValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ReadonlyValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ReadonlyValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/RepositoryAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/RepositoryAlreadyExistsException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 public class RepositoryAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "D10";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/RepositoryAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/RepositoryAlreadyExistsException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 public class RepositoryAlreadyExistsException extends DataAlreadyExistsException {
   private static final String ERROR_CODE = "D10";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/RepositoryNotCapableException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/RepositoryNotCapableException.java
@@ -10,7 +10,7 @@ import org.molgenis.util.exception.BadRequestException;
  * @see Repository
  * @see RepositoryCapability
  */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class RepositoryNotCapableException extends BadRequestException {
   private static final String ERROR_CODE = "D11";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/RepositoryNotCapableException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/RepositoryNotCapableException.java
@@ -10,7 +10,7 @@ import org.molgenis.util.exception.BadRequestException;
  * @see Repository
  * @see RepositoryCapability
  */
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class RepositoryNotCapableException extends BadRequestException {
   private static final String ERROR_CODE = "D11";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownAttributeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownAttributeException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.meta.model.EntityType;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownAttributeException extends UnknownDataException {
   private static final String ERROR_CODE = "D04";
   private final transient EntityType entityType;

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownAttributeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownAttributeException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.meta.model.EntityType;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownAttributeException extends UnknownDataException {
   private static final String ERROR_CODE = "D04";
   private final transient EntityType entityType;

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownDataException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownDataException.java
@@ -11,7 +11,7 @@ package org.molgenis.data;
  * @see UnknownPluginException
  * @see UnknownSortAttributeException
  */
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public abstract class UnknownDataException extends ErrorCodedDataAccessException {
   protected UnknownDataException(String errorCode) {
     super(errorCode);

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownDataException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownDataException.java
@@ -11,7 +11,7 @@ package org.molgenis.data;
  * @see UnknownPluginException
  * @see UnknownSortAttributeException
  */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public abstract class UnknownDataException extends ErrorCodedDataAccessException {
   protected UnknownDataException(String errorCode) {
     super(errorCode);

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityException.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 public class UnknownEntityException extends UnknownDataException {
   private static final String ERROR_CODE = "D02";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityException.java
@@ -8,7 +8,7 @@ import javax.annotation.Nullable;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 public class UnknownEntityException extends UnknownDataException {
   private static final String ERROR_CODE = "D02";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityTypeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityTypeException.java
@@ -2,7 +2,7 @@ package org.molgenis.data;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownEntityTypeException extends UnknownDataException {
   private static final String ERROR_CODE = "D01";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityTypeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownEntityTypeException.java
@@ -2,7 +2,7 @@ package org.molgenis.data;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownEntityTypeException extends UnknownDataException {
   private static final String ERROR_CODE = "D01";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownEnumValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownEnumValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownEnumValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownEnumValueException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownEnumValueException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownEnumValueException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownPackageException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownPackageException.java
@@ -2,7 +2,7 @@ package org.molgenis.data;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 public class UnknownPackageException extends UnknownDataException {
   private static final String ERROR_CODE = "D13";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownPackageException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownPackageException.java
@@ -2,7 +2,7 @@ package org.molgenis.data;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 public class UnknownPackageException extends UnknownDataException {
   private static final String ERROR_CODE = "D13";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownPluginException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownPluginException.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 /** Thrown when a Plugin is requested that doesn't exist */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownPluginException extends UnknownDataException {
   private static final String ERROR_CODE = "D07";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownPluginException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownPluginException.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 /** Thrown when a Plugin is requested that doesn't exist */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownPluginException extends UnknownDataException {
   private static final String ERROR_CODE = "D07";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryCollectionException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryCollectionException.java
@@ -2,7 +2,7 @@ package org.molgenis.data;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownRepositoryCollectionException extends UnknownDataException {
   private static final String ERROR_CODE = "D06";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryCollectionException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryCollectionException.java
@@ -2,7 +2,7 @@ package org.molgenis.data;
 
 import static java.util.Objects.requireNonNull;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownRepositoryCollectionException extends UnknownDataException {
   private static final String ERROR_CODE = "D06";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryException.java
@@ -3,7 +3,7 @@ package org.molgenis.data;
 import static java.util.Objects.requireNonNull;
 
 /** @see Repository */
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class UnknownRepositoryException extends UnknownDataException {
   private static final String ERROR_CODE = "D05";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownRepositoryException.java
@@ -3,7 +3,7 @@ package org.molgenis.data;
 import static java.util.Objects.requireNonNull;
 
 /** @see Repository */
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class UnknownRepositoryException extends UnknownDataException {
   private static final String ERROR_CODE = "D05";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownSortAttributeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownSortAttributeException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.meta.model.EntityType;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownSortAttributeException extends UnknownDataException {
   private static final String ERROR_CODE = "D27";
   private final transient EntityType entityType;

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownSortAttributeException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownSortAttributeException.java
@@ -4,7 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.meta.model.EntityType;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownSortAttributeException extends UnknownDataException {
   private static final String ERROR_CODE = "D27";
   private final transient EntityType entityType;

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownTagException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownTagException.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 /** Thrown when a Tag is requested that doesn't exist */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownTagException extends UnknownDataException {
   private static final String ERROR_CODE = "D14";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownTagException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownTagException.java
@@ -6,7 +6,7 @@ import static java.util.Objects.requireNonNull;
 /** Thrown when a Tag is requested that doesn't exist */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownTagException extends UnknownDataException {
   private static final String ERROR_CODE = "D14";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownValueReferenceException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownValueReferenceException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class UnknownValueReferenceException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/UnknownValueReferenceException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/UnknownValueReferenceException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class UnknownValueReferenceException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueAlreadyExistsException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ValueAlreadyExistsException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueAlreadyExistsException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueAlreadyExistsException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ValueAlreadyExistsException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueLengthExceededException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueLengthExceededException.java
@@ -3,7 +3,7 @@ package org.molgenis.data;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ValueLengthExceededException extends DataConstraintViolationException {
   private static final String ERROR_CODE = "D17";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueLengthExceededException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueLengthExceededException.java
@@ -3,7 +3,7 @@ package org.molgenis.data;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ValueLengthExceededException extends DataConstraintViolationException {
   private static final String ERROR_CODE = "D17";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueReferencedException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueReferencedException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ValueReferencedException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueReferencedException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueReferencedException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ValueReferencedException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueRequiredException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueRequiredException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public class ValueRequiredException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/ValueRequiredException.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/ValueRequiredException.java
@@ -6,7 +6,7 @@ import static org.springframework.context.i18n.LocaleContextHolder.getLocale;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public class ValueRequiredException extends DataConstraintViolationException {
   private static final String UNKNOWN_PLACEHOLDER = "unknown.placeholder";
 

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/Package.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/Package.java
@@ -178,7 +178,7 @@ public class Package extends StaticEntity {
    *
    * @return root package of this package or <tt>null</tt>
    */
-  @SuppressWarnings("squid:S2259") // potential multi-threading NPE
+  @SuppressWarnings("java:S2259") // potential multi-threading NPE
   public Package getRootPackage() {
     Package aPackage = this;
     while (aPackage.getParent() != null) {
@@ -203,7 +203,7 @@ public class Package extends StaticEntity {
    * }
    * </code></pre>
    */
-  @SuppressWarnings("squid:S2259") // potential multi-threading NPEs
+  @SuppressWarnings("java:S2259") // potential multi-threading NPEs
   @Override
   public boolean equals(Object o) {
     if (o == this) {

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/Tag.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/Tag.java
@@ -108,7 +108,7 @@ public class Tag extends StaticEntity {
    * }
    * </code></pre>
    */
-  @SuppressWarnings("squid:S2259") // potential multi-threading NPEs
+  @SuppressWarnings("java:S2259") // potential multi-threading NPEs
   @Override
   public boolean equals(Object o) {
     if (o == this) {

--- a/molgenis-data/src/main/java/org/molgenis/data/semantic/Relation.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/semantic/Relation.java
@@ -1,6 +1,6 @@
 package org.molgenis.data.semantic;
 
-@SuppressWarnings("squid:S00115") // Constant names should comply with a naming convention
+@SuppressWarnings("java:S00115") // Constant names should comply with a naming convention
 public enum Relation {
   instanceOf("http://molgenis.org/biobankconnect/instanceOf"),
   link("http://molgenis.org/biobankconnect/link"),

--- a/molgenis-data/src/main/java/org/molgenis/data/semantic/Relation.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/semantic/Relation.java
@@ -1,6 +1,6 @@
 package org.molgenis.data.semantic;
 
-@SuppressWarnings("java:S00115") // Constant names should comply with a naming convention
+@SuppressWarnings("java:S115") // Constant names should comply with a naming convention
 public enum Relation {
   instanceOf("http://molgenis.org/biobankconnect/instanceOf"),
   link("http://molgenis.org/biobankconnect/link"),

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/meta/DecoratorConfigurationTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/meta/DecoratorConfigurationTest.java
@@ -20,7 +20,7 @@ public class DecoratorConfigurationTest extends AbstractSystemEntityTest {
   @Autowired DecoratorConfigurationMetadata metadata;
   @Autowired DecoratorConfigurationFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/meta/DecoratorParametersTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/meta/DecoratorParametersTest.java
@@ -19,7 +19,7 @@ public class DecoratorParametersTest extends AbstractSystemEntityTest {
   @Autowired DecoratorParametersMetadata metadata;
   @Autowired DecoratorParametersFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data/src/test/java/org/molgenis/data/decorator/meta/DynamicDecoratorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/decorator/meta/DynamicDecoratorTest.java
@@ -18,7 +18,7 @@ public class DynamicDecoratorTest extends AbstractSystemEntityTest {
   @Autowired DynamicDecoratorMetadata metadata;
   @Autowired DynamicDecoratorFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/AttributeTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/AttributeTest.java
@@ -70,7 +70,7 @@ class AttributeTest extends AbstractSystemEntityTest {
     return map;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/EntityTypeTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/EntityTypeTest.java
@@ -48,7 +48,7 @@ class EntityTypeTest extends AbstractSystemEntityTest {
   @Autowired EntityTypeMetadata metadata;
   @Autowired EntityTypeFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/PackageTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/PackageTest.java
@@ -24,7 +24,7 @@ class PackageTest extends AbstractSystemEntityTest {
   @Autowired PackageMetadata metadata;
   @Autowired PackageFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-data/src/test/java/org/molgenis/data/meta/model/TagTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/meta/model/TagTest.java
@@ -19,7 +19,7 @@ public class TagTest extends AbstractSystemEntityTest {
   @Autowired TagMetadata metadata;
   @Autowired TagFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/NavigatorLink.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/NavigatorLink.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_NavigatorLink.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class NavigatorLink {
   public abstract String getHref();
 

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/Collection.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/Collection.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Collection.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Collection {
   public abstract String getCollectionId();
 

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/ExportValidationResponse.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/ExportValidationResponse.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ExportValidationResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ExportValidationResponse {
   public abstract boolean isValid();
 

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/NegotiatorController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/NegotiatorController.java
@@ -225,7 +225,7 @@ public class NegotiatorController extends PluginController {
         .collect(Collectors.toList());
   }
 
-  @SuppressWarnings("squid:S1125") // boolean literal isn't redundant here
+  @SuppressWarnings("java:S1125") // boolean literal isn't redundant here
   private boolean evaluateExpressionOnEntity(String expression, Entity entity) {
     return expression == null
         ? true

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/NegotiatorQuery.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/NegotiatorQuery.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_NegotiatorQuery.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class NegotiatorQuery {
   public abstract String getURL();
 

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/NegotiatorRequest.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/NegotiatorRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_NegotiatorRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class NegotiatorRequest {
   public abstract String getURL();
 

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorConfigMetadata.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorConfigMetadata.java
@@ -14,7 +14,7 @@ class NegotiatorConfigMetadata extends SystemEntityType {
   public static final String NEGOTIATOR_URL = "negotiator_url";
   public static final String USERNAME = "username";
 
-  @java.lang.SuppressWarnings("squid:S2068")
+  @java.lang.SuppressWarnings("java:S2068")
   public static final String PASSWORD = "password";
 
   private static final String ID = "id";

--- a/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorConfigTest.java
+++ b/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorConfigTest.java
@@ -18,7 +18,7 @@ public class NegotiatorConfigTest extends AbstractSystemEntityTest {
   @Autowired NegotiatorConfigMetadata metadata;
   @Autowired NegotiatorConfigFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorEntityConfigTest.java
+++ b/molgenis-dataexplorer/src/test/java/org/molgenis/dataexplorer/negotiator/config/NegotiatorEntityConfigTest.java
@@ -19,7 +19,7 @@ public class NegotiatorEntityConfigTest extends AbstractSystemEntityTest {
   @Autowired NegotiatorEntityConfigMetadata metadata;
   @Autowired NegotiatorEntityConfigFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-file-ingester/src/main/java/org/molgenis/file/ingest/execution/FileIngestConfig.java
+++ b/molgenis-file-ingester/src/main/java/org/molgenis/file/ingest/execution/FileIngestConfig.java
@@ -60,7 +60,7 @@ public class FileIngestConfig {
     };
   }
 
-  @SuppressWarnings("squid:S1192") // String literals should not be duplicated
+  @SuppressWarnings("java:S1192") // String literals should not be duplicated
   @Lazy
   @Bean
   public ScheduledJobType fileIngestJobType() {

--- a/molgenis-file-ingester/src/test/java/org/molgenis/file/ingest/meta/FileIngestJobExecutionTest.java
+++ b/molgenis-file-ingester/src/test/java/org/molgenis/file/ingest/meta/FileIngestJobExecutionTest.java
@@ -47,7 +47,7 @@ public class FileIngestJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/GenomeBrowserTrack.java
+++ b/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/GenomeBrowserTrack.java
@@ -15,11 +15,10 @@ import org.molgenis.genomebrowser.meta.GenomeBrowserSettings;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GenomeBrowserTrack {
 
-  @SuppressWarnings("squid:S00107") // Methods should not have too many parameters
+  @SuppressWarnings("java:S00107") // Methods should not have too many parameters
   public static GenomeBrowserTrack create(
       String id,
       String label,

--- a/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/GenomeBrowserTrack.java
+++ b/molgenis-genomebrowser/src/main/java/org/molgenis/genomebrowser/GenomeBrowserTrack.java
@@ -18,7 +18,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GenomeBrowserTrack {
 
-  @SuppressWarnings("java:S00107") // Methods should not have too many parameters
+  @SuppressWarnings("java:S107") // Methods should not have too many parameters
   public static GenomeBrowserTrack create(
       String id,
       String label,

--- a/molgenis-genomebrowser/src/test/java/org/molgenis/genomebrowser/meta/GenomeBrowserAttributesTest.java
+++ b/molgenis-genomebrowser/src/test/java/org/molgenis/genomebrowser/meta/GenomeBrowserAttributesTest.java
@@ -18,7 +18,7 @@ public class GenomeBrowserAttributesTest extends AbstractSystemEntityTest {
   @Autowired GenomeBrowserAttributesMetadata metadata;
   @Autowired GenomeBrowserAttributesFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-genomebrowser/src/test/java/org/molgenis/genomebrowser/meta/GenomeBrowserSettingsTest.java
+++ b/molgenis-genomebrowser/src/test/java/org/molgenis/genomebrowser/meta/GenomeBrowserSettingsTest.java
@@ -19,7 +19,7 @@ public class GenomeBrowserSettingsTest extends AbstractSystemEntityTest {
   @Autowired GenomeBrowserSettingsMetadata metadata;
   @Autowired GenomeBrowserSettingsFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/JobExecutionContext.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/JobExecutionContext.java
@@ -5,8 +5,7 @@ import java.util.Locale;
 import org.springframework.security.core.Authentication;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class JobExecutionContext {
   abstract Authentication getAuthentication();
 

--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/ProgressImpl.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/ProgressImpl.java
@@ -96,7 +96,7 @@ class ProgressImpl implements Progress {
   }
 
   @SuppressWarnings(
-      "squid:S2629") // "Preconditions" and logging arguments should not require evaluation
+      "java:S2629") // "Preconditions" and logging arguments should not require evaluation
   @Override
   public void failed(String message, @Nullable @CheckForNull Throwable throwable) {
     JOB_EXECUTION_LOG.error("Failed. " + message, throwable);

--- a/molgenis-jobs/src/test/java/org/molgenis/jobs/model/ScheduledJobTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/jobs/model/ScheduledJobTest.java
@@ -19,7 +19,7 @@ public class ScheduledJobTest extends AbstractSystemEntityTest {
   @Autowired ScheduledJobMetadata metadata;
   @Autowired ScheduledJobFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-jobs/src/test/java/org/molgenis/jobs/model/ScheduledJobTypeTest.java
+++ b/molgenis-jobs/src/test/java/org/molgenis/jobs/model/ScheduledJobTypeTest.java
@@ -18,7 +18,7 @@ public class ScheduledJobTypeTest extends AbstractSystemEntityTest {
   @Autowired ScheduledJobTypeMetadata metadata;
   @Autowired ScheduledJobTypeFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorAttribute.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorAttribute.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorAttribute.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorAttribute {
   public abstract String getId();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorAttributeIdentifier.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorAttributeIdentifier.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorAttributeIdentifier.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorAttributeIdentifier {
   public abstract String getId();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorAttributeResponse.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorAttributeResponse.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorAttributeResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorAttributeResponse {
   abstract EditorAttribute getAttribute();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityType.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityType.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorEntityType.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorEntityType {
   public abstract String getId();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityTypeIdentifier.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityTypeIdentifier.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorEntityTypeIdentifier.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorEntityTypeIdentifier {
   public abstract String getId();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityTypeParent.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityTypeParent.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorEntityTypeParent.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorEntityTypeParent {
   public abstract String getId();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityTypeResponse.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorEntityTypeResponse.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorEntityTypeResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorEntityTypeResponse {
   abstract EditorEntityType getEntityType();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorOrder.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorOrder.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorOrder.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorOrder {
   public abstract String getAttributeName();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorPackageIdentifier.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorPackageIdentifier.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorPackageIdentifier.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorPackageIdentifier {
   public abstract String getId();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorSort.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorSort.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorSort.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorSort {
   public abstract List<EditorOrder> getOrders();
 

--- a/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorTagIdentifier.java
+++ b/molgenis-metadata-manager/src/main/java/org/molgenis/metadata/manager/model/EditorTagIdentifier.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EditorTagIdentifier.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EditorTagIdentifier {
   public abstract String getId();
 

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/CopyResourcesRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/CopyResourcesRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_CopyResourcesRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class CopyResourcesRequest {
   public abstract List<ResourceIdentifier> getResources();
 

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/DeleteResourcesRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/DeleteResourcesRequest.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_DeleteResourcesRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class DeleteResourcesRequest {
   @NotEmpty
   public abstract List<ResourceIdentifier> getResources();

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/DownloadResourcesRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/DownloadResourcesRequest.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_DownloadResourcesRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class DownloadResourcesRequest {
   @NotEmpty
   public abstract List<ResourceIdentifier> getResources();

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/Folder.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/Folder.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Folder.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Folder {
   public abstract String getId();
 

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/GetResourcesResponse.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/GetResourcesResponse.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_GetResourcesResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GetResourcesResponse {
   /** @return <tt>null</tt> folder implies the root package */
   @Nullable

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/MoveResourcesRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/MoveResourcesRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_MoveResourcesRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class MoveResourcesRequest {
   public abstract List<ResourceIdentifier> getResources();
 

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/SearchResourcesResponse.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/SearchResourcesResponse.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_SearchResourcesResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class SearchResourcesResponse {
   public abstract List<Resource> getResources();
 

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/UpdateResourceRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/UpdateResourceRequest.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_UpdateResourceRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class UpdateResourceRequest {
   public abstract Resource getResource();
 

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/CopyResourceRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/CopyResourceRequest.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_CopyResourceRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class CopyResourceRequest {
 
   public abstract List<ResourceIdentifier> getResources();

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/CopyFailedException.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/CopyFailedException.java
@@ -4,7 +4,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public abstract class CopyFailedException extends CodedRuntimeException {
 
   public CopyFailedException(String errorCode) {

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/CopyFailedException.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/CopyFailedException.java
@@ -4,7 +4,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public abstract class CopyFailedException extends CodedRuntimeException {
 
   public CopyFailedException(String errorCode) {

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/RecursiveCopyException.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/RecursiveCopyException.java
@@ -3,7 +3,7 @@ package org.molgenis.navigator.copy.exception;
 /** Exception that's thrown when a Package is copied into itself or its children. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class RecursiveCopyException extends CopyFailedException {
 
   private static final String ERROR_CODE = "NAV02";

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/RecursiveCopyException.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/RecursiveCopyException.java
@@ -3,7 +3,7 @@ package org.molgenis.navigator.copy.exception;
 /** Exception that's thrown when a Package is copied into itself or its children. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class RecursiveCopyException extends CopyFailedException {
 
   private static final String ERROR_CODE = "NAV02";

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/UnknownCopyFailedException.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/UnknownCopyFailedException.java
@@ -2,7 +2,7 @@ package org.molgenis.navigator.copy.exception;
 
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class UnknownCopyFailedException extends CopyFailedException {
 
   private static final String ERROR_CODE = "NAV03";

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/UnknownCopyFailedException.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/exception/UnknownCopyFailedException.java
@@ -2,7 +2,7 @@ package org.molgenis.navigator.copy.exception;
 
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class UnknownCopyFailedException extends CopyFailedException {
 
   private static final String ERROR_CODE = "NAV03";

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/service/CopyServiceImpl.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/service/CopyServiceImpl.java
@@ -48,7 +48,7 @@ public class CopyServiceImpl implements CopyService {
 
   @Override
   @SuppressWarnings(
-      "squid:S1193") // Exception types should not be tested using "instanceof" in catch blocks
+      "java:S1193") // Exception types should not be tested using "instanceof" in catch blocks
   @Transactional(isolation = Isolation.SERIALIZABLE)
   public Void copy(
       List<ResourceIdentifier> resources,

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/service/RelationTransformer.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/copy/service/RelationTransformer.java
@@ -106,7 +106,7 @@ class RelationTransformer {
         .forEach(attr -> transformMappedBy(attr, newAttributes));
   }
 
-  @SuppressWarnings("squid:S2259")
+  @SuppressWarnings("java:S2259")
   private static void transformMappedBy(Attribute attribute, Map<String, Attribute> newAttributes) {
     if (attribute.isMappedBy()) {
       @SuppressWarnings("ConstantConditions")

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/download/DownloadResourcesRequest.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/download/DownloadResourcesRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_DownloadResourcesRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class DownloadResourcesRequest {
 
   public abstract List<Resource> getResources();

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/model/Resource.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/model/Resource.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Resource.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Resource {
 
   public abstract ResourceType getType();

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/model/ResourceIdentifier.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/model/ResourceIdentifier.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ResourceIdentifier.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ResourceIdentifier {
 
   public abstract ResourceType getType();

--- a/molgenis-navigator/src/main/java/org/molgenis/navigator/util/ResourceCollection.java
+++ b/molgenis-navigator/src/main/java/org/molgenis/navigator/util/ResourceCollection.java
@@ -10,8 +10,7 @@ import org.molgenis.util.AutoGson;
 /** Collection of typed resources. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ResourceCollection.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ResourceCollection {
 
   @NotNull

--- a/molgenis-navigator/src/test/java/org/molgenis/navigator/copy/job/ResourceCopyJobExecutionTest.java
+++ b/molgenis-navigator/src/test/java/org/molgenis/navigator/copy/job/ResourceCopyJobExecutionTest.java
@@ -59,7 +59,7 @@ public class ResourceCopyJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-navigator/src/test/java/org/molgenis/navigator/delete/job/ResourceDeleteJobExecutionTest.java
+++ b/molgenis-navigator/src/test/java/org/molgenis/navigator/delete/job/ResourceDeleteJobExecutionTest.java
@@ -58,7 +58,7 @@ public class ResourceDeleteJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-navigator/src/test/java/org/molgenis/navigator/download/job/ResourceDownloadJobExecutionTest.java
+++ b/molgenis-navigator/src/test/java/org/molgenis/navigator/download/job/ResourceDownloadJobExecutionTest.java
@@ -58,7 +58,7 @@ public class ResourceDownloadJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/model/Column.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/model/Column.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Column.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Column {
   public abstract String getName();
 

--- a/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/model/DataCollection.java
+++ b/molgenis-one-click-importer/src/main/java/org/molgenis/oneclickimporter/model/DataCollection.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_DataCollection.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class DataCollection {
   public abstract String getName();
 

--- a/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/job/OneClickImportJobExecutionTest.java
+++ b/molgenis-one-click-importer/src/test/java/org/molgenis/oneclickimporter/job/OneClickImportJobExecutionTest.java
@@ -47,7 +47,7 @@ public class OneClickImportJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/model/Ontology.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/model/Ontology.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Ontology.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Ontology {
   public abstract String getId();
 

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/model/OntologyTerm.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/model/OntologyTerm.java
@@ -13,8 +13,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_OntologyTerm.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class OntologyTerm {
   public abstract String getIRI();
 

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermDynamicAnnotationTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermDynamicAnnotationTest.java
@@ -21,7 +21,7 @@ public class OntologyTermDynamicAnnotationTest extends AbstractSystemEntityTest 
   @Autowired OntologyTermDynamicAnnotationMetadata metadata;
   @Autowired OntologyTermDynamicAnnotationFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermNodePathTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermNodePathTest.java
@@ -21,7 +21,7 @@ public class OntologyTermNodePathTest extends AbstractSystemEntityTest {
   @Autowired OntologyTermNodePathMetadata metadata;
   @Autowired OntologyTermNodePathFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermSynonymTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermSynonymTest.java
@@ -21,7 +21,7 @@ public class OntologyTermSynonymTest extends AbstractSystemEntityTest {
   @Autowired OntologyTermSynonymMetadata metadata;
   @Autowired OntologyTermSynonymFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTermTest.java
@@ -21,7 +21,7 @@ public class OntologyTermTest extends AbstractSystemEntityTest {
   @Autowired OntologyTermMetadata metadata;
   @Autowired OntologyTermFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/meta/OntologyTest.java
@@ -21,7 +21,7 @@ public class OntologyTest extends AbstractSystemEntityTest {
   @Autowired OntologyMetadata metadata;
   @Autowired OntologyFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-ontology/src/test/java/org/molgenis/ontology/sorta/job/SortaJobExecutionTest.java
+++ b/molgenis-ontology/src/test/java/org/molgenis/ontology/sorta/job/SortaJobExecutionTest.java
@@ -48,7 +48,7 @@ public class SortaJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-questionnaires/src/main/java/org/molgenis/questionnaires/response/QuestionnaireResponse.java
+++ b/molgenis-questionnaires/src/main/java/org/molgenis/questionnaires/response/QuestionnaireResponse.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_QuestionnaireResponse.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class QuestionnaireResponse {
   public abstract String getId();
 

--- a/molgenis-scripts-core/src/test/java/org/molgenis/script/core/ScriptParameterTest.java
+++ b/molgenis-scripts-core/src/test/java/org/molgenis/script/core/ScriptParameterTest.java
@@ -12,7 +12,7 @@ public class ScriptParameterTest extends AbstractSystemEntityTest {
   @Autowired ScriptParameterMetadata metadata;
   @Autowired ScriptParameterFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-scripts-core/src/test/java/org/molgenis/script/core/ScriptTest.java
+++ b/molgenis-scripts-core/src/test/java/org/molgenis/script/core/ScriptTest.java
@@ -30,7 +30,7 @@ public class ScriptTest extends AbstractSystemEntityTest {
     return map;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-scripts-core/src/test/java/org/molgenis/script/core/ScriptTypeTest.java
+++ b/molgenis-scripts-core/src/test/java/org/molgenis/script/core/ScriptTypeTest.java
@@ -12,7 +12,7 @@ public class ScriptTypeTest extends AbstractSystemEntityTest {
   @Autowired ScriptTypeMetadata metadata;
   @Autowired ScriptTypeFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-scripts/src/main/java/org/molgenis/script/ScriptRunnerController.java
+++ b/molgenis-scripts/src/main/java/org/molgenis/script/ScriptRunnerController.java
@@ -63,7 +63,7 @@ public class ScriptRunnerController {
    * @param parameters parameter values for the script
    * @throws IOException if an input or output exception occurs when redirecting
    */
-  @SuppressWarnings("squid:S3752") // backwards compatability: multiple methods required
+  @SuppressWarnings("java:S3752") // backwards compatability: multiple methods required
   @RequestMapping(
       method = {RequestMethod.GET, RequestMethod.POST},
       value = "/scripts/{name}/start")
@@ -77,7 +77,7 @@ public class ScriptRunnerController {
     response.sendRedirect(jobsController.createJobExecutionViewHref(scriptJobExecutionHref, 1000));
   }
 
-  @SuppressWarnings("squid:S3752") // backwards compatability: multiple methods required
+  @SuppressWarnings("java:S3752") // backwards compatability: multiple methods required
   @RequestMapping(
       method = {RequestMethod.GET, RequestMethod.POST},
       value = "/scripts/{name}/submit",
@@ -107,7 +107,7 @@ public class ScriptRunnerController {
    * @throws ScriptException if the script name is unknown or one of the script parameters is
    *     missing
    */
-  @SuppressWarnings("squid:S3752") // backwards compatability: multiple methods required
+  @SuppressWarnings("java:S3752") // backwards compatability: multiple methods required
   @RequestMapping(
       method = {RequestMethod.GET, RequestMethod.POST},
       value = "/scripts/{name}/run")

--- a/molgenis-scripts/src/test/java/org/molgenis/script/ScriptJobExecutionTest.java
+++ b/molgenis-scripts/src/test/java/org/molgenis/script/ScriptJobExecutionTest.java
@@ -47,7 +47,7 @@ public class ScriptJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/model/AttributeResult.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/model/AttributeResult.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AttributeResult.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AttributeResult implements Described {
   public abstract String getDataType();
 

--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/model/EntityTypeResult.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/model/EntityTypeResult.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_EntityTypeResult.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EntityTypeResult implements Described {
   public abstract String getId();
 

--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/model/PackageResult.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/model/PackageResult.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_PackageResult.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PackageResult implements Described {
   public abstract String getId();
 

--- a/molgenis-searchall/src/main/java/org/molgenis/searchall/model/Result.java
+++ b/molgenis-searchall/src/main/java/org/molgenis/searchall/model/Result.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Result.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Result {
   public abstract ImmutableList<EntityTypeResult> getEntityTypes();
 

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/model/GroupValue.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/model/GroupValue.java
@@ -6,8 +6,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GroupValue {
   public abstract String getName();
 

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/model/PackageValue.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/model/PackageValue.java
@@ -5,8 +5,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class PackageValue {
   public abstract String getName();
 

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/model/RoleValue.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/model/RoleValue.java
@@ -5,8 +5,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class RoleValue {
   public abstract String getName();
 

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/RunAsSystemAspect.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/RunAsSystemAspect.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class RunAsSystemAspect {
-  @SuppressWarnings("squid:S00112") // generic exceptions should never be thrown
+  @SuppressWarnings("java:S00112") // generic exceptions should never be thrown
   @Around("@annotation(RunAsSystem)")
   public Object aroundAdvice(ProceedingJoinPoint joinPoint) throws Throwable {
     return runAsSystem((RunnableAsSystem<Object, Throwable>) joinPoint::proceed);

--- a/molgenis-security/src/main/java/org/molgenis/security/account/AccountController.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/AccountController.java
@@ -46,10 +46,10 @@ public class AccountController {
 
   public static final String URI = "/account";
 
-  @SuppressWarnings("squid:S2068") // this is not a hardcoded password
+  @SuppressWarnings("java:S2068") // this is not a hardcoded password
   private static final String CHANGE_PASSWORD_RELATIVE_URI = "/password/change";
 
-  @SuppressWarnings("squid:S2068") // this is not a hardcoded password
+  @SuppressWarnings("java:S2068") // this is not a hardcoded password
   public static final String CHANGE_PASSWORD_URI = URI + CHANGE_PASSWORD_RELATIVE_URI;
 
   static final String REGISTRATION_SUCCESS_MESSAGE_USER =

--- a/molgenis-security/src/main/java/org/molgenis/security/account/ExpiredPasswordResetTokenException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/ExpiredPasswordResetTokenException.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import org.molgenis.data.security.auth.PasswordResetToken;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 class ExpiredPasswordResetTokenException extends BadRequestException {
   private static final String ERROR_CODE = "SEC02";
   private final String id;

--- a/molgenis-security/src/main/java/org/molgenis/security/account/ExpiredPasswordResetTokenException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/ExpiredPasswordResetTokenException.java
@@ -6,7 +6,7 @@ import java.time.Instant;
 import org.molgenis.data.security.auth.PasswordResetToken;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 class ExpiredPasswordResetTokenException extends BadRequestException {
   private static final String ERROR_CODE = "SEC02";
   private final String id;

--- a/molgenis-security/src/main/java/org/molgenis/security/account/InvalidPasswordResetTokenException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/InvalidPasswordResetTokenException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.molgenis.data.security.auth.PasswordResetToken;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 class InvalidPasswordResetTokenException extends BadRequestException {
   private static final String ERROR_CODE = "SEC03";
   private final String id;

--- a/molgenis-security/src/main/java/org/molgenis/security/account/InvalidPasswordResetTokenException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/InvalidPasswordResetTokenException.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import org.molgenis.data.security.auth.PasswordResetToken;
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 class InvalidPasswordResetTokenException extends BadRequestException {
   private static final String ERROR_CODE = "SEC03";
   private final String id;

--- a/molgenis-security/src/main/java/org/molgenis/security/account/PasswordResetTokenCreationException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/PasswordResetTokenCreationException.java
@@ -2,7 +2,7 @@ package org.molgenis.security.account;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 class PasswordResetTokenCreationException extends BadRequestException {
   private static final String ERROR_CODE = "SEC01";
 

--- a/molgenis-security/src/main/java/org/molgenis/security/account/PasswordResetTokenCreationException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/PasswordResetTokenCreationException.java
@@ -2,7 +2,7 @@ package org.molgenis.security.account;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 class PasswordResetTokenCreationException extends BadRequestException {
   private static final String ERROR_CODE = "SEC01";
 

--- a/molgenis-security/src/main/java/org/molgenis/security/account/UnknownPasswordResetTokenException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/UnknownPasswordResetTokenException.java
@@ -2,7 +2,7 @@ package org.molgenis.security.account;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"java:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:S110"})
 class UnknownPasswordResetTokenException extends BadRequestException {
   private static final String ERROR_CODE = "SEC04";
 

--- a/molgenis-security/src/main/java/org/molgenis/security/account/UnknownPasswordResetTokenException.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/account/UnknownPasswordResetTokenException.java
@@ -2,7 +2,7 @@ package org.molgenis.security.account;
 
 import org.molgenis.util.exception.BadRequestException;
 
-@SuppressWarnings({"squid:MaximumInheritanceDepth"})
+@SuppressWarnings({"java:MaximumInheritanceDepth"})
 class UnknownPasswordResetTokenException extends BadRequestException {
   private static final String ERROR_CODE = "SEC04";
 

--- a/molgenis-security/src/main/java/org/molgenis/security/permission/Permissions.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/permission/Permissions.java
@@ -8,8 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Permissions {
   public abstract Set<String> getIds();
 

--- a/molgenis-security/src/test/java/org/molgenis/security/oidc/model/OidcClientTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/oidc/model/OidcClientTest.java
@@ -33,7 +33,7 @@ public class OidcClientTest extends AbstractSystemEntityTest {
     return map;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-security/src/test/java/org/molgenis/security/oidc/model/OidcUserMappingTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/oidc/model/OidcUserMappingTest.java
@@ -19,7 +19,7 @@ public class OidcUserMappingTest extends AbstractSystemEntityTest {
   @Autowired OidcUserMappingMetadata metadata;
   @Autowired OidcUserMappingFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-security/src/test/java/org/molgenis/security/twofactor/model/RecoveryCodeTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/twofactor/model/RecoveryCodeTest.java
@@ -19,7 +19,7 @@ public class RecoveryCodeTest extends AbstractSystemEntityTest {
   @Autowired RecoveryCodeMetadata metadata;
   @Autowired RecoveryCodeFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-security/src/test/java/org/molgenis/security/twofactor/model/UserSecretTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/twofactor/model/UserSecretTest.java
@@ -19,7 +19,7 @@ public class UserSecretTest extends AbstractSystemEntityTest {
   @Autowired UserSecretMetadata metadata;
   @Autowired UserSecretFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/bean/AmountWrapper.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/bean/AmountWrapper.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AmountWrapper.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AmountWrapper {
   @Nullable
   @CheckForNull

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/bean/Category.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/bean/Category.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_Category.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Category {
   public abstract String getCode();
 

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/bean/GeneratedAlgorithm.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/bean/GeneratedAlgorithm.java
@@ -10,8 +10,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_GeneratedAlgorithm.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GeneratedAlgorithm {
   public abstract String getAlgorithm();
 

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/rules/CategoryMatchQuality.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/rules/CategoryMatchQuality.java
@@ -9,8 +9,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_CategoryMatchQuality.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class CategoryMatchQuality<T> implements Comparable<CategoryMatchQuality<T>> {
   public abstract boolean isRuleApplied();
 

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/rules/quality/impl/NumericQuality.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/algorithmgenerator/rules/quality/impl/NumericQuality.java
@@ -6,8 +6,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_NumericQuality.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class NumericQuality extends Quality<Double> {
   public abstract Double getQualityIndicator();
 

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/controller/FirstAttributeMappingInfo.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/controller/FirstAttributeMappingInfo.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_FirstAttributeMappingInfo.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class FirstAttributeMappingInfo {
   public abstract String getMappingProjectId();
 

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/AddTagRequest.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/AddTagRequest.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AddTagRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AddTagRequest {
   @NotNull
   public abstract String getEntityTypeId();

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/AutoTagRequest.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/AutoTagRequest.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_AutoTagRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AutoTagRequest {
   @NotBlank
   public abstract String getEntityTypeId();

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/GenerateAlgorithmRequest.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/GenerateAlgorithmRequest.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_GenerateAlgorithmRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GenerateAlgorithmRequest {
   @NotNull
   public abstract String getTargetEntityTypeId();

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/GetOntologyTermRequest.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/GetOntologyTermRequest.java
@@ -8,8 +8,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_GetOntologyTermRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class GetOntologyTermRequest {
   @NotBlank
   public abstract String getSearchTerm();

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/RemoveTagRequest.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/data/request/RemoveTagRequest.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_RemoveTagRequest.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class RemoveTagRequest {
   @NotNull
   public abstract String getEntityTypeId();

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/mapping/model/AlgorithmResult.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/mapping/model/AlgorithmResult.java
@@ -7,8 +7,7 @@ import org.molgenis.data.Entity;
 
 /** Result of applying algorithm to one source entity row */
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AlgorithmResult {
   @Nullable
   @CheckForNull

--- a/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/mapping/model/CategoryMapping.java
+++ b/molgenis-semantic-mapper/src/main/java/org/molgenis/semanticmapper/mapping/model/CategoryMapping.java
@@ -13,8 +13,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class CategoryMapping<S, T> {
   private static Gson gson = new GsonBuilder().serializeNulls().create();
 

--- a/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/job/MappingJobExecutionTest.java
+++ b/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/job/MappingJobExecutionTest.java
@@ -47,7 +47,7 @@ public class MappingJobExecutionTest extends AbstractSystemEntityTest {
     return attrs;
   }
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/AttributeSearchResults.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/AttributeSearchResults.java
@@ -5,8 +5,7 @@ import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.semanticsearch.semantic.Hits;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class AttributeSearchResults {
   public abstract Attribute getAttribute();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/EntityTypeSearchResults.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/EntityTypeSearchResults.java
@@ -6,8 +6,7 @@ import java.util.List;
 import org.molgenis.data.meta.model.EntityType;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class EntityTypeSearchResults {
   public abstract EntityType getEntityType();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/ExplainedAttribute.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/ExplainedAttribute.java
@@ -5,8 +5,7 @@ import java.util.Set;
 import org.molgenis.data.meta.model.Attribute;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ExplainedAttribute {
   public abstract Attribute getAttribute();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/ExplainedAttributeDto.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/ExplainedAttributeDto.java
@@ -12,8 +12,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ExplainedAttribute.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ExplainedAttributeDto {
   public static ExplainedAttributeDto create(Attribute attribute) {
     return new AutoValue_ExplainedAttributeDto(

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/ExplainedQueryString.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/explain/bean/ExplainedQueryString.java
@@ -5,8 +5,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_ExplainedQueryString.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class ExplainedQueryString {
   public abstract String getMatchedWords();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/semantic/Hit.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/semantic/Hit.java
@@ -3,8 +3,7 @@ package org.molgenis.semanticsearch.semantic;
 import com.google.auto.value.AutoValue;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Hit<T> implements Comparable<Hit<T>> {
   public abstract T getResult();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/semantic/Hits.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/semantic/Hits.java
@@ -7,8 +7,7 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 @AutoValue
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class Hits<T> implements Iterable<Hit<T>> {
   public abstract List<Hit<T>> getHits();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/semantic/OntologyTag.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/semantic/OntologyTag.java
@@ -7,8 +7,7 @@ import org.molgenis.util.AutoGson;
 
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_OntologyTag.class)
-@SuppressWarnings(
-    "squid:S1610") // Abstract classes without fields should be converted to interfaces
+@SuppressWarnings("java:S1610") // Abstract classes without fields should be converted to interfaces
 public abstract class OntologyTag {
   public abstract OntologyTerm getOntologyTerm();
 

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/service/impl/SemanticSearchServiceImpl.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/service/impl/SemanticSearchServiceImpl.java
@@ -283,7 +283,7 @@ public class SemanticSearchServiceImpl implements SemanticSearchService {
   }
 
   /** package-private for testability */
-  @SuppressWarnings("squid:S1643") // Strings should not be concatenated using '+' in a loop
+  @SuppressWarnings("java:S1643") // Strings should not be concatenated using '+' in a loop
   Hit<OntologyTerm> findTags(Attribute attribute, List<String> ontologyIds) {
     String description =
         attribute.getDescription() == null ? attribute.getLabel() : attribute.getDescription();

--- a/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/string/NGramDistanceAlgorithm.java
+++ b/molgenis-semantic-search/src/main/java/org/molgenis/semanticsearch/string/NGramDistanceAlgorithm.java
@@ -30,7 +30,7 @@ import org.apache.commons.lang3.StringUtils;
  *
  * @author Chao Pang
  */
-@SuppressWarnings("squid:S2386") // false positive: Mutable fields should not be "public static"
+@SuppressWarnings("java:S2386") // false positive: Mutable fields should not be "public static"
 public class NGramDistanceAlgorithm {
 
   private static int N_GRAMS = 2;

--- a/molgenis-settings/src/main/java/org/molgenis/settings/PropertyType.java
+++ b/molgenis-settings/src/main/java/org/molgenis/settings/PropertyType.java
@@ -28,7 +28,7 @@ public class PropertyType extends SystemEntityType {
     this.metaPackage = requireNonNull(metaPackage);
   }
 
-  @SuppressWarnings("squid:S1192") // String literals should not be duplicated
+  @SuppressWarnings("java:S1192") // String literals should not be duplicated
   @Override
   public void init() {
     setLabel("Property");

--- a/molgenis-settings/src/main/java/org/molgenis/settings/mail/MailSettingsImpl.java
+++ b/molgenis-settings/src/main/java/org/molgenis/settings/mail/MailSettingsImpl.java
@@ -79,7 +79,7 @@ public class MailSettingsImpl extends DefaultSettingsEntity implements MailSetti
     public static final String PROTOCOL = "protocol";
     public static final String USERNAME = "username";
 
-    @SuppressWarnings("squid:S2068") // not a hard-coded password
+    @SuppressWarnings("java:S2068") // not a hard-coded password
     public static final String PASSWORD = "password";
 
     public static final String DEFAULT_ENCODING = "defaultEncoding";

--- a/molgenis-settings/src/test/java/org/molgenis/settings/mail/JavaMailPropertyTest.java
+++ b/molgenis-settings/src/test/java/org/molgenis/settings/mail/JavaMailPropertyTest.java
@@ -19,7 +19,7 @@ class JavaMailPropertyTest extends AbstractSystemEntityTest {
   @Autowired JavaMailPropertyType metadata;
   @Autowired JavaMailPropertyFactory factory;
 
-  @SuppressWarnings("squid:S2699") // Tests should include assertions
+  @SuppressWarnings("java:S2699") // Tests should include assertions
   @Test
   protected void testSystemEntity() {
     internalTestAttributes(

--- a/molgenis-util/src/main/java/org/molgenis/util/ApplicationContextProvider.java
+++ b/molgenis-util/src/main/java/org/molgenis/util/ApplicationContextProvider.java
@@ -9,7 +9,7 @@ import org.springframework.context.ApplicationContextAware;
  * @author erwin
  */
 // Intended static write from instance
-@SuppressWarnings("squid:S2696")
+@SuppressWarnings("java:S2696")
 public class ApplicationContextProvider implements ApplicationContextAware {
   private static ApplicationContext ctx = null;
 

--- a/molgenis-util/src/main/java/org/molgenis/util/exception/CodedRuntimeException.java
+++ b/molgenis-util/src/main/java/org/molgenis/util/exception/CodedRuntimeException.java
@@ -7,7 +7,7 @@ import java.text.MessageFormat;
 import org.molgenis.util.i18n.MessageSourceHolder;
 
 /** {@link RuntimeException} with error code. */
-@SuppressWarnings("java:MaximumInheritanceDepth")
+@SuppressWarnings("java:S110")
 public abstract class CodedRuntimeException extends RuntimeException implements ErrorCoded {
   private final String errorCode;
 

--- a/molgenis-util/src/main/java/org/molgenis/util/exception/CodedRuntimeException.java
+++ b/molgenis-util/src/main/java/org/molgenis/util/exception/CodedRuntimeException.java
@@ -7,7 +7,7 @@ import java.text.MessageFormat;
 import org.molgenis.util.i18n.MessageSourceHolder;
 
 /** {@link RuntimeException} with error code. */
-@SuppressWarnings("squid:MaximumInheritanceDepth")
+@SuppressWarnings("java:MaximumInheritanceDepth")
 public abstract class CodedRuntimeException extends RuntimeException implements ErrorCoded {
   private final String errorCode;
 

--- a/molgenis-util/src/main/java/org/molgenis/util/stream/MapCollectors.java
+++ b/molgenis-util/src/main/java/org/molgenis/util/stream/MapCollectors.java
@@ -21,7 +21,7 @@ public class MapCollectors {
    * Based on <a
    * href="https://stackoverflow.com/a/29090335/8579801">https://stackoverflow.com/a/29090335/8579801</a>
    */
-  @SuppressWarnings("squid:S1452")
+  @SuppressWarnings("java:S1452")
   public static <T, K, U> Collector<T, ?, Map<K, U>> toLinkedMap(
       Function<? super T, ? extends K> keyMapper, Function<? super T, ? extends U> valueMapper) {
     return Collectors.toMap(keyMapper, valueMapper, throwingMerger(), LinkedHashMap::new);

--- a/molgenis-validation/src/main/java/org/molgenis/validation/InvalidJsonSchemaException.java
+++ b/molgenis-validation/src/main/java/org/molgenis/validation/InvalidJsonSchemaException.java
@@ -8,7 +8,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Exception that's thrown when a JSON Schema contains errors. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class InvalidJsonSchemaException extends CodedRuntimeException {
   private static final String ERROR_CODE = "V02";
   private final Throwable cause;

--- a/molgenis-validation/src/main/java/org/molgenis/validation/InvalidJsonSchemaException.java
+++ b/molgenis-validation/src/main/java/org/molgenis/validation/InvalidJsonSchemaException.java
@@ -8,7 +8,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Exception that's thrown when a JSON Schema contains errors. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class InvalidJsonSchemaException extends CodedRuntimeException {
   private static final String ERROR_CODE = "V02";
   private final Throwable cause;

--- a/molgenis-validation/src/main/java/org/molgenis/validation/JsonValidationException.java
+++ b/molgenis-validation/src/main/java/org/molgenis/validation/JsonValidationException.java
@@ -10,7 +10,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Exception that lists one or more violations in a JSON object or schema. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"squid:MaximumInheritanceDepth", "squid:S2166"})
+@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
 public class JsonValidationException extends CodedRuntimeException {
   private static final String ERROR_CODE = "V01";
   private final Set<ConstraintViolation> violations;

--- a/molgenis-validation/src/main/java/org/molgenis/validation/JsonValidationException.java
+++ b/molgenis-validation/src/main/java/org/molgenis/validation/JsonValidationException.java
@@ -10,7 +10,7 @@ import org.molgenis.util.exception.CodedRuntimeException;
 /** Exception that lists one or more violations in a JSON object or schema. */
 // S2166 'Classes named like "Exception" should extend "Exception" or a subclass' often gives false
 // positives at dev time
-@SuppressWarnings({"java:MaximumInheritanceDepth", "java:S2166"})
+@SuppressWarnings({"java:S110", "java:S2166"})
 public class JsonValidationException extends CodedRuntimeException {
   private static final String ERROR_CODE = "V01";
   private final Set<ConstraintViolation> violations;

--- a/molgenis-web/src/main/java/org/molgenis/web/menu/model/Menu.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/menu/model/Menu.java
@@ -13,7 +13,7 @@ import org.molgenis.util.AutoGson;
 /** Menu grouping a list of child items. */
 @AutoGson(autoValueClass = AutoValue_Menu.class)
 @AutoValue
-@SuppressWarnings("squid:S1610") // Autovalue class cannot be an interface
+@SuppressWarnings("java:S1610") // Autovalue class cannot be an interface
 public abstract class Menu implements MenuNode {
 
   /** @return the child items grouped in this menu */

--- a/molgenis-web/src/main/java/org/molgenis/web/menu/model/MenuItem.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/menu/model/MenuItem.java
@@ -11,7 +11,7 @@ import org.molgenis.util.AutoGson;
 /** A menu item. */
 @AutoValue
 @AutoGson(autoValueClass = AutoValue_MenuItem.class)
-@SuppressWarnings("squid:S1610") // Autovalue class cannot be an interface
+@SuppressWarnings("java:S1610") // Autovalue class cannot be an interface
 public abstract class MenuItem implements MenuNode {
 
   /** @return the parameters for this menu item */


### PR DESCRIPTION
Sonar changed their rule identifiers from `squid:x` to `java:x` and `javasecurity:x`. 
https://community.sonarsource.com/t/java-analyzer-v6-0-more-accurate-analysis-with-fewer-false-positives/18547
https://jira.sonarsource.com/browse/SONARJAVA-3268

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
