### PR TITLE
feat(api-fair): name the blank nodes with the valueof the Entity ID

### DIFF
--- a/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriter.java
+++ b/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriter.java
@@ -264,7 +264,7 @@ public class EntityModelWriter {
               .toUriString();
       return valueFactory.createIRI(iri);
     }
-    return valueFactory.createBNode();
+    return valueFactory.createBNode(entity.getIdValue().toString());
   }
 
   UriComponentsBuilder getServletUriComponentsBuilder() {

--- a/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriter.java
+++ b/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriter.java
@@ -264,7 +264,8 @@ public class EntityModelWriter {
               .toUriString();
       return valueFactory.createIRI(iri);
     }
-    return valueFactory.createBNode(entity.getIdValue().toString());
+    return valueFactory.createBNode(
+        String.format("%s_%s", entity.getEntityType().getId(), entity.getIdValue().toString()));
   }
 
   UriComponentsBuilder getServletUriComponentsBuilder() {

--- a/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/EntityModelWriterTest.java
+++ b/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/EntityModelWriterTest.java
@@ -227,6 +227,7 @@ class EntityModelWriterTest extends AbstractMockitoTest {
       AttributeType attributeType, Object value, Consumer<Entity> consumer, String fragment) {
     when(objectEntity.getEntityType()).thenReturn(entityType);
     when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
     when(objectEntity.get("attributeName")).thenReturn(value);
     consumer.accept(objectEntity);
 
@@ -251,6 +252,7 @@ class EntityModelWriterTest extends AbstractMockitoTest {
   void testCreateRfdModelXREF() {
     when(objectEntity.getEntityType()).thenReturn(entityType);
     when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
     when(objectEntity.get("attributeName")).thenReturn(refEntity);
     when(objectEntity.getEntity("attributeName")).thenReturn(refEntity);
 
@@ -280,6 +282,7 @@ class EntityModelWriterTest extends AbstractMockitoTest {
   void testCreateRfdModelMREF() {
     when(objectEntity.getEntityType()).thenReturn(entityType);
     when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
     when(objectEntity.get("attributeName")).thenReturn(refEntity);
     when(objectEntity.getEntities("attributeName")).thenReturn(List.of(refEntity));
 
@@ -315,6 +318,7 @@ class EntityModelWriterTest extends AbstractMockitoTest {
 
     when(objectEntity.getEntityType()).thenReturn(entityType);
     String value = "molgenis,genetics,fair";
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
     when(objectEntity.get("attributeName")).thenReturn(value);
     when(objectEntity.getString("attributeName")).thenReturn(value);
 
@@ -340,6 +344,7 @@ class EntityModelWriterTest extends AbstractMockitoTest {
   void testCreateRfdModelNullValue() {
     when(objectEntity.getEntityType()).thenReturn(entityType);
     when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute));
+    when(objectEntity.getIdValue()).thenReturn("attributeName1");
     when(objectEntity.get("attributeName1")).thenReturn(null);
     when(attribute.getName()).thenReturn("attributeName1");
 


### PR DESCRIPTION
In the api-fair module, when two properties point to the same xref object, the RDF representation creates two BNode that, as a matter of fact, represent the same object. 
For example, if for some reason the `fdp_Dataset` `rights` attribute is associated with two tags (e.g., `dct:rights`, `dct:accessRights`), the current behavior creates two blank nodes. 

```
:dataset_1 a dcat:Dataset, dcat:Resource;
    dct:rights [
        a dct:RightsStatement;
        dct:description "This resource has access restriction" .
    ];
    dct:accessRights [
        a dct:RightsStatement;
        dct:description "This resource has access restriction" .
    ].
```
This PR changes this giving the BNode a name corresponding to the entityId. In this way, the properties refer to the same object.
The above example in the new version is:

```
:dataset_1 a dcat:Dataset, dcat:Resource;
    dct:rights _:restricted;
    dct:accessRights _:restricted.

_:restricted a dct:RightsStatement;
    dct:description "This resource has access restriction" .
```



#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
