### PR TITLE
test: fix flaky api test

### DIFF
--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/identities/IdentitiesApiControllerIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/identities/IdentitiesApiControllerIT.java
@@ -52,8 +52,9 @@ class IdentitiesApiControllerIT extends AbstractApiTests {
     anonymousID =
         given()
             .contentType(APPLICATION_JSON_VALUE)
-            .get("/api/data/sys_sec_Role?q=name=q=ANONYMOUS")
+            .get("/api/data/sys_sec_Role?q=name==ANONYMOUS")
             .then()
+            .statusCode(OK.value())
             .extract()
             .response()
             .getBody()


### PR DESCRIPTION
Don't use search query to find role anonymous.
Search query may return zero items if entity type is being reindexed.

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
