### PR TITLE
M4347: Remember original authentication when running as SYSTEM (improvements)

### DIFF
--- a/molgenis-jobs/src/main/java/org/molgenis/jobs/JobExecutorTokenServiceImpl.java
+++ b/molgenis-jobs/src/main/java/org/molgenis/jobs/JobExecutorTokenServiceImpl.java
@@ -28,7 +28,7 @@ public class JobExecutorTokenServiceImpl implements JobExecutorTokenService {
     return jobExecution
         .getUser()
         .map(this::createRunAsUsertoken)
-        .orElseGet(SystemSecurityToken::create);
+        .orElseGet(SystemSecurityToken::new);
   }
 
   private AbstractAuthenticationToken createRunAsUsertoken(String username) {

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/RunAsSystemToken.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/RunAsSystemToken.java
@@ -1,0 +1,32 @@
+package org.molgenis.security.core.runas;
+
+import static java.util.Objects.requireNonNull;
+
+import org.springframework.security.core.Authentication;
+
+/**
+ * A system token that can be used to elevate a non-system authentication to system.
+ */
+public class RunAsSystemToken extends SystemSecurityToken {
+
+  private final Authentication originalAuthentication;
+
+  public RunAsSystemToken(Authentication originalAuthentication) {
+    super();
+
+    this.originalAuthentication = requireNonNull(originalAuthentication);
+
+    if (originalAuthentication instanceof SystemSecurityToken) {
+      throw new IllegalStateException("Can't \"run as system\" as system");
+    }
+  }
+
+  /**
+   * Gets the original authentication
+   *
+   * @return the original authentication
+   */
+  public Authentication getOriginalAuthentication() {
+    return originalAuthentication;
+  }
+}

--- a/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/SystemSecurityToken.java
+++ b/molgenis-security-core/src/main/java/org/molgenis/security/core/runas/SystemSecurityToken.java
@@ -6,10 +6,7 @@ import static org.molgenis.security.core.utils.SecurityUtils.ROLE_ACL_TAKE_OWNER
 import static org.molgenis.security.core.utils.SecurityUtils.ROLE_SYSTEM;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Optional;
-import javax.annotation.Nullable;
 import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 
 /** Authentication token for the SYSTEM user */
@@ -22,30 +19,8 @@ public class SystemSecurityToken extends AbstractAuthenticationToken {
           new SimpleGrantedAuthority(ROLE_ACL_MODIFY_AUDITING),
           new SimpleGrantedAuthority(ROLE_ACL_GENERAL_CHANGES));
 
-  private final Authentication originalAuthentication;
-
-  private SystemSecurityToken(@Nullable Authentication originalAuthentication) {
+  public SystemSecurityToken() {
     super(AUTHORITIES);
-    this.originalAuthentication = originalAuthentication;
-  }
-
-  /**
-   * Factory method to create a standard SystemSecurityToken.
-   *
-   * @return a SystemSecurityToken
-   */
-  public static SystemSecurityToken create() {
-    return new SystemSecurityToken(null);
-  }
-
-  /**
-   * Factory method to elevate an existing authentication to SYSTEM, a.k.a. "run as system".
-   *
-   * @param originalAuthentication the authentication to elevate
-   * @return a SystemSecurityToken with an original authentication
-   */
-  public static SystemSecurityToken createElevated(Authentication originalAuthentication) {
-    return new SystemSecurityToken(originalAuthentication);
   }
 
   @Override
@@ -56,16 +31,6 @@ public class SystemSecurityToken extends AbstractAuthenticationToken {
   @Override
   public Object getPrincipal() {
     return SystemPrincipal.getInstance();
-  }
-
-  /**
-   * Gets the original authentication if this SystemSecurityToken represents an elevated
-   * authentication.
-   *
-   * @return an Optional with the original authentication if present, empty Optional otherwise
-   */
-  public Optional<Authentication> getOriginalAuthentication() {
-    return Optional.ofNullable(originalAuthentication);
   }
 
   @Override

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/SidUtilsTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/SidUtilsTest.java
@@ -43,7 +43,7 @@ class SidUtilsTest {
 
   @Test
   void createSecurityContextSidSystem() {
-    SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.create());
+    SecurityContextHolder.getContext().setAuthentication(new SystemSecurityToken());
     assertEquals(new GrantedAuthoritySid("ROLE_SYSTEM"), createSecurityContextSid());
   }
 

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/WithMockSystemUserSecurityContextFactory.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/WithMockSystemUserSecurityContextFactory.java
@@ -2,6 +2,7 @@ package org.molgenis.security.core;
 
 import static java.util.Collections.emptySet;
 
+import org.molgenis.security.core.runas.RunAsSystemToken;
 import org.molgenis.security.core.runas.SystemSecurityToken;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContext;
@@ -21,9 +22,9 @@ class WithMockSystemUserSecurityContextFactory
     if (!name.isEmpty()) {
       var user = new User(name, name, emptySet());
       var auth = new UsernamePasswordAuthenticationToken(user, name, emptySet());
-      context.setAuthentication(SystemSecurityToken.createElevated(auth));
+      context.setAuthentication(new RunAsSystemToken(auth));
     } else {
-      context.setAuthentication(SystemSecurityToken.create());
+      context.setAuthentication(new SystemSecurityToken());
     }
 
     return context;

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/RunAsSystemAspectTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/RunAsSystemAspectTest.java
@@ -1,6 +1,8 @@
 package org.molgenis.security.core.runas;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.molgenis.security.core.runas.RunAsSystemAspect.runAsSystem;
@@ -39,11 +41,10 @@ class RunAsSystemAspectTest extends AbstractMockitoSpringContextTests {
   @WithMockUser
   void testRunAsSystemRunnableAsSystem() {
     var originalAuth = getAuthentication();
-    var auth = (SystemSecurityToken) runAsSystem(this::getAuthentication);
+    var auth = (RunAsSystemToken) runAsSystem(this::getAuthentication);
 
     assertTrue(originalAuth instanceof UsernamePasswordAuthenticationToken);
-    assertTrue(auth.getOriginalAuthentication().isPresent());
-    assertEquals(originalAuth, auth.getOriginalAuthentication().get());
+    assertSame(originalAuth, auth.getOriginalAuthentication());
     assertTrue(getAuthentication() instanceof UsernamePasswordAuthenticationToken);
   }
 
@@ -65,6 +66,15 @@ class RunAsSystemAspectTest extends AbstractMockitoSpringContextTests {
     assertTrue(originalAuth instanceof SystemSecurityToken);
     assertSame(originalAuth, runAsSystem(this::getAuthentication));
     assertSame(originalAuth, getAuthentication());
+  }
+
+  @Test
+  void testRunAsSystemWithoutAuthentication() {
+    var auth = runAsSystem(this::getAuthentication);
+
+    assertTrue(auth instanceof SystemSecurityToken);
+    assertFalse(auth instanceof RunAsSystemToken);
+    assertNull(getAuthentication());
   }
 
   private Authentication getAuthentication() {

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/RunAsSystemTokenTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/RunAsSystemTokenTest.java
@@ -1,0 +1,42 @@
+package org.molgenis.security.core.runas;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+
+class RunAsSystemTokenTest {
+
+  @Test
+  public void testRunAsSystemAsSystem() {
+    var systemSecurityToken = mock(SystemSecurityToken.class);
+    assertThrows(IllegalStateException.class, () -> {
+      new RunAsSystemToken(systemSecurityToken);
+    });
+  }
+
+  @Test
+  public void testRunAsSystemAsRunAsSystem() {
+    var runAsSystemToken = mock(RunAsSystemToken.class);
+    assertThrows(IllegalStateException.class, () -> {
+      new RunAsSystemToken(runAsSystemToken);
+    });
+  }
+
+  @Test
+  public void testRunAsUser() {
+    var userToken = mock(UsernamePasswordAuthenticationToken.class);
+    assertDoesNotThrow(() -> {
+      new RunAsSystemToken(userToken);
+    });
+  }
+
+  @Test
+  public void testRunAsNull() {
+    assertThrows(NullPointerException.class, () -> {
+      new RunAsSystemToken(null);
+    });
+  }
+}

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/SystemSecurityTokenTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/runas/SystemSecurityTokenTest.java
@@ -23,38 +23,21 @@ class SystemSecurityTokenTest {
             new SimpleGrantedAuthority("ROLE_ACL_TAKE_OWNERSHIP"),
             new SimpleGrantedAuthority("ROLE_ACL_MODIFY_AUDITING"),
             new SimpleGrantedAuthority("ROLE_ACL_GENERAL_CHANGES"));
-    assertEquals(expectedAuthorities, SystemSecurityToken.create().getAuthorities());
+    assertEquals(expectedAuthorities, new SystemSecurityToken().getAuthorities());
   }
 
   @Test
   void testGetCredentials() {
-    assertNull(SystemSecurityToken.create().getCredentials());
+    assertNull(new SystemSecurityToken().getCredentials());
   }
 
   @Test
   void testGetPrincipal() {
-    assertTrue(SystemSecurityToken.create().getPrincipal() instanceof SystemPrincipal);
+    assertTrue(new SystemSecurityToken().getPrincipal() instanceof SystemPrincipal);
   }
 
   @Test
   void testIsAuthenticated() {
-    assertTrue(SystemSecurityToken.create().isAuthenticated());
-  }
-
-  @Test
-  void testGetOriginalAuthenticationWithElevatedUser() {
-    var user = new User("name", "password", emptySet());
-    var auth = new UsernamePasswordAuthenticationToken(user, "password", emptySet());
-
-    var originalAuth = SystemSecurityToken.createElevated(auth).getOriginalAuthentication();
-
-    assertTrue(originalAuth.isPresent());
-    assertEquals(auth, originalAuth.get());
-  }
-
-  @Test
-  void testGetOriginalAuthenticationWithoutElevatedUser() {
-    var originalAuth = SystemSecurityToken.create().getOriginalAuthentication();
-    assertFalse(originalAuth.isPresent());
+    assertTrue(new SystemSecurityToken().isAuthenticated());
   }
 }

--- a/molgenis-security-core/src/test/java/org/molgenis/security/core/utils/SecurityUtilsTest.java
+++ b/molgenis-security-core/src/test/java/org/molgenis/security/core/utils/SecurityUtilsTest.java
@@ -137,7 +137,7 @@ class SecurityUtilsTest {
   @Test
   void getCurrentUsernameSystemPrincipal() {
     try {
-      SecurityContextHolder.getContext().setAuthentication(SystemSecurityToken.create());
+      SecurityContextHolder.getContext().setAuthentication(new SystemSecurityToken());
       assertNull(SecurityUtils.getCurrentUsername());
     } finally {
       SecurityContextHolder.getContext().setAuthentication(authentication);


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
