### PR TITLE
fix: do not crash row-edit if data-explorer is not in menu

### DIFF
--- a/molgenis-data-row-edit/src/main/resources/templates/view-data-row-edit.ftl
+++ b/molgenis-data-row-edit/src/main/resources/templates/view-data-row-edit.ftl
@@ -14,8 +14,8 @@
     window.__INITIAL_STATE__ = {
         baseUrl: '${baseUrl}',
         lng: '${lng}',
-        fallbackLng: '${fallbackLng}',
-        dataExplorerBaseUrl: <#if dataExplorerBaseUrl??>\'${dataExplorerBaseUrl}\'<#else>null</#if>
+        fallbackLng: '${fallbackLng}'<#if dataExplorerBaseUrl??>,
+        dataExplorerBaseUrl: '${dataExplorerBaseUrl}'</#if>
     }
 </script>
 


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [x] Clean commits
- [ ] Added Feature/Fix to release notes
