### PR TITLE
feat(api-fair): prioritizes IRI attribute over iri created with BASE_…

### DIFF
--- a/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriter.java
+++ b/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriter.java
@@ -253,6 +253,9 @@ public class EntityModelWriter {
     if ("fdp_Metadata".equals(entityType.getId())) {
       return valueFactory.createIRI(getServletUriComponentsBuilder().build().toUriString());
     }
+    if (contains(entity.getEntityType().getAttributeNames(), "IRI")) {
+      return valueFactory.createIRI(entity.getString("IRI"));
+    }
     if (isADcatResource(entityType)) {
       var iri =
           getServletUriComponentsBuilder()
@@ -260,9 +263,6 @@ public class EntityModelWriter {
               .build()
               .toUriString();
       return valueFactory.createIRI(iri);
-    }
-    if (contains(entity.getEntityType().getAttributeNames(), "IRI")) {
-      return valueFactory.createIRI(entity.getString("IRI"));
     }
     return valueFactory.createBNode();
   }

--- a/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/EntityModelWriterTest.java
+++ b/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/EntityModelWriterTest.java
@@ -125,6 +125,37 @@ class EntityModelWriterTest extends AbstractMockitoTest {
                 + "    ]");
   }
 
+  @Test
+  void testCreateRfdModelWithCustomIRI() {
+
+    List<Attribute> attributeList = singletonList(attribute);
+
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getString("IRI")).thenReturn("http://purl.org/example/catalog_id");
+    when(entityType.getAttributeNames()).thenReturn(singletonList("IRI"));
+    when(entityType.getAtomicAttributes()).thenReturn(attributeList);
+
+    when(attribute.getName()).thenReturn("IRI");
+
+    when(tagService.getTagsForEntity(entityType)).thenReturn(List.of(entityTag, entityTag2));
+    when(entityTag.getRelation()).thenReturn(isAssociatedWith);
+    when(entityTag.getObject()).thenReturn(labeledResource);
+    when(labeledResource.getIri()).thenReturn(DCAT_RESOURCE);
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(4, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://purl.org/example/catalog_id> a dcat:Resource")
+        .contains(
+            "fdp:metadataIdentifier [ a datacite:Identifier;\n"
+                + "      dct:identifier <http://purl.org/example/catalog_id>\n"
+                + "    ]");
+  }
+
   static Object[][] createStatementForAttributeProvider() {
     return new Object[][] {
       new Object[] {


### PR DESCRIPTION
This PR changes the behavior of the FDP API when setting the IRI of a Resouce.
It prioritizes the presence of IRI attribute in the Entity over the `isADcatResource()` check.
This allows assigning to the Resource an external universal IRI instead of creating it as BASE_URI + entityID.
For example, if we want to assign to an entity of type `dcat:Dataset` the IRI http://purl.org/domain/dataset_id we can add to the fdp_Dataset model the IRI attribute and assign the value <http://purl.org/domain/dataset_id>. 
This result in the following turtle serialization:
```
...
<http://purl.org/domain/dataset_id> a dcat:Resource, r3d:Repository
...
fdp:metadataIdentifier [ a datacite:Identifier;
    dct:identifier < http://purl.org/domain/dataset_id>
]
```

Currently, the turtle serialization is always
```
...
<http://<my_domain.com>/my_internal_id> a dcat:Resource, r3d:Repository
...
fdp:metadataIdentifier [ a datacite:Identifier;
    dct:identifier <http://<my_domain.com>/my_internal_id>
]
```

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
