### PR TITLE
refactor: user details service should not depend on dataservice directly

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppSecurityConfig.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppSecurityConfig.java
@@ -1,23 +1,16 @@
 package org.molgenis.app;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.ArrayList;
 import java.util.List;
 import org.molgenis.core.ui.security.MolgenisAccessDecisionVoter;
-import org.molgenis.data.DataService;
 import org.molgenis.data.postgresql.DatabaseConfig;
-import org.molgenis.data.security.DataserviceRoleHierarchy;
-import org.molgenis.data.security.auth.CachedRoleHierarchyImpl;
 import org.molgenis.data.support.DataServiceImpl;
-import org.molgenis.data.transaction.TransactionManager;
 import org.molgenis.security.MolgenisWebAppSecurityConfig;
 import org.molgenis.security.acl.AclConfig;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.access.AccessDecisionVoter;
-import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.access.vote.AffirmativeBased;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,13 +23,6 @@ import org.springframework.security.web.access.expression.WebExpressionVoter;
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class WebAppSecurityConfig extends MolgenisWebAppSecurityConfig {
-  private final DataService dataService;
-  private final TransactionManager transactionManager;
-
-  public WebAppSecurityConfig(DataService dataService, TransactionManager transactionManager) {
-    this.dataService = requireNonNull(dataService);
-    this.transactionManager = requireNonNull(transactionManager);
-  }
 
   @Override
   protected void configureUrlAuthorization(
@@ -48,12 +34,6 @@ public class WebAppSecurityConfig extends MolgenisWebAppSecurityConfig {
     expressionInterceptUrlRegistry.accessDecisionManager(new AffirmativeBased(listOfVoters));
 
     expressionInterceptUrlRegistry.antMatchers("/").permitAll();
-  }
-
-  @Override
-  public RoleHierarchy roleHierarchy() {
-    return new CachedRoleHierarchyImpl(
-        new DataserviceRoleHierarchy(dataService), transactionManager);
   }
 
   @Bean

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/RoleMembershipService.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/RoleMembershipService.java
@@ -12,6 +12,8 @@ public interface RoleMembershipService {
 
   Collection<RoleMembership> getMemberships(Collection<Role> roles);
 
+  Collection<RoleMembership> getCurrentMemberships(User user);
+
   void removeMembership(final RoleMembership roleMembership);
 
   void updateMembership(RoleMembership roleMembership, Role newRole);

--- a/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/RoleMembershipServiceImpl.java
+++ b/molgenis-data-security/src/main/java/org/molgenis/data/security/permission/RoleMembershipServiceImpl.java
@@ -1,13 +1,14 @@
 package org.molgenis.data.security.permission;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toList;
 import static org.molgenis.data.security.auth.RoleMembershipMetadata.ROLE_MEMBERSHIP;
+import static org.molgenis.data.security.auth.RoleMembershipMetadata.USER;
 import static org.molgenis.data.security.auth.RoleMetadata.NAME;
 import static org.molgenis.data.security.auth.UserMetadata.USERNAME;
 
 import java.time.Instant;
 import java.util.Collection;
-import java.util.stream.Collectors;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Fetch;
 import org.molgenis.data.UnknownEntityException;
@@ -108,6 +109,16 @@ public class RoleMembershipServiceImpl implements RoleMembershipService {
         .fetch(fetch)
         .findAll()
         .filter(RoleMembership::isCurrent)
-        .collect(Collectors.toList());
+        .collect(toList());
+  }
+
+  @Override
+  public Collection<RoleMembership> getCurrentMemberships(User user) {
+    return dataService
+        .query(ROLE_MEMBERSHIP, RoleMembership.class)
+        .eq(USER, user)
+        .findAll()
+        .filter(RoleMembership::isCurrent)
+        .collect(toList());
   }
 }

--- a/molgenis-data-security/src/test/java/org/molgenis/data/security/permission/RoleMembershipServiceImplTest.java
+++ b/molgenis-data-security/src/test/java/org/molgenis/data/security/permission/RoleMembershipServiceImplTest.java
@@ -188,4 +188,30 @@ class RoleMembershipServiceImplTest extends AbstractMockitoTest {
     assertEquals(
         singletonList(roleMembership), roleMembershipService.getMemberships(of(editor, viewer)));
   }
+
+  @Test
+  void testGetCurrentMemberships() {
+    User user = mock(User.class);
+
+    Fetch roleFetch = new Fetch().field(RoleMetadata.NAME).field(RoleMetadata.LABEL);
+    Fetch userFetch = new Fetch().field(UserMetadata.USERNAME).field(UserMetadata.ID);
+    Fetch fetch =
+        new Fetch()
+            .field(RoleMembershipMetadata.ROLE, roleFetch)
+            .field(RoleMembershipMetadata.USER, userFetch)
+            .field(RoleMembershipMetadata.FROM)
+            .field(RoleMembershipMetadata.TO)
+            .field(RoleMembershipMetadata.ID);
+
+    @SuppressWarnings("unchecked")
+    Query<RoleMembership> query = mock(Query.class, RETURNS_SELF);
+    when(dataService.query(RoleMembershipMetadata.ROLE_MEMBERSHIP, RoleMembership.class))
+        .thenReturn(query);
+    when(query.eq(RoleMembershipMetadata.USER, user).fetch(fetch).findAll())
+        .thenReturn(Stream.of(oldRoleMembership, roleMembership));
+
+    when(roleMembership.isCurrent()).thenReturn(true);
+
+    assertEquals(singletonList(roleMembership), roleMembershipService.getCurrentMemberships(user));
+  }
 }

--- a/molgenis-security/src/main/java/org/molgenis/security/SecurityConfig.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/SecurityConfig.java
@@ -11,14 +11,19 @@ import org.molgenis.security.core.MolgenisPasswordEncoder;
 import org.molgenis.security.oidc.MappedOidcUserService;
 import org.molgenis.security.oidc.OidcUserMapper;
 import org.molgenis.security.oidc.OidcUserMapperImpl;
+import org.molgenis.security.oidc.ResettableOAuth2AuthorizedClientService;
 import org.molgenis.security.oidc.model.OidcUserMappingFactory;
+import org.molgenis.security.user.MolgenisUserDetailsChecker;
 import org.molgenis.security.user.UserDetailsServiceImpl;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
 import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.core.userdetails.UserDetailsChecker;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 @Configuration
 public class SecurityConfig {
@@ -29,6 +34,11 @@ public class SecurityConfig {
       UserService userService,
       RoleMembershipService roleMembershipService) {
     return new UserDetailsServiceImpl(authoritiesMapper, userService, roleMembershipService);
+  }
+
+  @Bean
+  public UserDetailsChecker userDetailsChecker() {
+    return new MolgenisUserDetailsChecker();
   }
 
   @Bean
@@ -52,6 +62,12 @@ public class SecurityConfig {
       OidcUserMappingFactory oidcUserMappingFactory,
       UserFactory userFactory) {
     return new OidcUserMapperImpl(dataService, oidcUserMappingFactory, userFactory);
+  }
+
+  @Bean
+  public OAuth2AuthorizedClientService authorizedClientService(
+      ClientRegistrationRepository clientRegistrationRepository) {
+    return new ResettableOAuth2AuthorizedClientService(clientRegistrationRepository);
   }
 
   @Bean

--- a/molgenis-security/src/main/java/org/molgenis/security/SecurityConfig.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/SecurityConfig.java
@@ -1,0 +1,61 @@
+package org.molgenis.security;
+
+import org.molgenis.data.DataService;
+import org.molgenis.data.security.DataserviceRoleHierarchy;
+import org.molgenis.data.security.auth.CachedRoleHierarchyImpl;
+import org.molgenis.data.security.auth.UserFactory;
+import org.molgenis.data.security.permission.RoleMembershipService;
+import org.molgenis.data.security.user.UserService;
+import org.molgenis.data.transaction.TransactionManager;
+import org.molgenis.security.core.MolgenisPasswordEncoder;
+import org.molgenis.security.oidc.MappedOidcUserService;
+import org.molgenis.security.oidc.OidcUserMapper;
+import org.molgenis.security.oidc.OidcUserMapperImpl;
+import org.molgenis.security.oidc.model.OidcUserMappingFactory;
+import org.molgenis.security.user.UserDetailsServiceImpl;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.core.authority.mapping.GrantedAuthoritiesMapper;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+  @Bean
+  public UserDetailsServiceImpl userDetailsService(
+      GrantedAuthoritiesMapper authoritiesMapper,
+      UserService userService,
+      RoleMembershipService roleMembershipService) {
+    return new UserDetailsServiceImpl(authoritiesMapper, userService, roleMembershipService);
+  }
+
+  @Bean
+  public RoleHierarchy roleHierarchy(
+      DataService dataService, TransactionManager transactionManager) {
+    return new CachedRoleHierarchyImpl(
+        new DataserviceRoleHierarchy(dataService), transactionManager);
+  }
+
+  @Bean
+  public MappedOidcUserService oidcUserService(
+      OidcUserMapper oidcUserMapper,
+      UserDetailsServiceImpl userDetailsService,
+      DataService dataService) {
+    return new MappedOidcUserService(oidcUserMapper, userDetailsService, dataService);
+  }
+
+  @Bean
+  public OidcUserMapper oidcUserMapper(
+      DataService dataService,
+      OidcUserMappingFactory oidcUserMappingFactory,
+      UserFactory userFactory) {
+    return new OidcUserMapperImpl(dataService, oidcUserMappingFactory, userFactory);
+  }
+
+  @Bean
+  public PasswordEncoder passwordEncoder() {
+    return new MolgenisPasswordEncoder(new BCryptPasswordEncoder());
+  }
+}


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
