### PR TITLE
chore(dev-env): switch to kibana image without xpack

### DIFF
--- a/molgenis-app/dev-env/docker-compose.yml
+++ b/molgenis-app/dev-env/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       - 9300:9300
 
   kibana:
-    image: docker.elastic.co/kibana/kibana:5.5.3
+    image: molgenis/molgenis-kibana:1.0.0
     ports:
       - 5601:5601
 


### PR DESCRIPTION
Depends on https://github.com/molgenis/molgenis-ops-docker/pull/96

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
