### PR TITLE
[FEAT] Upgrade to ElasticSearch 6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ executors:
           POSTGRES_USER: molgenis
           POSTGRES_PASSWORD: molgenis
           POSTGRES_DB: molgenis
-      - image: molgenis/molgenis-elasticsearch:1.0.0
+      - image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.19
         environment:
           cluster.name: molgenis
           bootstrap.memory_lock: true

--- a/molgenis-app/dev-env/docker-compose.yml
+++ b/molgenis-app/dev-env/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - db-data:/var/lib/postgresql/data
 
   elasticsearch:
-    image: molgenis/molgenis-elasticsearch:1.0.0
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.19
     environment:
       - cluster.name=molgenis
       - bootstrap.memory_lock=true

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/ClientFactory.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/ClientFactory.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Objects;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.transport.TransportClient;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.molgenis.data.MolgenisDataException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,9 +81,7 @@ class ClientFactory {
     return result;
   }
 
-  private InetSocketTransportAddress[] createInetTransportAddresses() {
-    return inetAddresses.stream()
-        .map(InetSocketTransportAddress::new)
-        .toArray(InetSocketTransportAddress[]::new);
+  private TransportAddress[] createInetTransportAddresses() {
+    return inetAddresses.stream().map(TransportAddress::new).toArray(TransportAddress[]::new);
   }
 }

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/PreBuiltTransportClientFactory.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/PreBuiltTransportClientFactory.java
@@ -17,7 +17,7 @@ public class PreBuiltTransportClientFactory {
     Settings.Builder builder = Settings.builder();
     builder.put("cluster.name", clusterName);
     if (settings != null) {
-      builder.put(settings);
+      settings.forEach(builder::put);
     }
     return builder.build();
   }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
@@ -44,7 +44,7 @@ class MappingContentBuilderTest {
     Mapping mapping =
         createMapping(FieldMapping.builder().setName("field").setType(mappingType).build());
     XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
-    assertEquals(expectedJson, xContentBuilder.string());
+    assertEquals(expectedJson, xContentBuilder.getOutputStream().toString());
   }
 
   @Test
@@ -59,7 +59,7 @@ class MappingContentBuilderTest {
 
     XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
 
-    assertEquals(JSON_KEYWORD_CASE_SENSITIVE, xContentBuilder.string());
+    assertEquals(JSON_KEYWORD_CASE_SENSITIVE, xContentBuilder.getOutputStream().toString());
   }
 
   @Test
@@ -74,7 +74,7 @@ class MappingContentBuilderTest {
                 .setNestedFieldMappings(singletonList(nestedFieldMapping))
                 .build());
     XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
-    assertEquals(JSON_NESTED, xContentBuilder.string());
+    assertEquals(JSON_NESTED, xContentBuilder.getOutputStream().toString());
   }
 
   private static Mapping createMapping(FieldMapping fieldMapping) {

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/DocumentContentBuilderTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/DocumentContentBuilderTest.java
@@ -23,7 +23,6 @@ import static org.molgenis.data.meta.AttributeType.TEXT;
 import static org.molgenis.data.meta.AttributeType.XREF;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.ArrayList;
@@ -309,11 +308,13 @@ class DocumentContentBuilderTest extends AbstractMockitoTest {
 
   private void assertDocumentEquals(Document document, String expectedContent) {
     assertEquals("id", document.getId());
-    assertNotNull(document.getContent());
+    var content = document.getContent();
+    assertNotNull(content);
     try {
-      assertEquals(expectedContent, document.getContent().string());
+      content.flush();
     } catch (IOException e) {
-      throw new UncheckedIOException(e);
+      e.printStackTrace();
     }
+    assertEquals(expectedContent, content.getOutputStream().toString());
   }
 }

--- a/molgenis-platform-integration-tests/integ-test-env/docker-compose.yml
+++ b/molgenis-platform-integration-tests/integ-test-env/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     network_mode: ${NETWORK_MODE:-bridge}
 
   elasticsearch:
-    image: molgenis/molgenis-elasticsearch:1.0.0
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.19
     environment:
       - cluster.name=molgenis
       - bootstrap.memory_lock=true

--- a/molgenis-platform-integration-tests/src/test/resources/conf/molgenis.properties
+++ b/molgenis-platform-integration-tests/src/test/resources/conf/molgenis.properties
@@ -1,6 +1,6 @@
 #Molgenis server properties used at dev time
 db_user=molgenis
 db_password=molgenis
-db_uri=jdbc\:postgresql\://localhost/molgenis_test
-elasticsearch.transport.addresses=localhost:9300
+db_uri=jdbc\:postgresql\://localhost/molgenis
+elasticsearch.hosts=localhost:9300
 elasticsearch.cluster.name=molgenis

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <sonar.skip>${skipTests}</sonar.skip>
 
     <!-- override dependency versions managed by parent pom -->
-    <elasticsearch.version>5.5.3</elasticsearch.version>
+    <elasticsearch.version>6.8.19</elasticsearch.version>
     <guava.version>30.1-jre</guava.version>
     <!-- parent version 0.35 depends on org.apache.commons:commons-compress:jar:1.9, 1.18 is required by org.apache.poi:poi:jar:4.0.1 -->
     <webjars-locator-core.version>0.36</webjars-locator-core.version>
@@ -137,7 +137,6 @@
     <!-- Integration test properties -->
     <cargo-plugin.version>1.7.7</cargo-plugin.version>
     <sql-maven-plugin.version>1.5</sql-maven-plugin.version>
-    <elasticsearch-maven-plugin.version>5.7</elasticsearch-maven-plugin.version>
     <!-- Integration test props to use docker infrastructure -->
     <it_db_name>molgenis</it_db_name>
     <it_db_user>molgenis</it_db_user>


### PR DESCRIPTION
# TODO
Fix all field
https://www.elastic.co/guide/en/elasticsearch/reference/6.8/mapping-all-field.html

# Breaking change
Users need to upgrade to ElasticSearch 6

> The client must have the same major version (e.g. 2.x, or 5.x) as the nodes in the cluster. Clients may connect to clusters which have a different minor version (e.g. 2.3.x) but it is possible that new functionality may not be supported. Ideally, the client should have the same version as the cluster.

See https://www.elastic.co/support/eol
6.8 goes eol tomorrow, will be maintained until 8.0 comes

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
