### PR TITLE
fix: Unable to remove a group that has role extensions #9082

### DIFF
--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/GroupPackageServiceImplTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/GroupPackageServiceImplTest.java
@@ -62,6 +62,7 @@ class GroupPackageServiceImplTest extends AbstractMockitoTest {
   @Mock private DataService dataService;
   @Mock private GroupFactory groupFactory;
   @Mock private MutableAclService mutableAclService;
+  @Mock private GroupService groupService;
 
   @Captor private ArgumentCaptor<Stream<Role>> roleCaptor;
   @Captor private ArgumentCaptor<Stream<RoleMembership>> memberCaptor;
@@ -78,7 +79,8 @@ class GroupPackageServiceImplTest extends AbstractMockitoTest {
             roleFactory,
             dataService,
             groupFactory,
-            mutableAclService);
+            mutableAclService,
+            groupService);
   }
 
   @Test
@@ -227,12 +229,17 @@ class GroupPackageServiceImplTest extends AbstractMockitoTest {
     Query<RoleMembership> membershipQuery = mock(Query.class, Mockito.RETURNS_SELF);
     when(dataService.query(RoleMembershipMetadata.ROLE_MEMBERSHIP, RoleMembership.class))
         .thenReturn(membershipQuery);
+
     Query<RoleMembership> role1Query = mock(Query.class);
     when(role1Query.findAll()).thenReturn(members.stream());
     doReturn(role1Query).when(membershipQuery).eq(RoleMembershipMetadata.ROLE, "role1");
+
     Query<RoleMembership> role2Query = mock(Query.class);
     when(role2Query.findAll()).thenReturn(Stream.empty());
     doReturn(role2Query).when(membershipQuery).eq(RoleMembershipMetadata.ROLE, "role2");
+
+    Query<Role> includesRoleQuery1 = mock(Query.class, RETURNS_SELF);
+    when(dataService.query(ROLE, Role.class)).thenReturn(includesRoleQuery1);
 
     groupPackageService.deleteGroup(pack);
 


### PR DESCRIPTION
On group delete, check if group roles are use as extention
If they are remove the extentions before removing the group roles

Closes #9082

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
