### PR TITLE
Fix #9166: Error when downloading a file with a comma in the name

### DIFF
--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/file/FileDownloadController.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/file/FileDownloadController.java
@@ -60,7 +60,8 @@ public class FileDownloadController {
       }
 
       response.setHeader(
-          "Content-Disposition", "attachment; filename=" + outputFilename.replace(" ", "_"));
+          "Content-Disposition",
+          "attachment; filename=\"" + outputFilename.replace(" ", "_") + "\"");
 
       try (InputStream is = new FileInputStream(fileStoreFile)) {
         FileCopyUtils.copy(is, response.getOutputStream());


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [ ] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [ ] Added Feature/Fix to release notes
