### PR TITLE
Fix #8936 Mapping service attribute search broken when no ontologies (8.3)

### DIFF
--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/repository/OntologyTermRepository.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/repository/OntologyTermRepository.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -76,6 +77,10 @@ public class OntologyTermRepository {
    */
   public List<OntologyTerm> findOntologyTerms(
       List<String> ontologyIds, Set<String> terms, int pageSize) {
+    if (ontologyIds.isEmpty() || terms.isEmpty()) {
+      return Collections.emptyList();
+    }
+
     List<QueryRule> rules = new ArrayList<>();
     for (String term : terms) {
       if (!rules.isEmpty()) {

--- a/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/service/impl/OntologyServiceImpl.java
+++ b/molgenis-ontology-core/src/main/java/org/molgenis/ontology/core/service/impl/OntologyServiceImpl.java
@@ -5,6 +5,7 @@ import static java.util.stream.Collectors.toList;
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.molgenis.ontology.core.model.Ontology;
@@ -54,6 +55,9 @@ public class OntologyServiceImpl implements OntologyService {
   @Override
   public List<OntologyTerm> findExactOntologyTerms(
       List<String> ontologyIds, Set<String> terms, int pageSize) {
+    if (ontologyIds.isEmpty()) {
+      return Collections.emptyList();
+    }
     if (null == terms || terms.isEmpty()) {
       return Lists.newArrayList();
     }
@@ -63,6 +67,9 @@ public class OntologyServiceImpl implements OntologyService {
   @Override
   public List<OntologyTerm> findOntologyTerms(
       List<String> ontologyIds, Set<String> terms, int pageSize) {
+    if (ontologyIds.isEmpty()) {
+      return Collections.emptyList();
+    }
     if (null == terms || terms.isEmpty()) {
       return Lists.newArrayList();
     }

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/repository/OntologyTermRepositoryTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/repository/OntologyTermRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_SELF;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.molgenis.ontology.core.meta.OntologyTermMetadata.ID;
 import static org.molgenis.ontology.core.meta.OntologyTermMetadata.ONTOLOGY;
@@ -140,6 +141,13 @@ class OntologyTermRepositoryTest extends AbstractMolgenisSpringTest {
     assertEquals(
         "rules=['ontology' IN [1, 2], AND, ('ontologyTermSynonym' FUZZY_MATCH 'term1', OR, 'ontologyTermSynonym' FUZZY_MATCH 'term2', OR, 'ontologyTermSynonym' FUZZY_MATCH 'term3')], pageSize=100",
         queryCaptor.getValue().toString());
+  }
+
+  @Test
+  void testFindOntologyTermsNoOntologies() {
+    assertEquals(
+        emptyList(), ontologyTermRepository.findOntologyTerms(emptyList(), of("term1"), 100));
+    verifyNoInteractions(dataService);
   }
 
   @Test

--- a/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/service/impl/OntologyServiceImplTest.java
+++ b/molgenis-ontology-core/src/test/java/org/molgenis/ontology/core/service/impl/OntologyServiceImplTest.java
@@ -1,16 +1,23 @@
 package org.molgenis.ontology.core.service.impl;
 
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptySet;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.molgenis.ontology.core.model.Ontology;
+import org.molgenis.ontology.core.model.OntologyTerm;
 import org.molgenis.ontology.core.repository.OntologyRepository;
 import org.molgenis.ontology.core.repository.OntologyTermRepository;
 import org.molgenis.test.AbstractMockitoTest;
@@ -34,5 +41,46 @@ class OntologyServiceImplTest extends AbstractMockitoTest {
     Ontology ontology1 = mock(Ontology.class);
     when(ontologyRepository.getOntologies(ontologyIds)).thenReturn(Stream.of(ontology0, ontology1));
     assertEquals(asList(ontology0, ontology1), ontologyServiceImpl.getOntologies(ontologyIds));
+  }
+
+  @Test
+  void testFindExactOntologyTerms() {
+    List<String> ontologies = singletonList("ontology1");
+    Set<String> ontologyTermStrings = singleton("term1");
+    int pageSize = 100;
+    List<OntologyTerm> ontologyTerms = singletonList(mock(OntologyTerm.class));
+    when(ontologyTermRepository.findExcatOntologyTerms(ontologies, ontologyTermStrings, pageSize))
+        .thenReturn(ontologyTerms);
+    assertEquals(
+        ontologyTerms,
+        ontologyServiceImpl.findExactOntologyTerms(ontologies, ontologyTermStrings, pageSize));
+  }
+
+  @Test
+  void testFindOntologyTerms() {
+    List<String> ontologies = singletonList("ontology1");
+    Set<String> ontologyTermStrings = singleton("term1");
+    int pageSize = 100;
+    List<OntologyTerm> ontologyTerms = singletonList(mock(OntologyTerm.class));
+    when(ontologyTermRepository.findOntologyTerms(ontologies, ontologyTermStrings, pageSize))
+        .thenReturn(ontologyTerms);
+    assertEquals(
+        ontologyTerms,
+        ontologyServiceImpl.findOntologyTerms(ontologies, ontologyTermStrings, pageSize));
+  }
+
+  @Test
+  void testFindOntologyTermsNoOntologies() {
+    assertEquals(
+        emptyList(), ontologyServiceImpl.findOntologyTerms(emptyList(), singleton("term1"), 100));
+    verifyNoInteractions(ontologyRepository);
+  }
+
+  @Test
+  void testFindOntologyTermsNoTerms() {
+    assertEquals(
+        emptyList(),
+        ontologyServiceImpl.findOntologyTerms(singletonList("ontology1"), emptySet(), 100));
+    verifyNoInteractions(ontologyRepository);
   }
 }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
