### PR TITLE
feat: configure max file size as runtime property

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppInitializer.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppInitializer.java
@@ -9,6 +9,6 @@ public class WebAppInitializer extends MolgenisWebAppInitializer
   @Override
   public void onStartup(ServletContext servletContext) {
     servletContext.addListener(new WebAppContextCleanupListener());
-    super.onStartup(servletContext, WebAppConfig.class, 150);
+    super.onStartup(servletContext, WebAppConfig.class);
   }
 }


### PR DESCRIPTION
Allows you to override max file upload size with system property `max.file.mb`.
The default remains 150MiB

In Tomcat:
* can be added to `JAVA_OPTS` or `CATALINA_OPTS` (`-Dmax.file.mb=512`)
* or specified in `catalina.properties`
* or as a parameter in `context.xml` 

In Docker:
* The container sets a context parameter from environment variable `MOLGENIS_MAX_FILE_MB`

In an app war:
* The default can still be overridden by subclassing the WebAppInitializer

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] Migration step added in case of breaking change
- [x] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
