### PR TITLE
M4347: Fix LocaleResolver throwing when running as system

### DIFF
--- a/molgenis-web/pom.xml
+++ b/molgenis-web/pom.xml
@@ -124,6 +124,13 @@
     </dependency>
     <dependency>
       <groupId>org.molgenis</groupId>
+      <artifactId>molgenis-security-core</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.molgenis</groupId>
       <artifactId>molgenis-test</artifactId>
       <version>${project.version}</version>
       <scope>test</scope>

--- a/molgenis-web/src/main/java/org/molgenis/web/i18n/HttpLocaleResolver.java
+++ b/molgenis-web/src/main/java/org/molgenis/web/i18n/HttpLocaleResolver.java
@@ -31,7 +31,7 @@ public class HttpLocaleResolver implements LocaleResolver {
 
   @Override
   public Locale resolveLocale(HttpServletRequest request) {
-    String username = SecurityUtils.getCurrentUsername();
+    String username = SecurityUtils.getActualUsername();
 
     Locale locale;
     if (username != null) {
@@ -45,7 +45,7 @@ public class HttpLocaleResolver implements LocaleResolver {
 
   @Override
   public void setLocale(HttpServletRequest request, HttpServletResponse response, Locale locale) {
-    String username = SecurityUtils.getCurrentUsername();
+    String username = SecurityUtils.getActualUsername();
     if (username == null) {
       throw new UnsupportedOperationException("Cannot change language if not logged in");
     }

--- a/molgenis-web/src/test/java/org/molgenis/web/i18n/HttpLocaleResolverTest.java
+++ b/molgenis-web/src/test/java/org/molgenis/web/i18n/HttpLocaleResolverTest.java
@@ -17,6 +17,7 @@ import org.mockito.Mock;
 import org.molgenis.data.security.auth.User;
 import org.molgenis.data.security.user.UnknownUserException;
 import org.molgenis.data.security.user.UserService;
+import org.molgenis.security.core.WithMockSystemUser;
 import org.molgenis.test.AbstractMockitoSpringContextTests;
 import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -45,6 +46,15 @@ class HttpLocaleResolverTest extends AbstractMockitoSpringContextTests {
     assertEquals(GERMAN, httpLocaleResolver.resolveLocale(httpServletRequest));
   }
 
+  @WithMockSystemUser(originalUsername = "user")
+  @Test
+  void testResolveLocaleAuthenticatedElevated() {
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    String username = "user";
+    when(userLocaleResolver.resolveLocale(username)).thenReturn(Locale.GERMAN);
+    assertEquals(GERMAN, httpLocaleResolver.resolveLocale(httpServletRequest));
+  }
+
   @Test
   void testResolveLocaleNotAuthenticated() {
     HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
@@ -55,6 +65,22 @@ class HttpLocaleResolverTest extends AbstractMockitoSpringContextTests {
   @WithMockUser
   @Test
   void testSetLocaleAuthenticated() {
+    HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+    HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
+    Locale locale = GERMAN;
+
+    String username = "user";
+    User user = mock(User.class);
+    when(userService.getUser(username)).thenReturn(user);
+    httpLocaleResolver.setLocale(httpServletRequest, httpServletResponse, locale);
+
+    verify(user).setLanguageCode(locale.getLanguage());
+    verify(userService).update(user);
+  }
+
+  @WithMockSystemUser(originalUsername = "user")
+  @Test
+  void testSetLocaleAuthenticatedElevated() {
     HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
     HttpServletResponse httpServletResponse = mock(HttpServletResponse.class);
     Locale locale = GERMAN;


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [x] Migration step added in case of breaking change
- [x] User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
