### PR TITLE
Migration step to remove dangling Sids from ACL tables

### DIFF
--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/bootstrap/MolgenisUpgradeBootstrapper.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/bootstrap/MolgenisUpgradeBootstrapper.java
@@ -18,6 +18,7 @@ import org.molgenis.data.migrate.version.Step41Reindex;
 import org.molgenis.data.migrate.version.Step42RemoveFormsUrlRow;
 import org.molgenis.data.migrate.version.Step43SetUsernameAttributeName;
 import org.molgenis.data.migrate.version.Step44CascadeDeleteSids;
+import org.molgenis.data.migrate.version.Step45RemoveDanglingSids;
 import org.springframework.stereotype.Component;
 
 /** Registers and executes {@link MolgenisUpgrade upgrades} during application bootstrapping. */
@@ -48,6 +49,7 @@ public class MolgenisUpgradeBootstrapper {
     upgradeService.addUpgrade(new Step42RemoveFormsUrlRow(dataSource));
     upgradeService.addUpgrade(new Step43SetUsernameAttributeName(dataSource));
     upgradeService.addUpgrade(new Step44CascadeDeleteSids(dataSource));
+    upgradeService.addUpgrade(new Step45RemoveDanglingSids(dataSource));
     upgradeService.upgrade();
   }
 }

--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/MolgenisVersionService.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/MolgenisVersionService.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Service;
 public class MolgenisVersionService {
 
   /** package-private for testability */
-  static final int VERSION = 44;
+  static final int VERSION = 45;
 
   private final DataSource dataSource;
 

--- a/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/Step45RemoveDanglingSids.java
+++ b/molgenis-data-migrate/src/main/java/org/molgenis/data/migrate/version/Step45RemoveDanglingSids.java
@@ -1,0 +1,44 @@
+package org.molgenis.data.migrate.version;
+
+import static java.util.Objects.requireNonNull;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import javax.sql.DataSource;
+import org.molgenis.data.migrate.framework.MolgenisUpgrade;
+import org.molgenis.util.ResourceUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class Step45RemoveDanglingSids extends MolgenisUpgrade {
+
+  private static final Logger LOG = LoggerFactory.getLogger(Step45RemoveDanglingSids.class);
+
+  private final JdbcTemplate jdbcTemplate;
+
+  public Step45RemoveDanglingSids(DataSource dataSource) {
+    this(new JdbcTemplate(dataSource));
+  }
+
+  Step45RemoveDanglingSids(JdbcTemplate jdbcTemplate) {
+    super(44, 45);
+    this.jdbcTemplate = requireNonNull(jdbcTemplate);
+  }
+
+  @Override
+  public void upgrade() {
+    LOG.debug("Cleaning dirty ACL tables: removing dangling Sids and associated ACEs");
+    try {
+      removeDanglingSids();
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    LOG.info("Cleaned dirty ACL tables: removed dangling Sids and associated ACEs");
+  }
+
+  private void removeDanglingSids() throws IOException {
+    String sql = ResourceUtils.getString("step45-removeDanglingSids.sql");
+    jdbcTemplate.execute(sql);
+  }
+}

--- a/molgenis-data-migrate/src/main/resources/step45-removeDanglingSids.sql
+++ b/molgenis-data-migrate/src/main/resources/step45-removeDanglingSids.sql
@@ -1,0 +1,8 @@
+DELETE
+FROM acl_sid AS sids
+WHERE id IN (SELECT id
+             FROM acl_sid
+             WHERE NOT EXISTS(SELECT *
+                              FROM "sys_sec_Role#b6639604" as roles
+                              WHERE CONCAT('ROLE_', roles.name) = sids.sid)
+               AND NOT sids.principal);

--- a/molgenis-data-migrate/src/test/java/org/molgenis/data/migrate/version/Step45RemoveDanglingSidsTest.java
+++ b/molgenis-data-migrate/src/test/java/org/molgenis/data/migrate/version/Step45RemoveDanglingSidsTest.java
@@ -1,0 +1,35 @@
+package org.molgenis.data.migrate.version;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.molgenis.test.AbstractMockitoTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+class Step45RemoveDanglingSidsTest extends AbstractMockitoTest {
+
+  @Mock private JdbcTemplate jdbcTemplate;
+  private Step45RemoveDanglingSids step45RemoveDanglingSids;
+
+  @BeforeEach
+  void setUpBeforeEach() {
+    step45RemoveDanglingSids = new Step45RemoveDanglingSids(jdbcTemplate);
+  }
+
+  @Test
+  void upgrade() {
+    step45RemoveDanglingSids.upgrade();
+    verify(jdbcTemplate)
+        .execute(
+            "DELETE\n"
+                + "FROM acl_sid AS sids\n"
+                + "WHERE id IN (SELECT id\n"
+                + "             FROM acl_sid\n"
+                + "             WHERE NOT EXISTS(SELECT *\n"
+                + "                              FROM \"sys_sec_Role#b6639604\" as roles\n"
+                + "                              WHERE CONCAT('ROLE_', roles.name) = sids.sid)\n"
+                + "               AND NOT sids.principal);");
+  }
+}


### PR DESCRIPTION
This migration step cleans up databases that were affected by #9078 

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
