### PR TITLE
feat: Expose selected theme stylesheet via endpoint

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/StyleController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/style/StyleController.java
@@ -3,6 +3,7 @@ package org.molgenis.core.ui.style;
 import static java.util.Objects.requireNonNull;
 import static org.molgenis.core.ui.style.BootstrapVersion.BOOTSTRAP_VERSION_3;
 import static org.molgenis.core.ui.style.BootstrapVersion.BOOTSTRAP_VERSION_4;
+import static org.molgenis.security.core.runas.RunAsSystemAspect.runAsSystem;
 import static org.springframework.http.HttpStatus.OK;
 
 import java.io.IOException;
@@ -10,6 +11,8 @@ import java.io.InputStream;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.io.IOUtils;
 import org.molgenis.core.ui.style.exception.GetThemeException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +23,13 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
 public class StyleController {
+  public static final String BS_THEME_PREFIX = "bootstrap-";
+  public static final String BS_THEME_SUFFIX = ".min.css";
+  public static final String MAX_AGE_24_HOURS = "max-age=86400";
   private final StyleService styleService;
+
+  private static final Logger LOG = LoggerFactory.getLogger(StyleController.class);
+  private static final String DEFAULT_STYLE = "molgenis-blue";
 
   public StyleController(StyleService styleService) {
     this.styleService = requireNonNull(styleService);
@@ -28,7 +37,7 @@ public class StyleController {
 
   @GetMapping("/css/bootstrap-{bootstrap-version}/{theme}")
   @ResponseStatus(OK)
-  public ResponseEntity getThemeCss(
+  public ResponseEntity<Void> getThemeCss(
       @PathVariable("bootstrap-version") String bootstrapVersion,
       @PathVariable("theme") String theme,
       HttpServletResponse response) {
@@ -48,6 +57,29 @@ public class StyleController {
       throw new GetThemeException(theme, e);
     }
 
-    return new ResponseEntity(HttpStatus.OK);
+    return new ResponseEntity<>(HttpStatus.OK);
+  }
+
+  @GetMapping("/css/active-theme.css")
+  @ResponseStatus(OK)
+  public ResponseEntity<Void> getActiveThemeCss(HttpServletResponse response) {
+    response.setHeader("Content-Type", "text/css");
+    response.setHeader("Cache-Control", MAX_AGE_24_HOURS);
+    // Get selected theme  with elevated permissions because the anonymous user can also request the
+    // selected theme
+    final Style selectedStyle = runAsSystem(styleService::getSelectedStyle);
+    String name = selectedStyle != null ? selectedStyle.getName() : DEFAULT_STYLE;
+    Resource styleSheetResource =
+        styleService.getThemeData(BS_THEME_PREFIX + name + BS_THEME_SUFFIX, BOOTSTRAP_VERSION_4);
+
+    try (InputStream inputStream = styleSheetResource.getInputStream()) {
+      IOUtils.copy(inputStream, response.getOutputStream());
+      response.flushBuffer();
+    } catch (IOException e) {
+      LOG.warn("Failed writing selected theme data to response");
+      return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    return new ResponseEntity<>(HttpStatus.OK);
   }
 }

--- a/molgenis-core-ui/src/test/java/org/molgenis/core/ui/style/StyleControllerTest.java
+++ b/molgenis-core-ui/src/test/java/org/molgenis/core/ui/style/StyleControllerTest.java
@@ -62,4 +62,19 @@ class StyleControllerTest {
         .perform(get("/css/bootstrap-4/bootstrap-molgenis.min.css").with(anonymous()))
         .andExpect(status().isOk());
   }
+
+  @Test
+  void getActiveThemeCss() throws Exception {
+    FileSystemResource themeResource = mock(FileSystemResource.class);
+    InputStream inputStream =
+        new ByteArrayInputStream("selected style ".getBytes(StandardCharsets.UTF_8));
+    when(themeResource.getInputStream()).thenReturn(inputStream);
+    Style selectedStyle = mock(Style.class);
+    when(selectedStyle.getName()).thenReturn("molgenis-blue");
+    when(styleService.getSelectedStyle()).thenReturn(selectedStyle);
+    when(styleService.getThemeData(
+            "bootstrap-molgenis-blue.min.css", BootstrapVersion.BOOTSTRAP_VERSION_4))
+        .thenReturn(themeResource);
+    mockMvc.perform(get("/css/active-theme.css").with(anonymous())).andExpect(status().isOk());
+  }
 }


### PR DESCRIPTION
- Selected theme style sheet is exposed on '/css/active-theme.css'
- Anyone is allowed to fetch the selected theme data
- Cache-Control is set to 24 hours

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
