### PR TITLE
Fix misleading links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ MOLGENIS has a frontend and a backend. You can develop on them separately. When 
 - [Develop backend](https://molgenis.gitbook.io/molgenis/guide-using-an-ide-for-backend.html)
 - [Develop frontend](https://github.com/molgenis/molgenis-frontend/blob/master/README.md)
 
-## Installation
-To install MOLGENIS for production usage click [here](http://docs.gcc.rug.nl/molgenis)
-
 ## Useful links
 - [Documentation](https://molgenis.gitbook.io/molgenis/)
 - [Organisation](https://molgenis.org) 
+
+## Other links
+To install MOLGENIS for production usage click [here](http://docs.gcc.rug.nl/molgenis) (internal use for UMCG only)

--- a/README.md
+++ b/README.md
@@ -16,5 +16,5 @@ MOLGENIS has a frontend and a backend. You can develop on them separately. When 
 - [Documentation](https://molgenis.gitbook.io/molgenis/)
 - [Organisation](https://molgenis.org) 
 
-## Other links
-To install MOLGENIS for production usage click [here](http://docs.gcc.rug.nl/molgenis) (internal use for UMCG only)
+## Deploy MOLGENIS
+- [Deploy MOLGENIS](https://molgenis.gitbook.io/molgenis/guide-deploy-molgenis)


### PR DESCRIPTION
We are missing installation instructions for outsiders. This link makes matters worse. Please add link to information for outside users how to install.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
