### PR TITLE
Rename AUDIT_SETTING_CHANGED to SETTING_CHANGED

### DIFF
--- a/molgenis-security/src/main/java/org/molgenis/security/audit/AuditSettingsRepositoryDecorator.java
+++ b/molgenis-security/src/main/java/org/molgenis/security/audit/AuditSettingsRepositoryDecorator.java
@@ -17,7 +17,7 @@ import org.molgenis.data.Repository;
  */
 public class AuditSettingsRepositoryDecorator extends AbstractRepositoryDecorator<Entity> {
 
-  static final String AUDIT_SETTING_CHANGED = "AUDIT_SETTING_CHANGED";
+  static final String SETTING_CHANGED = "SETTING_CHANGED";
   private final AuditEventPublisher auditEventPublisher;
 
   public AuditSettingsRepositoryDecorator(
@@ -55,7 +55,7 @@ public class AuditSettingsRepositoryDecorator extends AbstractRepositoryDecorato
                 data.put("oldValue", oldValue);
                 data.put("newValue", newValue);
                 data.put("entityTypeId", delegate().getEntityType().getId());
-                auditEventPublisher.publish(getActualUsername(), AUDIT_SETTING_CHANGED, data);
+                auditEventPublisher.publish(getActualUsername(), SETTING_CHANGED, data);
               }
             });
 

--- a/molgenis-security/src/test/java/org/molgenis/security/audit/AuditSettingsRepositoryDecoratorTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/audit/AuditSettingsRepositoryDecoratorTest.java
@@ -4,7 +4,7 @@ import static java.util.Arrays.asList;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.molgenis.security.audit.AuditSettingsRepositoryDecorator.AUDIT_SETTING_CHANGED;
+import static org.molgenis.security.audit.AuditSettingsRepositoryDecorator.SETTING_CHANGED;
 
 import java.util.Map;
 import java.util.stream.Stream;
@@ -68,7 +68,7 @@ class AuditSettingsRepositoryDecoratorTest extends AbstractMockitoSpringContextT
     verify(auditEventPublisher)
         .publish(
             "henk",
-            AUDIT_SETTING_CHANGED,
+            SETTING_CHANGED,
             Map.of(
                 "setting",
                 "attr1",
@@ -108,7 +108,7 @@ class AuditSettingsRepositoryDecoratorTest extends AbstractMockitoSpringContextT
     verify(auditEventPublisher)
         .publish(
             "henk",
-            AUDIT_SETTING_CHANGED,
+            SETTING_CHANGED,
             Map.of(
                 "setting",
                 "attr1",
@@ -121,7 +121,7 @@ class AuditSettingsRepositoryDecoratorTest extends AbstractMockitoSpringContextT
     verify(auditEventPublisher)
         .publish(
             "henk",
-            AUDIT_SETTING_CHANGED,
+            SETTING_CHANGED,
             Map.of(
                 "setting",
                 "attr2",


### PR DESCRIPTION
This decorator audits **all** changes in settings, not just settings related to auditing.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
