### PR TITLE
M4347: Remember original authentication when running as SYSTEM

### DIFF
--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/JobExecutorTokenServiceImpl.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/JobExecutorTokenServiceImpl.java
@@ -28,7 +28,7 @@ public class JobExecutorTokenServiceImpl implements JobExecutorTokenService {
     return jobExecution
         .getUser()
         .map(this::createRunAsUsertoken)
-        .orElseGet(SystemSecurityToken::getInstance);
+        .orElseGet(SystemSecurityToken::create);
   }
 
   private AbstractAuthenticationToken createRunAsUsertoken(String username) {

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/RunAsSystemAspect.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/RunAsSystemAspect.java
@@ -1,19 +1,27 @@
 package org.molgenis.security.core.runas;
 
+import static org.springframework.security.core.context.SecurityContextHolder.createEmptyContext;
+import static org.springframework.security.core.context.SecurityContextHolder.getContext;
+import static org.springframework.security.core.context.SecurityContextHolder.setContext;
+
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
-/** Proxy that set a SystemSecurityToken in the security context for the duration of a method */
+/**
+ * Proxy that sets a SystemSecurityToken in the security context for the duration of a method. The
+ * original authentication is stored in the SystemSecurityToken. If the current authentication is
+ * already a SystemSecurityToken, this authentication is used instead of setting a new one.
+ */
 @Order(Ordered.HIGHEST_PRECEDENCE + 1)
 @Aspect
 @Component
 public class RunAsSystemAspect {
+
   @SuppressWarnings("java:S00112") // generic exceptions should never be thrown
   @Around("@annotation(RunAsSystem)")
   public Object aroundAdvice(ProceedingJoinPoint joinPoint) throws Throwable {
@@ -30,15 +38,18 @@ public class RunAsSystemAspect {
 
   public static <T, X extends Throwable> T runAsSystem(RunnableAsSystem<T, X> runnable) throws X {
     // Remember the original context
-    SecurityContext origCtx = SecurityContextHolder.getContext();
+    SecurityContext origCtx = getContext();
     try {
-      // Set a SystemSecurityToken
-      SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext());
-      SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.getInstance());
+      var auth = origCtx.getAuthentication();
+      if (!(auth instanceof SystemSecurityToken)) {
+        // Set a SystemSecurityToken
+        setContext(createEmptyContext());
+        getContext().setAuthentication(SystemSecurityToken.createElevated(auth));
+      }
       return runnable.run();
     } finally {
       // Set the original context back when method is finished
-      SecurityContextHolder.setContext(origCtx);
+      setContext(origCtx);
     }
   }
 }

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/SidUtilsTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/SidUtilsTest.java
@@ -43,7 +43,7 @@ class SidUtilsTest {
 
   @Test
   void createSecurityContextSidSystem() {
-    SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.getInstance());
+    SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.create());
     assertEquals(new GrantedAuthoritySid("ROLE_SYSTEM"), createSecurityContextSid());
   }
 

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/WithMockSystemUser.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/WithMockSystemUser.java
@@ -1,0 +1,18 @@
+package org.molgenis.security.core;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+/** Akin to @WithMockUser but sets a SystemSecurityToken. */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockSystemUserSecurityContextFactory.class)
+public @interface WithMockSystemUser {
+
+  /**
+   * If non-empty, creates an elevated SystemSecurityToken token.
+   *
+   * @return the original username
+   */
+  String originalUsername() default "";
+}

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/WithMockSystemUserSecurityContextFactory.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/WithMockSystemUserSecurityContextFactory.java
@@ -1,0 +1,31 @@
+package org.molgenis.security.core;
+
+import static java.util.Collections.emptySet;
+
+import org.molgenis.security.core.runas.SystemSecurityToken;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+/** Factory for the @WithMockSystemUser annotation. */
+class WithMockSystemUserSecurityContextFactory
+    implements WithSecurityContextFactory<WithMockSystemUser> {
+
+  @Override
+  public SecurityContext createSecurityContext(WithMockSystemUser systemUser) {
+    SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+    var name = systemUser.originalUsername();
+    if (!name.isEmpty()) {
+      var user = new User(name, name, emptySet());
+      var auth = new UsernamePasswordAuthenticationToken(user, name, emptySet());
+      context.setAuthentication(SystemSecurityToken.createElevated(auth));
+    } else {
+      context.setAuthentication(SystemSecurityToken.create());
+    }
+
+    return context;
+  }
+}

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/RunAsSystemAspectTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/RunAsSystemAspectTest.java
@@ -1,11 +1,14 @@
 package org.molgenis.security.core.runas;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.molgenis.security.core.runas.RunAsSystemAspect.runAsSystem;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.molgenis.security.core.WithMockSystemUser;
 import org.molgenis.test.AbstractMockitoSpringContextTests;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -35,9 +38,33 @@ class RunAsSystemAspectTest extends AbstractMockitoSpringContextTests {
   @Test
   @WithMockUser
   void testRunAsSystemRunnableAsSystem() {
+    var originalAuth = getAuthentication();
+    var auth = (SystemSecurityToken) runAsSystem(this::getAuthentication);
+
+    assertTrue(originalAuth instanceof UsernamePasswordAuthenticationToken);
+    assertTrue(auth.getOriginalAuthentication().isPresent());
+    assertEquals(originalAuth, auth.getOriginalAuthentication().get());
     assertTrue(getAuthentication() instanceof UsernamePasswordAuthenticationToken);
-    assertTrue(runAsSystem(this::getAuthentication) instanceof SystemSecurityToken);
-    assertTrue(getAuthentication() instanceof UsernamePasswordAuthenticationToken);
+  }
+
+  @Test
+  @WithMockSystemUser
+  void testRunAsSystemWithSystemToken() {
+    var originalAuth = getAuthentication();
+
+    assertTrue(originalAuth instanceof SystemSecurityToken);
+    assertSame(originalAuth, runAsSystem(this::getAuthentication));
+    assertSame(originalAuth, getAuthentication());
+  }
+
+  @Test
+  @WithMockSystemUser(originalUsername = "henk")
+  void testRunAsSystemWithElevatedUser() {
+    var originalAuth = getAuthentication();
+
+    assertTrue(originalAuth instanceof SystemSecurityToken);
+    assertSame(originalAuth, runAsSystem(this::getAuthentication));
+    assertSame(originalAuth, getAuthentication());
   }
 
   private Authentication getAuthentication() {

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/SystemSecurityTokenTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/SystemSecurityTokenTest.java
@@ -1,16 +1,20 @@
 package org.molgenis.security.core.runas;
 
+import static java.util.Collections.emptySet;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.molgenis.security.core.runas.SystemSecurityToken.getInstance;
 
 import com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.molgenis.security.core.runas.SystemSecurityToken.SystemPrincipal;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
 
 class SystemSecurityTokenTest {
+
   @Test
   void testGetAuthorities() {
     ImmutableList<SimpleGrantedAuthority> expectedAuthorities =
@@ -19,21 +23,38 @@ class SystemSecurityTokenTest {
             new SimpleGrantedAuthority("ROLE_ACL_TAKE_OWNERSHIP"),
             new SimpleGrantedAuthority("ROLE_ACL_MODIFY_AUDITING"),
             new SimpleGrantedAuthority("ROLE_ACL_GENERAL_CHANGES"));
-    assertEquals(expectedAuthorities, getInstance().getAuthorities());
+    assertEquals(expectedAuthorities, SystemSecurityToken.create().getAuthorities());
   }
 
   @Test
   void testGetCredentials() {
-    assertNull(SystemSecurityToken.getInstance().getCredentials());
+    assertNull(SystemSecurityToken.create().getCredentials());
   }
 
   @Test
   void testGetPrincipal() {
-    assertTrue(SystemSecurityToken.getInstance().getPrincipal() instanceof SystemPrincipal);
+    assertTrue(SystemSecurityToken.create().getPrincipal() instanceof SystemPrincipal);
   }
 
   @Test
   void testIsAuthenticated() {
-    assertTrue(SystemSecurityToken.getInstance().isAuthenticated());
+    assertTrue(SystemSecurityToken.create().isAuthenticated());
+  }
+
+  @Test
+  void testGetOriginalAuthenticationWithElevatedUser() {
+    var user = new User("name", "password", emptySet());
+    var auth = new UsernamePasswordAuthenticationToken(user, "password", emptySet());
+
+    var originalAuth = SystemSecurityToken.createElevated(auth).getOriginalAuthentication();
+
+    assertTrue(originalAuth.isPresent());
+    assertEquals(auth, originalAuth.get());
+  }
+
+  @Test
+  void testGetOriginalAuthenticationWithoutElevatedUser() {
+    var originalAuth = SystemSecurityToken.create().getOriginalAuthentication();
+    assertFalse(originalAuth.isPresent());
   }
 }

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/utils/SecurityUtilsTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/utils/SecurityUtilsTest.java
@@ -137,7 +137,7 @@ class SecurityUtilsTest {
   @Test
   void getCurrentUsernameSystemPrincipal() {
     try {
-      SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.getInstance());
+      SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.create());
       assertNull(SecurityUtils.getCurrentUsername());
     } finally {
       SecurityContextHolder.getContext().setAuthentication(authentication);


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
