### PR TITLE
Fix #8926: Duplicate basePath /api in swagger documentation

### DIFF
--- a/molgenis-api-identities/pom.xml
+++ b/molgenis-api-identities/pom.xml
@@ -18,7 +18,6 @@
         <configuration>
           <apiSources>
             <apiSource>
-              <basePath>/api</basePath>
               <info>
                 <title>${project.name}</title>
                 <version>${project.version}</version>

--- a/molgenis-api-metrics/pom.xml
+++ b/molgenis-api-metrics/pom.xml
@@ -18,7 +18,6 @@
         <configuration>
           <apiSources>
             <apiSource>
-              <basePath>/api</basePath>
               <info>
                 <title>${project.name}</title>
                 <version>${project.version}</version>


### PR DESCRIPTION
Fixes #8926

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [NA] Code unit/integration/system tested
- [NA] Migration step added in case of breaking change
- [NA] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
