### PR TITLE
Fix #9269: Error if roles path is missing

### DIFF
--- a/molgenis-security/src/test/java/org/molgenis/security/oidc/MappedOidcUserServiceTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/oidc/MappedOidcUserServiceTest.java
@@ -15,6 +15,7 @@ import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.S
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -248,20 +249,18 @@ class MappedOidcUserServiceTest extends AbstractMockitoTest {
                 Set.of("ROLE_A")));
   }
 
-  private static Stream<Arguments> getRolesFromClaimSource() {
+  private static Stream<Arguments> getStreamClaimsArguments() {
     return Stream.of(
-        Arguments.of(
-            Map.of("roles", List.of("A", "B")),
-            Map.of(CLAIMS_ROLE_PATH, "roles"),
-            Set.of("ROLE_A", "ROLE_B")),
-        Arguments.of(Map.of(), Map.of(CLAIMS_ROLE_PATH, "roles"), Set.of()));
+        Arguments.of(Map.of("claimName", List.of("urn:foo:bar")), Set.of("urn:foo:bar")),
+        Arguments.of(Map.of(), Set.of()));
   }
 
   @ParameterizedTest
-  @MethodSource("getRolesFromClaimSource")
-  void testGetRolesFromClaim(
-      Map<String, Object> claims, Map<String, Object> configurationMetadata, Set<String> expected) {
-    assertEquals(expected, MappedOidcUserService.getRolesFromClaim(claims, configurationMetadata));
+  @MethodSource("getStreamClaimsArguments")
+  void testStreamClaims(Map<String, Object> claims, Set<String> expected) {
+    assertEquals(
+        expected,
+        MappedOidcUserService.streamClaimsForPath(claims, "claimName").collect(Collectors.toSet()));
   }
 
   @Test

--- a/molgenis-security/src/test/java/org/molgenis/security/oidc/MappedOidcUserServiceTest.java
+++ b/molgenis-security/src/test/java/org/molgenis/security/oidc/MappedOidcUserServiceTest.java
@@ -15,8 +15,12 @@ import static org.springframework.security.oauth2.core.oidc.StandardClaimNames.S
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.molgenis.audit.AuditEventPublisher;
@@ -242,6 +246,22 @@ class MappedOidcUserServiceTest extends AbstractMockitoTest {
                 Set.of("urn:mace:surf.nl:sram:group:molgenis:dev"),
                 "rolesFromVoGroupsClaim",
                 Set.of("ROLE_A")));
+  }
+
+  private static Stream<Arguments> getRolesFromClaimSource() {
+    return Stream.of(
+        Arguments.of(
+            Map.of("roles", List.of("A", "B")),
+            Map.of(CLAIMS_ROLE_PATH, "roles"),
+            Set.of("ROLE_A", "ROLE_B")),
+        Arguments.of(Map.of(), Map.of(CLAIMS_ROLE_PATH, "roles"), Set.of()));
+  }
+
+  @ParameterizedTest
+  @MethodSource("getRolesFromClaimSource")
+  void testGetRolesFromClaim(
+      Map<String, Object> claims, Map<String, Object> configurationMetadata, Set<String> expected) {
+    assertEquals(expected, MappedOidcUserService.getRolesFromClaim(claims, configurationMetadata));
   }
 
   @Test


### PR DESCRIPTION
- fix: return null if path is not present in the claims
- refactor: extract shared claims path code

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
-  Migration step added in case of breaking change
-  User documentation updated
-  (If you have changed REST API interface) view-swagger.ftl updated
-  Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
