### PR TITLE
M7343: As search user I want case-insensitive keyword search

### DIFF
--- a/molgenis-app/dev-env/docker-compose.yml
+++ b/molgenis-app/dev-env/docker-compose.yml
@@ -7,7 +7,6 @@ services:
     container_name: frontend
     ports:
       - 80:80
-    network_mode: ${NETWORK_MODE:-bridge}
     volumes:
       - ./backend.conf.template:/etc/nginx/proxy.d/backend.conf.template
     command: >
@@ -23,7 +22,6 @@ services:
       - POSTGRES_PASSWORD=postgres
     ports:
       - 5432:5432
-    network_mode: ${NETWORK_MODE:-bridge}
     volumes:
       - ./init_db.sql:/docker-entrypoint-initdb.d/init.sql
       - db-data:/var/lib/postgresql/data
@@ -47,7 +45,11 @@ services:
     ports:
       - 9200:9200
       - 9300:9300
-    network_mode: ${NETWORK_MODE:-bridge}
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:5.5.3
+    ports:
+      - 5601:5601
 
   minio:
     image: minio/minio:RELEASE.2019-03-20T22-38-47Z
@@ -55,7 +57,6 @@ services:
       - ~/.molgenis/minio/:/data
     ports:
       - 9000:9000
-    network_mode: ${NETWORK_MODE:-bridge}
     environment:
       MINIO_ACCESS_KEY: molgenis
       MINIO_SECRET_KEY: molgenis
@@ -66,7 +67,6 @@ services:
     container_name: opencpu
     ports:
       - 8004:8004
-    network_mode: ${NETWORK_MODE:-bridge}
 
 volumes:
   db-data:

--- a/molgenis-bootstrap/pom.xml
+++ b/molgenis-bootstrap/pom.xml
@@ -71,5 +71,11 @@
       <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.molgenis</groupId>
+      <artifactId>molgenis-semantic-search</artifactId>
+      <version>${project.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/molgenis-bootstrap/src/main/java/org/molgenis/bootstrap/populate/RepositoryPopulator.java
+++ b/molgenis-bootstrap/src/main/java/org/molgenis/bootstrap/populate/RepositoryPopulator.java
@@ -28,6 +28,7 @@ public class RepositoryPopulator {
   private final ScriptTypePopulator scriptTypePopulator;
   private final GenomeBrowserAttributesPopulator genomeBrowserAttributesPopulator;
   private final DynamicDecoratorPopulator dynamicDecoratorPopulator;
+  private final TagPopulator tagPopulator;
 
   public RepositoryPopulator(
       DataService dataService,
@@ -38,7 +39,8 @@ public class RepositoryPopulator {
       I18nPopulator i18nPopulator,
       ScriptTypePopulator scriptTypePopulator,
       GenomeBrowserAttributesPopulator genomeBrowserAttributesPopulator,
-      DynamicDecoratorPopulator dynamicDecoratorPopulator) {
+      DynamicDecoratorPopulator dynamicDecoratorPopulator,
+      TagPopulator tagPopulator) {
     this.dataService = requireNonNull(dataService);
     this.usersGroupsAuthoritiesPopulator = requireNonNull(usersGroupsAuthoritiesPopulator);
     this.systemEntityPopulator = requireNonNull(systemEntityPopulator);
@@ -48,6 +50,7 @@ public class RepositoryPopulator {
     this.scriptTypePopulator = requireNonNull(scriptTypePopulator);
     this.genomeBrowserAttributesPopulator = requireNonNull(genomeBrowserAttributesPopulator);
     this.dynamicDecoratorPopulator = requireNonNull(dynamicDecoratorPopulator);
+    this.tagPopulator = requireNonNull(tagPopulator);
   }
 
   /** Returns whether the database was populated previously. */
@@ -89,6 +92,10 @@ public class RepositoryPopulator {
       systemEntityPopulator.populate(event);
       LOG.trace("Populated database with application entities");
     }
+
+    LOG.trace("Populating tag entities ...");
+    tagPopulator.populate();
+    LOG.trace("Populated tag entities");
 
     LOG.trace("Populating dynamic decorator entities ...");
     dynamicDecoratorPopulator.populate();

--- a/molgenis-bootstrap/src/main/java/org/molgenis/bootstrap/populate/TagPopulator.java
+++ b/molgenis-bootstrap/src/main/java/org/molgenis/bootstrap/populate/TagPopulator.java
@@ -1,0 +1,39 @@
+package org.molgenis.bootstrap.populate;
+
+import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.TOKEN;
+import static org.molgenis.data.meta.model.TagMetadata.TAG;
+import static org.molgenis.data.semantic.Relation.type;
+import static org.molgenis.data.semantic.Vocabulary.CASE_SENSITIVE;
+
+import java.util.List;
+import org.molgenis.data.DataService;
+import org.molgenis.data.meta.model.Tag;
+import org.molgenis.data.meta.model.TagFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TagPopulator {
+  private final TagFactory tagFactory;
+  private final DataService dataService;
+
+  public TagPopulator(TagFactory tagFactory, DataService dataService) {
+    this.tagFactory = tagFactory;
+    this.dataService = dataService;
+  }
+
+  public void populate() {
+    Tag isAToken = tagFactory.create("token");
+    isAToken.setLabel("Token");
+    isAToken.setObjectIri(TOKEN.toString());
+    isAToken.setRelationIri(type.getIRI());
+    isAToken.setRelationLabel(type.getLabel());
+
+    Tag isCaseSensitive = tagFactory.create("case-sensitive");
+    isCaseSensitive.setLabel("Case Sensitive");
+    isCaseSensitive.setObjectIri(CASE_SENSITIVE.toString());
+    isCaseSensitive.setRelationIri(type.getIRI());
+    isCaseSensitive.setRelationLabel(type.getLabel());
+
+    dataService.getRepository(TAG, Tag.class).upsertBatch(List.of(isAToken, isCaseSensitive));
+  }
+}

--- a/molgenis-bootstrap/src/test/java/org/molgenis/bootstrap/populate/TagPopulatorTest.java
+++ b/molgenis-bootstrap/src/test/java/org/molgenis/bootstrap/populate/TagPopulatorTest.java
@@ -1,0 +1,51 @@
+package org.molgenis.bootstrap.populate;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.XMLSchema;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.molgenis.data.DataService;
+import org.molgenis.data.Repository;
+import org.molgenis.data.meta.model.Tag;
+import org.molgenis.data.meta.model.TagFactory;
+import org.molgenis.data.meta.model.TagMetadata;
+import org.molgenis.data.semantic.Vocabulary;
+
+@ExtendWith(MockitoExtension.class)
+class TagPopulatorTest {
+  @Mock DataService dataService;
+  @Mock TagFactory tagFactory;
+  @Mock Tag token;
+  @Mock Tag caseSensitive;
+  @Mock Repository<Tag> tagRepository;
+
+  private TagPopulator tagPopulator;
+
+  @BeforeEach
+  public void setup() {
+    tagPopulator = new TagPopulator(tagFactory, dataService);
+  }
+
+  @Test
+  public void testPopulate() {
+    when(tagFactory.create("token")).thenReturn(token);
+    when(tagFactory.create("case-sensitive")).thenReturn(caseSensitive);
+    when(dataService.getRepository(TagMetadata.TAG, Tag.class)).thenReturn(tagRepository);
+
+    tagPopulator.populate();
+
+    verify(tagRepository).upsertBatch(List.of(token, caseSensitive));
+    verify(token).setRelationIri(RDF.TYPE.toString());
+    verify(token).setObjectIri(XMLSchema.TOKEN.toString());
+
+    verify(caseSensitive).setRelationIri(RDF.TYPE.toString());
+    verify(caseSensitive).setObjectIri(Vocabulary.CASE_SENSITIVE.toString());
+  }
+}

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/SettingsContentBuilder.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/SettingsContentBuilder.java
@@ -12,8 +12,11 @@ import org.molgenis.data.elasticsearch.generator.model.IndexSettings;
 
 /** Creates Elasticsearch transport client content for settings. */
 class SettingsContentBuilder {
+
+  public static final String CI_NORMALIZER = "lowercase_asciifold";
   private static final String DEFAULT_TOKENIZER = "default_tokenizer";
   private static final String DEFAULT_STEMMER = "default_stemmer";
+  public static final String FILTER = "filter";
 
   private final XContentType xContentType;
 
@@ -72,11 +75,12 @@ class SettingsContentBuilder {
     createFilterSettings(contentBuilder);
     createAnalyzerSettings(contentBuilder);
     createTokenizerSettings(contentBuilder);
+    createNormalizerSettings(contentBuilder);
     contentBuilder.endObject();
   }
 
   private void createFilterSettings(XContentBuilder contentBuilder) throws IOException {
-    contentBuilder.startObject("filter");
+    contentBuilder.startObject(FILTER);
     createDefaultStemmerSettings(contentBuilder);
     contentBuilder.endObject();
   }
@@ -97,7 +101,7 @@ class SettingsContentBuilder {
   private void createDefaultAnalyzerSettings(XContentBuilder contentBuilder) throws IOException {
     contentBuilder.startObject(FieldConstants.DEFAULT_ANALYZER);
     contentBuilder.field("type", "custom");
-    contentBuilder.array("filter", "word_delimiter", "lowercase", "asciifolding", DEFAULT_STEMMER);
+    contentBuilder.array(FILTER, "word_delimiter", "lowercase", "asciifolding", DEFAULT_STEMMER);
     contentBuilder.field("tokenizer", DEFAULT_TOKENIZER);
     contentBuilder.field("char_filter", "html_strip");
     contentBuilder.endObject();
@@ -113,5 +117,16 @@ class SettingsContentBuilder {
     contentBuilder.startObject(DEFAULT_TOKENIZER);
     contentBuilder.field("type", "whitespace");
     contentBuilder.endObject();
+  }
+
+  private static void createNormalizerSettings(XContentBuilder contentBuilder) throws IOException {
+    contentBuilder
+        .startObject("normalizer")
+        .startObject(CI_NORMALIZER)
+        .field("type", "custom")
+        .array("char_filter")
+        .array(FILTER, "lowercase", "asciifolding")
+        .endObject()
+        .endObject();
   }
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/MappingGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/MappingGenerator.java
@@ -3,6 +3,9 @@ package org.molgenis.data.elasticsearch.generator;
 import static com.google.common.collect.Streams.stream;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toList;
+import static org.eclipse.rdf4j.model.vocabulary.XMLSchema.TOKEN;
+import static org.molgenis.data.QueryUtils.isTaggedType;
+import static org.molgenis.data.semantic.Vocabulary.CASE_SENSITIVE;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -42,16 +45,28 @@ class MappingGenerator {
   private FieldMapping createFieldMapping(Attribute attribute, int depth, int maxDepth) {
     String fieldName = documentIdGenerator.generateId(attribute);
     MappingType mappingType = toMappingType(attribute, depth, maxDepth);
-    List<FieldMapping> nestedFieldMappings =
-        mappingType == MappingType.NESTED
-            ? createFieldMappings(attribute.getRefEntity(), depth + 1, maxDepth)
-            : null;
-    return FieldMapping.create(fieldName, mappingType, nestedFieldMappings);
+    var result = FieldMapping.builder().setName(fieldName).setType(mappingType);
+    if (mappingType == MappingType.NESTED) {
+      result.setNestedFieldMappings(
+          createFieldMappings(attribute.getRefEntity(), depth + 1, maxDepth));
+    }
+    if (mappingType == MappingType.KEYWORD && isTaggedType(attribute, CASE_SENSITIVE)) {
+      result.setCaseSensitive(true);
+    }
+    return result.build();
   }
 
   private MappingType toMappingType(Attribute attribute, int depth, int maxDepth) {
+    MappingType result = getMappingType(attribute);
+    if (result == MappingType.NESTED) {
+      return toMappingTypeReferenceAttribute(attribute, depth, maxDepth);
+    }
+    return result;
+  }
+
+  public static MappingType getMappingType(Attribute attribute) {
     AttributeType attributeType = attribute.getDataType();
-    switch (attributeType) {
+    switch (attribute.getDataType()) {
       case BOOL:
         return MappingType.BOOLEAN;
       case CATEGORICAL:
@@ -60,7 +75,7 @@ class MappingGenerator {
       case MREF:
       case ONE_TO_MANY:
       case XREF:
-        return toMappingTypeReferenceAttribute(attribute, depth, maxDepth);
+        return MappingType.NESTED;
       case DATE:
         return MappingType.DATE;
       case DATE_TIME:
@@ -69,10 +84,11 @@ class MappingGenerator {
         return MappingType.DOUBLE;
       case EMAIL:
       case ENUM:
-      case HTML:
       case HYPERLINK:
-      case SCRIPT:
       case STRING:
+        return isTaggedType(attribute, TOKEN) ? MappingType.KEYWORD : MappingType.TEXT;
+      case HTML:
+      case SCRIPT:
       case TEXT:
         return MappingType.TEXT;
       case INT:

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/FieldMapping.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/FieldMapping.java
@@ -12,6 +12,12 @@ public abstract class FieldMapping {
 
   public abstract MappingType getType();
 
+  /**
+   * For FieldMappings of type {@link MappingType#KEYWORD}, indicates if the keyword is case
+   * sensitive.
+   */
+  public abstract boolean isCaseSensitive();
+
   @Nullable
   @CheckForNull
   public abstract List<FieldMapping> getNestedFieldMappings();
@@ -26,7 +32,7 @@ public abstract class FieldMapping {
   }
 
   public static Builder builder() {
-    return new AutoValue_FieldMapping.Builder();
+    return new AutoValue_FieldMapping.Builder().setCaseSensitive(false);
   }
 
   @AutoValue.Builder
@@ -34,6 +40,8 @@ public abstract class FieldMapping {
     public abstract Builder setName(String newName);
 
     public abstract Builder setType(MappingType newType);
+
+    public abstract Builder setCaseSensitive(boolean caseSensitive);
 
     public abstract Builder setNestedFieldMappings(List<FieldMapping> newNestedFieldMappings);
 

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/MappingType.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/model/MappingType.java
@@ -8,5 +8,6 @@ public enum MappingType {
   INTEGER,
   LONG,
   NESTED,
-  TEXT
+  TEXT,
+  KEYWORD
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
@@ -34,6 +34,7 @@ class MappingContentBuilderTest {
     dataItems.add(new Object[] {MappingType.INTEGER, JSON_INTEGER});
     dataItems.add(new Object[] {MappingType.LONG, JSON_LONG});
     dataItems.add(new Object[] {MappingType.TEXT, JSON_TEXT});
+    dataItems.add(new Object[] {MappingType.KEYWORD, JSON_KEYWORD});
     return dataItems.iterator();
   }
 
@@ -44,6 +45,21 @@ class MappingContentBuilderTest {
         createMapping(FieldMapping.builder().setName("field").setType(mappingType).build());
     XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
     assertEquals(expectedJson, xContentBuilder.string());
+  }
+
+  @Test
+  void testCreateMappingKeywordCaseSensitive() throws IOException {
+    Mapping mapping =
+        createMapping(
+            FieldMapping.builder()
+                .setName("field")
+                .setType(MappingType.KEYWORD)
+                .setCaseSensitive(true)
+                .build());
+
+    XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
+
+    assertEquals(JSON_KEYWORD_CASE_SENSITIVE, xContentBuilder.string());
   }
 
   @Test
@@ -79,6 +95,10 @@ class MappingContentBuilderTest {
       "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"long\"}}}";
   private static final String JSON_TEXT =
       "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"text\",\"norms\":true,\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true,\"ignore_above\":8191}}}}}";
+  private static final String JSON_KEYWORD =
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"keyword\",\"normalizer\":\"lowercase_asciifold\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
+  private static final String JSON_KEYWORD_CASE_SENSITIVE =
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"keyword\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
   private static final String JSON_NESTED =
       "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"nested\",\"properties\":{\"nestedField\":{\"type\":\"boolean\"}}}}}";
 }

--- a/molgenis-data/pom.xml
+++ b/molgenis-data/pom.xml
@@ -98,5 +98,11 @@
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.eclipse.rdf4j</groupId>
+      <artifactId>rdf4j-model</artifactId>
+      <version>2.0.2</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/molgenis-data/src/main/java/org/molgenis/data/QueryUtils.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/QueryUtils.java
@@ -1,6 +1,8 @@
 package org.molgenis.data;
 
+import static com.google.common.collect.Streams.stream;
 import static java.lang.String.format;
+import static org.eclipse.rdf4j.model.vocabulary.RDF.TYPE;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableList.Builder;
@@ -9,6 +11,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.eclipse.rdf4j.model.IRI;
 import org.molgenis.data.QueryRule.Operator;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
@@ -206,5 +209,9 @@ public class QueryUtils {
       expandedAttributePath = attributePath;
     }
     return expandedAttributePath;
+  }
+
+  public static boolean isTaggedType(Attribute attribute, IRI typeIRI) {
+    return stream(attribute.getTags()).anyMatch(tag -> tag.equals(TYPE, typeIRI));
   }
 }

--- a/molgenis-data/src/main/java/org/molgenis/data/meta/model/Tag.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/meta/model/Tag.java
@@ -2,6 +2,7 @@ package org.molgenis.data.meta.model;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
+import org.eclipse.rdf4j.model.IRI;
 import org.molgenis.data.Entity;
 import org.molgenis.data.support.StaticEntity;
 
@@ -32,6 +33,10 @@ public class Tag extends StaticEntity {
     tagCopy.setRelationLabel(tag.getRelationLabel());
     tagCopy.setCodeSystem(tag.getCodeSystem());
     return tagCopy;
+  }
+
+  public boolean equals(IRI relation, IRI object) {
+    return relation.toString().equals(getRelationIri()) && object.toString().equals(getObjectIri());
   }
 
   public String getId() {

--- a/molgenis-data/src/main/java/org/molgenis/data/semantic/Relation.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/semantic/Relation.java
@@ -1,12 +1,18 @@
 package org.molgenis.data.semantic;
 
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.model.vocabulary.RDFS;
+
 @SuppressWarnings("java:S115") // Constant names should comply with a naming convention
 public enum Relation {
   instanceOf("http://molgenis.org/biobankconnect/instanceOf"),
   link("http://molgenis.org/biobankconnect/link"),
-  homepage("http://xmlns.com/foaf/0.1/homepage"),
-  isDefinedBy("http://www.w3.org/2000/01/rdf-schema#isDefinedBy"),
-  seeAlso("http://www.w3.org/2000/01/rdf-schema#seeAlso"),
+  homepage(FOAF.HOMEPAGE),
+  type(RDF.TYPE),
+  isDefinedBy(RDFS.ISDEFINEDBY),
+  seeAlso(RDFS.SEEALSO),
   hasLowerValue("http://molgenis.org/uml/hasLowerValue"),
   hasUpperValue("http://molgenis.org/uml/hasUpperValue"),
   isRealizationOf("http://molgenis.org/uml/isRealizationOf"),
@@ -16,6 +22,10 @@ public enum Relation {
   isAssociatedWith("http://molgenis.org#isAssociatedWith");
 
   private String iri;
+
+  Relation(IRI iri) {
+    this.iri = iri.toString();
+  }
 
   Relation(String iri) {
     this.iri = iri;

--- a/molgenis-data/src/main/java/org/molgenis/data/semantic/Vocabulary.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/semantic/Vocabulary.java
@@ -1,0 +1,12 @@
+package org.molgenis.data.semantic;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+
+public class Vocabulary {
+  private Vocabulary() {}
+
+  /** http://purl.obolibrary.org/obo/NCIT_C71490 */
+  public static final IRI CASE_SENSITIVE =
+      SimpleValueFactory.getInstance().createIRI("http://purl.obolibrary.org/obo/NCIT_C71490");
+}

--- a/molgenis-data/src/test/java/org/molgenis/data/QueryUtilsTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/QueryUtilsTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.QueryRule.Operator.DIS_MAX;
 import static org.molgenis.data.QueryRule.Operator.EQUALS;
@@ -22,15 +23,20 @@ import com.google.common.collect.Lists;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import org.eclipse.rdf4j.model.vocabulary.FOAF;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.molgenis.data.meta.model.Attribute;
 import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.meta.model.Tag;
 import org.molgenis.data.support.QueryImpl;
 import org.molgenis.test.AbstractMockitoTest;
 
 class QueryUtilsTest extends AbstractMockitoTest {
   @Mock private Query<Entity> query;
+  @Mock private Attribute attribute;
+  @Mock private Tag tag;
 
   @Test
   void containsAnyOperator() {
@@ -412,5 +418,19 @@ class QueryUtilsTest extends AbstractMockitoTest {
     assertEquals(
         ImmutableList.of(grandparentAttribute, parentAttribute, childAttribute),
         QueryUtils.getAttributePathExpanded("grandparent.parent.child", grandparentEntityType));
+  }
+
+  @Test
+  public void testIsTaggedTypeTrue() {
+    when(attribute.getTags()).thenReturn(List.of(tag));
+    when(tag.equals(RDF.TYPE, FOAF.PERSON)).thenReturn(true);
+    assertTrue(QueryUtils.isTaggedType(attribute, FOAF.PERSON));
+  }
+
+  @Test
+  public void testIsTaggedTypeFalse() {
+    when(attribute.getTags()).thenReturn(List.of(tag));
+    assertFalse(QueryUtils.isTaggedType(attribute, FOAF.PERSON));
+    verify(tag).equals(RDF.TYPE, FOAF.PERSON);
   }
 }

--- a/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/controller/TagWizardControllerTest.java
+++ b/molgenis-semantic-mapper/src/test/java/org/molgenis/semanticmapper/controller/TagWizardControllerTest.java
@@ -83,6 +83,7 @@ class TagWizardControllerTest extends AbstractMockitoTest {
               Relation.instanceOf,
               Relation.link,
               Relation.homepage,
+              Relation.type,
               Relation.isDefinedBy,
               Relation.seeAlso,
               Relation.hasLowerValue,


### PR DESCRIPTION
In EMX, you can now tag ENUM, HYPERLINK, EMAIL and STRING attributes (i.e. max length 255) with predefined tags `token` and `case-sensitive`.

# no tag
Nothing changed

# token
The attribute is analyzed using the ElasticSearch keyword analyzer, with a normalizer that lowercases and ascii-folds the values.
* SEARCH on the field remains case-insensitive.
* SEARCH will only match the complete token, no partial matches

# token, case-sensitive
The attribute is analyzed using the ElasticSearch keyword analyzer, but no normalizer is applied.
* SEARCH on the field field becomes case-sensitive
* SEARCH will only match the complete token, no partial matches

# where can I see this
You can test this in the data explorer filters, those use search on the attribute if it is a string.
The top-left search box does a search on the _all field, this is unchanged.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
