### PR TITLE
Fix #9044: Elasticsearch break after cleanup script

### DIFF
--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/Step41Reindex.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/Step41Reindex.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import org.molgenis.data.elasticsearch.client.ClientFacade;
 import org.molgenis.data.elasticsearch.generator.model.Index;
+import org.molgenis.data.index.exception.UnknownIndexException;
 import org.molgenis.data.migrate.framework.MolgenisUpgrade;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -23,7 +24,11 @@ public class Step41Reindex extends MolgenisUpgrade {
     // Right now is too early to do metadata and reindex work.
     // Remove attrMetadata index.
     // Then the IndexBootstrapper will schedule the full reindex.
-    clientFacade.deleteIndex(Index.create("sysmdattribute_c8d9a252"));
-    LOG.info("The standard tokenizer got changed, will do a full reindex.");
+    try {
+      clientFacade.deleteIndex(Index.create("sysmdattribute_c8d9a252"));
+      LOG.info("The standard tokenizer got changed, will do a full reindex.");
+    } catch (UnknownIndexException ignore) {
+      LOG.info("Index not found, full index will be done already.");
+    }
   }
 }

--- a/molgenis-data-migrate/src/test/java/org/molgenis/data/migrate/version/Step41ReindexTest.java
+++ b/molgenis-data-migrate/src/test/java/org/molgenis/data/migrate/version/Step41ReindexTest.java
@@ -1,6 +1,7 @@
 package org.molgenis.data.migrate.version;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.molgenis.data.elasticsearch.client.ClientFacade;
 import org.molgenis.data.elasticsearch.generator.model.Index;
+import org.molgenis.data.index.exception.UnknownIndexException;
 
 @ExtendWith(MockitoExtension.class)
 class Step41ReindexTest {
@@ -28,5 +30,12 @@ class Step41ReindexTest {
     step41Reindex.upgrade();
 
     verify(clientFacade).deleteIndex(attributeIndex);
+  }
+
+  @Test
+  void testUpgradeIndexNotFound() {
+    doThrow(new UnknownIndexException("Not found")).when(clientFacade).deleteIndex(attributeIndex);
+
+    step41Reindex.upgrade();
   }
 }


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
