### PR TITLE
Fix #9015: When you make ROLE_ANONYMOUS a viewer on your group, they cannot see metadata

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppPermissionRegistry.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppPermissionRegistry.java
@@ -113,6 +113,14 @@ public class WebAppPermissionRegistry implements PermissionRegistry {
     register(PLUGIN, MetadataManagerController.METADATA_MANAGER, manager, READ);
     register(ENTITY_TYPE, ResourceCopyJobExecutionMetadata.COPY_JOB_EXECUTION, manager, WRITE);
     register(ENTITY_TYPE, ResourceDeleteJobExecutionMetadata.DELETE_JOB_EXECUTION, manager, WRITE);
+    // When role_ANONYMOUS role includes role_VIEWER, it skips role_USER.
+    // So also add the role_USER permissions to role_VIEWER,
+    // except for the account plugin which makes no sense when the user is not
+    // authenticated.
+    register(PLUGIN, FeedbackController.ID, viewer, READ);
+    register(PACKAGE, PACKAGE_ONTOLOGY, viewer, READ);
+    register(PACKAGE, PACKAGE_META, viewer, READ);
+    register(PACKAGE, PACKAGE_SYSTEM, viewer, READMETA);
   }
 
   @Override


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
