### PR TITLE
Remove Data Explorer from default menu

### DIFF
--- a/molgenis-app/src/main/resources/molgenis_ui.json
+++ b/molgenis-app/src/main/resources/molgenis_ui.json
@@ -31,11 +31,6 @@
       "label": "Navigator"
     },
     {
-      "type": "plugin",
-      "id": "dataexplorer",
-      "label": "Data Explorer"
-    },
-    {
       "type": "menu",
       "id": "dataintegration",
       "label": "Data Integration",


### PR DESCRIPTION
The Navigator will automatically switch to the Data Explorer 2.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
