### PR TITLE
fix: Update resource paths for apps 

### DIFF
--- a/molgenis-app-manager/src/main/resources/templates/view-app-manager.ftl
+++ b/molgenis-app-manager/src/main/resources/templates/view-app-manager.ftl
@@ -8,6 +8,7 @@
 <@header css js version/>
     <div id="app-manager"></div>
 
+    <link rel="stylesheet" href="/@molgenis-ui/app-manager/dist/css/chunk-vendors.css"/>
     <link rel="stylesheet" href="/@molgenis-ui/app-manager/dist/css/app.css"/>
 
     <script type=text/javascript src="/@molgenis-ui/app-manager/dist/js/chunk-vendors.js"></script>

--- a/molgenis-app-manager/src/main/resources/templates/view-app-manager.ftl
+++ b/molgenis-app-manager/src/main/resources/templates/view-app-manager.ftl
@@ -1,18 +1,16 @@
-<#include "resource-macros.ftl">
 <#include "molgenis-header.ftl">
 <#include "molgenis-footer.ftl">
 
 <#assign css = []>
 <#assign js=[]>
 <#assign version = 2>
+
 <@header css js version/>
+    <div id="app-manager"></div>
 
-<div id="app-manager"></div>
+    <link rel="stylesheet" href="/@molgenis-ui/app-manager/dist/css/app.css"/>
 
-<link rel="stylesheet" href="/@molgenis-ui/app-manager/dist/css/app.css"/>
-
-<script type=text/javascript src="/@molgenis-ui/app-manager/dist/js/manifest.js"></script>
-<script type=text/javascript src="/@molgenis-ui/app-manager/dist/js/vendor.js"></script>
-<script type=text/javascript src="/@molgenis-ui/app-manager/dist/js/app.js"></script>
+    <script type=text/javascript src="/@molgenis-ui/app-manager/dist/js/chunk-vendors.js"></script>
+    <script type=text/javascript src="/@molgenis-ui/app-manager/dist/js/app.js"></script>
 
 <@footer version/>

--- a/molgenis-data-row-edit/src/main/resources/templates/view-data-row-edit.ftl
+++ b/molgenis-data-row-edit/src/main/resources/templates/view-data-row-edit.ftl
@@ -19,10 +19,9 @@
     }
 </script>
 
-<link rel="stylesheet" href="/@molgenis-ui/data-row-edit/dist/css/app.css"/>
+<link rel="stylesheet" href="/@molgenis-ui/data-row-edit/dist/css/chunk-vendors.css"/>
 
-<script type=text/javascript src="/@molgenis-ui/data-row-edit/dist/js/manifest.js"></script>
-<script type=text/javascript src="/@molgenis-ui/data-row-edit/dist/js/vendor.js"></script>
+<script type=text/javascript src="/@molgenis-ui/data-row-edit/dist/js/chunk-vendors.js"></script>
 <script type=text/javascript src="/@molgenis-ui/data-row-edit/dist/js/app.js"></script>
 
 <@footer version/>

--- a/molgenis-security-ui/src/main/resources/templates/view-security-ui.ftl
+++ b/molgenis-security-ui/src/main/resources/templates/view-security-ui.ftl
@@ -19,10 +19,10 @@
     }
 </script>
 
+<link rel="stylesheet" href="/@molgenis-ui/security/dist/css/chunk-vendors.css"/>
 <link rel="stylesheet" href="/@molgenis-ui/security/dist/css/app.css"/>
 
-<script type=text/javascript src="/@molgenis-ui/security/dist/js/manifest.js"></script>
-<script type=text/javascript src="/@molgenis-ui/security/dist/js/vendor.js"></script>
+<script type=text/javascript src="/@molgenis-ui/security/dist/js/chunk-vendors.js"></script>
 <script type=text/javascript src="/@molgenis-ui/security/dist/js/app.js"></script>
 
 <@footer version/>

--- a/molgenis-settings-ui/src/main/resources/templates/view-settings.ftl
+++ b/molgenis-settings-ui/src/main/resources/templates/view-settings.ftl
@@ -21,7 +21,7 @@
 
 <link rel="stylesheet" href="/@molgenis-ui/settings/dist/css/chunk-vendors.css"/>
 
-<script type=text/javascript src="/@molgenis-ui/settings/dist/js/chunk-vendors.js.js"></script>
+<script type=text/javascript src="/@molgenis-ui/settings/dist/js/chunk-vendors.js"></script>
 <script type=text/javascript src="/@molgenis-ui/settings/dist/js/app.js"></script>
 
 <@footer version/>

--- a/molgenis-settings-ui/src/main/resources/templates/view-settings.ftl
+++ b/molgenis-settings-ui/src/main/resources/templates/view-settings.ftl
@@ -19,10 +19,9 @@
     }
 </script>
 
-<link rel="stylesheet" href="/@molgenis-ui/settings/dist/css/app.css"/>
+<link rel="stylesheet" href="/@molgenis-ui/settings/dist/css/chunk-vendors.css"/>
 
-<script type=text/javascript src="/@molgenis-ui/settings/dist/js/manifest.js"></script>
-<script type=text/javascript src="/@molgenis-ui/settings/dist/js/vendor.js"></script>
+<script type=text/javascript src="/@molgenis-ui/settings/dist/js/chunk-vendors.js.js"></script>
 <script type=text/javascript src="/@molgenis-ui/settings/dist/js/app.js"></script>
 
 <@footer version/>


### PR DESCRIPTION
fix: Update resource paths for apps app-manager, data-row-edit, security-u…i and settings

Related to: https://github.com/molgenis/molgenis-frontend/pull/303

- These apps have been updated to vue new vue-cli-4 defaults, this results in changes to resources paths.
- This PR updates the resources to point to the new path/files names

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
