### PR TITLE
Fix #9265: Template expressions escape their values

### DIFF
--- a/molgenis-data/src/main/java/org/molgenis/data/support/TemplateExpressionEvaluator.java
+++ b/molgenis-data/src/main/java/org/molgenis/data/support/TemplateExpressionEvaluator.java
@@ -8,6 +8,7 @@ import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
 import com.github.jknack.handlebars.Context;
+import com.github.jknack.handlebars.EscapingStrategy;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.HandlebarsException;
 import com.github.jknack.handlebars.TagType;
@@ -30,7 +31,7 @@ import org.molgenis.util.UnexpectedEnumException;
 
 public class TemplateExpressionEvaluator implements ExpressionEvaluator {
   private static final Handlebars HANDLEBARS =
-      new Handlebars().with(new ConcurrentMapTemplateCache());
+      new Handlebars().with(new ConcurrentMapTemplateCache()).with(EscapingStrategy.NOOP);
 
   private final Attribute attribute;
   private final EntityType entityType;

--- a/molgenis-data/src/test/java/org/molgenis/data/support/TemplateExpressionEvaluatorTest.java
+++ b/molgenis-data/src/test/java/org/molgenis/data/support/TemplateExpressionEvaluatorTest.java
@@ -186,6 +186,16 @@ class TemplateExpressionEvaluatorTest extends AbstractMockitoTest {
   }
 
   @Test
+  void testEvaluateShouldNotEscape() {
+    when(expressionAttribute.getExpression()).thenReturn("{\"template\":\"my {{attr}}\"}");
+    Attribute attribute = when(mock(Attribute.class).getDataType()).thenReturn(STRING).getMock();
+    when(entityType.getAttribute("attr")).thenReturn(attribute);
+    Entity entity = when(mock(Entity.class).getString("attr")).thenReturn("a>b").getMock();
+    when(entity.getEntityType()).thenReturn(entityType);
+    assertEquals("my a>b", templateExpressionEvaluator.evaluate(entity));
+  }
+
+  @Test
   void testEvaluateInt() {
     when(expressionAttribute.getExpression()).thenReturn("{\"template\":\"my {{attr}}\"}");
     Attribute attribute = when(mock(Attribute.class).getDataType()).thenReturn(INT).getMock();


### PR DESCRIPTION
Fixes #9265

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
-  User documentation updated
-  (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
