### PR TITLE
Fix #9207: N/A option appears when enum or categorical is not mandatory

### DIFF
--- a/molgenis-app/src/main/java/org/molgenis/app/WebAppPermissionRegistry.java
+++ b/molgenis-app/src/main/java/org/molgenis/app/WebAppPermissionRegistry.java
@@ -2,6 +2,7 @@ package org.molgenis.app;
 
 import static org.molgenis.beacon.config.BeaconPackage.PACKAGE_BEACON;
 import static org.molgenis.core.ui.data.system.core.FreemarkerTemplateMetadata.FREEMARKER_TEMPLATE;
+import static org.molgenis.core.ui.settings.FormSettings.FORM_SETTINGS;
 import static org.molgenis.data.decorator.meta.DecoratorConfigurationMetadata.DECORATOR_CONFIGURATION;
 import static org.molgenis.data.file.model.FileMetaMetadata.FILE_META;
 import static org.molgenis.data.i18n.model.L10nStringMetadata.L10N_STRING;
@@ -31,6 +32,7 @@ import static org.molgenis.security.core.SidUtils.createAnonymousSid;
 import static org.molgenis.security.core.SidUtils.createAuthoritySid;
 import static org.molgenis.security.core.utils.SecurityUtils.AUTHORITY_USER;
 import static org.molgenis.settings.SettingsPackage.PACKAGE_SETTINGS;
+import static org.molgenis.settings.entity.DataExplorerEntitySettings.DATA_EXPLORER_ENTITY_SETTINGS;
 
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -53,7 +55,6 @@ import org.molgenis.questionnaires.controller.QuestionnaireController;
 import org.molgenis.searchall.controller.SearchAllPluginController;
 import org.molgenis.security.core.PermissionSet;
 import org.molgenis.securityui.controller.SecurityUiController;
-import org.molgenis.settings.entity.DataExplorerEntitySettings;
 import org.molgenis.util.Pair;
 import org.springframework.security.acls.domain.ObjectIdentityImpl;
 import org.springframework.security.acls.model.ObjectIdentity;
@@ -63,6 +64,7 @@ import org.springframework.stereotype.Component;
 /** Registry of permissions specific for this web application. */
 @Component
 public class WebAppPermissionRegistry implements PermissionRegistry {
+
   private ImmutableMultimap.Builder<ObjectIdentity, Pair<PermissionSet, Sid>> builder =
       new ImmutableMultimap.Builder<>();
 
@@ -122,8 +124,8 @@ public class WebAppPermissionRegistry implements PermissionRegistry {
     register(PACKAGE, PACKAGE_ONTOLOGY, viewer, READ);
     register(PACKAGE, PACKAGE_META, viewer, READ);
     register(PACKAGE, PACKAGE_SYSTEM, viewer, READMETA);
-    register(
-        ENTITY_TYPE, DataExplorerEntitySettings.DATA_EXPLORER_ENTITY_SETTINGS, anonymousRole, READ);
+    register(ENTITY_TYPE, DATA_EXPLORER_ENTITY_SETTINGS, anonymousRole, READ);
+    register(ENTITY_TYPE, FORM_SETTINGS, anonymousRole, READ);
   }
 
   @Override

--- a/molgenis-core-ui/src/main/java/org/molgenis/core/ui/settings/FormSettings.java
+++ b/molgenis-core-ui/src/main/java/org/molgenis/core/ui/settings/FormSettings.java
@@ -1,0 +1,69 @@
+package org.molgenis.core.ui.settings;
+
+import static org.molgenis.data.meta.AttributeType.BOOL;
+
+import org.molgenis.settings.DefaultSettingsEntity;
+import org.molgenis.settings.DefaultSettingsEntityType;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FormSettings extends DefaultSettingsEntity {
+  public static final String FORM_SETTINGS = "sys_set_forms";
+  public static final String ADD_CATEGORICAL_NULL_OPTION = "addCategoricalNullOption";
+  public static final String ADD_ENUM_NULL_OPTION = "addEnumNullOption";
+  public static final String ADD_BOOLEAN_NULL_OPTION = "addBooleanNullOption";
+
+  static final String ID = "forms";
+
+  public FormSettings() {
+    super(ID);
+  }
+
+  public boolean isAddCategoricalNullOption() {
+    return getBoolean(ADD_CATEGORICAL_NULL_OPTION);
+  }
+
+  public boolean isAddEnumNullOption() {
+    return getBoolean(ADD_ENUM_NULL_OPTION);
+  }
+
+  public boolean isAddBooleanNullOption() {
+    return getBoolean(ADD_BOOLEAN_NULL_OPTION);
+  }
+
+  @Component
+  public static class Meta extends DefaultSettingsEntityType {
+
+    public Meta() {
+      super(ID);
+    }
+
+    @Override
+    public void init() {
+      super.init();
+      setLabel("Form settings");
+
+      addAttribute(ADD_ENUM_NULL_OPTION)
+          .setDataType(BOOL)
+          .setNillable(false)
+          .setDefaultValue(String.valueOf(true))
+          .setLabel("Add null option to nullable enums")
+          .setDescription(
+              "Add an extra option for the radio button list of nullable enum attributes, to allow deselection.");
+      addAttribute(ADD_BOOLEAN_NULL_OPTION)
+          .setDataType(BOOL)
+          .setNillable(false)
+          .setDefaultValue(String.valueOf(true))
+          .setLabel("Add null option to nullable booleans")
+          .setDescription(
+              "Add an extra option for the radio button list of nullable boolean attributes, to allow deselection.");
+      addAttribute(ADD_CATEGORICAL_NULL_OPTION)
+          .setDataType(BOOL)
+          .setNillable(false)
+          .setDefaultValue(String.valueOf(true))
+          .setLabel("Add null option to nullable categoricals")
+          .setDescription(
+              "Add an an extra option for the radio button list of nullable categorical attributes, to allow deselection.");
+    }
+  }
+}

--- a/molgenis-data-row-edit/src/main/java/org/molgenis/datarowedit/controller/DataRowEditController.java
+++ b/molgenis-data-row-edit/src/main/java/org/molgenis/datarowedit/controller/DataRowEditController.java
@@ -2,6 +2,7 @@ package org.molgenis.datarowedit.controller;
 
 import static java.util.Objects.requireNonNull;
 
+import org.molgenis.core.ui.settings.FormSettings;
 import org.molgenis.dataexplorer.controller.DataExplorerController;
 import org.molgenis.settings.AppSettings;
 import org.molgenis.web.PluginController;
@@ -21,11 +22,14 @@ public class DataRowEditController extends PluginController {
   public static final String VIEW_TEMPLATE = "view-data-row-edit";
   private final MenuReaderService menuReaderService;
 
-  private AppSettings appSettings;
+  private final AppSettings appSettings;
+  private final FormSettings formSettings;
 
-  DataRowEditController(MenuReaderService menuReaderService, AppSettings appSettings) {
+  DataRowEditController(
+      MenuReaderService menuReaderService, AppSettings appSettings, FormSettings formSettings) {
     super(URI);
     this.appSettings = requireNonNull(appSettings);
+    this.formSettings = requireNonNull(formSettings);
     this.menuReaderService = requireNonNull(menuReaderService);
   }
 
@@ -36,6 +40,7 @@ public class DataRowEditController extends PluginController {
     model.addAttribute("fallbackLng", appSettings.getLanguageCode());
     model.addAttribute(
         "dataExplorerBaseUrl", menuReaderService.findMenuItemPath(DataExplorerController.ID));
+    model.addAttribute("formSettings", formSettings);
     return VIEW_TEMPLATE;
   }
 }

--- a/molgenis-data-row-edit/src/main/resources/templates/view-data-row-edit.ftl
+++ b/molgenis-data-row-edit/src/main/resources/templates/view-data-row-edit.ftl
@@ -15,7 +15,12 @@
     window.__INITIAL_STATE__ = {
         baseUrl: '${baseUrl}',
         lng: '${lng}',
-        fallbackLng: '${fallbackLng}'<#if dataExplorerBaseUrl??>,
+        fallbackLng: '${fallbackLng}',
+        formSettings: {
+            addBooleanNullOption: ${formSettings.addBooleanNullOption?c},
+            addCategoricalNullOption: ${formSettings.addCategoricalNullOption?c},
+            addEnumNullOption: ${formSettings.addEnumNullOption?c}
+        }<#if dataExplorerBaseUrl??>,
         dataExplorerBaseUrl: '${dataExplorerBaseUrl}'</#if>
     }
 </script>

--- a/molgenis-data-row-edit/src/test/java/org/molgenis/datarowedit/controller/DataRowEditControllerTest.java
+++ b/molgenis-data-row-edit/src/test/java/org/molgenis/datarowedit/controller/DataRowEditControllerTest.java
@@ -12,6 +12,7 @@ import static org.springframework.test.web.servlet.setup.MockMvcBuilders.standal
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
+import org.molgenis.core.ui.settings.FormSettings;
 import org.molgenis.data.security.auth.User;
 import org.molgenis.security.user.UserAccountService;
 import org.molgenis.settings.AppSettings;
@@ -28,6 +29,7 @@ class DataRowEditControllerTest {
   @Mock private MenuReaderService menuReaderService;
 
   @Mock private AppSettings appSettings;
+  @Mock private FormSettings formSettings;
 
   @Mock private UserAccountService userAccountService;
 
@@ -43,7 +45,7 @@ class DataRowEditControllerTest {
     when(user.isSuperuser()).thenReturn(false);
 
     DataRowEditController settingsController =
-        new DataRowEditController(menuReaderService, appSettings);
+        new DataRowEditController(menuReaderService, appSettings, formSettings);
     mockMvc = standaloneSetup(settingsController).build();
   }
 

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -159,8 +159,6 @@ public class DataExplorerController extends PluginController {
     model.addAttribute(
         "hasMolgenisTrackingId", null != appSettings.getGoogleAnalyticsTrackingIdMolgenis());
 
-    model.addAttribute("formSettings", formSettings);
-
     return "view-dataexplorer";
   }
 
@@ -204,6 +202,7 @@ public class DataExplorerController extends PluginController {
             "showDirectoryButton", directoryController.showDirectoryButton(entityTypeId));
         model.addAttribute(
             "NegotiatorEnabled", directoryController.showDirectoryButton(entityTypeId));
+        model.addAttribute("formSettings", formSettings);
         break;
       case MOD_ENTITIESREPORT:
         // TODO: figure out if we need to know pos and chrom attrs here

--- a/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
+++ b/molgenis-dataexplorer/src/main/java/org/molgenis/dataexplorer/controller/DataExplorerController.java
@@ -27,6 +27,7 @@ import java.util.stream.Stream;
 import javax.servlet.ServletOutputStream;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang3.StringUtils;
+import org.molgenis.core.ui.settings.FormSettings;
 import org.molgenis.data.DataService;
 import org.molgenis.data.Fetch;
 import org.molgenis.data.MolgenisDataAccessException;
@@ -104,6 +105,8 @@ public class DataExplorerController extends PluginController {
 
   @Autowired private AppSettings appSettings;
 
+  @Autowired private FormSettings formSettings;
+
   @Autowired private DataExplorerService dataExplorerService;
 
   public DataExplorerController() {
@@ -155,6 +158,8 @@ public class DataExplorerController extends PluginController {
     model.addAttribute("hasTrackingId", null != appSettings.getGoogleAnalyticsTrackingId());
     model.addAttribute(
         "hasMolgenisTrackingId", null != appSettings.getGoogleAnalyticsTrackingIdMolgenis());
+
+    model.addAttribute("formSettings", formSettings);
 
     return "view-dataexplorer";
   }

--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer-data.js
@@ -57,6 +57,7 @@
                 onRowEdit: onDataChange,
                 onRowInspect: onRowInspect,
                 onRowClick: (doShowGenomeBrowser() && isGenomeBrowserAttributesSelected()) ? onRowClick : null,
+                formSettings: self.formSettings,
                 enableInspect: canRead,
                 onSort: function (e) {
                     tableSort = {

--- a/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-data.ftl
+++ b/molgenis-dataexplorer/src/main/resources/templates/view-dataexplorer-mod-data.ftl
@@ -126,6 +126,11 @@
             $.ajax('<@resource_href "/js/dataexplorer-directory.js"/>', {'cache': true}))
             .done(function () {
             <#-- do *not* js escape values below -->
+                molgenis.dataexplorer.data.formSettings = {
+                    addBooleanNullOption: ${formSettings.addBooleanNullOption?c},
+                    addCategoricalNullOption: ${formSettings.addCategoricalNullOption?c},
+                    addEnumNullOption: ${formSettings.addEnumNullOption?c}
+                }
                 molgenis.dataexplorer.data.useDateEditRowPlugin = ${plugin_settings.use_vue_data_row_edit?c}
                 molgenis.dataexplorer.data.setGenomeBrowserSettings({
                 ${plugin_settings.gb_init_location},


### PR DESCRIPTION
- feat: add form settings entity
- feat: expose form settings in data-row-edit plugin

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] Migration step added in case of breaking change
- [ ] User documentation updated (will do later)
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [x] Test plan template updated (will do later)
- [x] Clean commits
- [ ] Added Feature/Fix to release notes
