### PR TITLE
test: add api test for password change dialog

### DIFF
--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/beacon/BeaconAPIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/beacon/BeaconAPIIT.java
@@ -61,7 +61,7 @@ class BeaconAPIIT extends AbstractApiTests {
     adminToken = AbstractApiTests.getAdminToken();
 
     testUsername = "beacon_test_user" + System.currentTimeMillis();
-    createUser(adminToken, testUsername, BEACON_TEST_USER_PASSWORD);
+    createUser(adminToken, testUsername, BEACON_TEST_USER_PASSWORD, false);
 
     RestTestUtils.uploadVCFToEntity(adminToken, "/beacon_set.vcf", BEACON_SET);
 

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/identities/IdentitiesApiControllerIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/identities/IdentitiesApiControllerIT.java
@@ -45,9 +45,9 @@ class IdentitiesApiControllerIT extends AbstractApiTests {
     testUserName1 = "identities_user1_" + System.currentTimeMillis();
     testUserName2 = "identities_user2_" + System.currentTimeMillis();
     testUserName3 = "identities_user3_" + System.currentTimeMillis();
-    createUser(adminToken, testUserName1, REST_TEST_USER_PASSWORD);
-    createUser(adminToken, testUserName2, REST_TEST_USER_PASSWORD);
-    createUser(adminToken, testUserName3, REST_TEST_USER_PASSWORD);
+    createUser(adminToken, testUserName1, REST_TEST_USER_PASSWORD, false);
+    createUser(adminToken, testUserName2, REST_TEST_USER_PASSWORD, false);
+    createUser(adminToken, testUserName3, REST_TEST_USER_PASSWORD, false);
 
     anonymousID =
         given()

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/oneclickimporter/OneClickImporterControllerAPIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/oneclickimporter/OneClickImporterControllerAPIIT.java
@@ -72,7 +72,8 @@ class OneClickImporterControllerAPIIT extends AbstractApiTests {
     RestTestUtils.createPackage(adminToken, "base");
 
     oneClickImporterTestUsername = "one_click_importer_test_user" + System.currentTimeMillis();
-    createUser(adminToken, oneClickImporterTestUsername, ONE_CLICK_IMPORTER_TEST_USER_PASSWORD);
+    createUser(
+        adminToken, oneClickImporterTestUsername, ONE_CLICK_IMPORTER_TEST_USER_PASSWORD, false);
 
     setGrantedRepositoryPermissions(
         adminToken,

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/permissions/PermissionAPIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/permissions/PermissionAPIIT.java
@@ -49,8 +49,8 @@ class PermissionAPIIT extends AbstractApiTests {
 
     testUserName = "api_v2_test_user" + System.currentTimeMillis();
     testUserName2 = "api_v2_test2_user" + System.currentTimeMillis();
-    createUser(adminToken, testUserName, REST_TEST_USER_PASSWORD);
-    createUser(adminToken, testUserName2, REST_TEST_USER_PASSWORD);
+    createUser(adminToken, testUserName, REST_TEST_USER_PASSWORD, false);
+    createUser(adminToken, testUserName2, REST_TEST_USER_PASSWORD, false);
 
     ImmutableMap.<String, Permission>builder()
         .put(RoleMetadata.ROLE, READ)

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerIT.java
@@ -49,7 +49,7 @@ class RestControllerIT extends AbstractApiTests {
     adminToken = AbstractApiTests.getAdminToken();
 
     testUsername = "rest_test_user" + System.currentTimeMillis();
-    createUser(adminToken, testUsername, REST_TEST_USER_PASSWORD);
+    createUser(adminToken, testUsername, REST_TEST_USER_PASSWORD, false);
 
     setGrantedRepositoryPermissions(
         adminToken,

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerV1APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v1/RestControllerV1APIIT.java
@@ -66,7 +66,7 @@ class RestControllerV1APIIT extends AbstractApiTests {
     LOG.info("Importing Done");
 
     testUserName = "api_v1_test_user" + System.currentTimeMillis();
-    RestTestUtils.createUser(adminToken, testUserName, REST_TEST_USER_PASSWORD);
+    RestTestUtils.createUser(adminToken, testUserName, REST_TEST_USER_PASSWORD, false);
 
     LOG.info("testUserName: " + testUserName);
 

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2APIIT.java
@@ -79,7 +79,7 @@ class RestControllerV2APIIT extends AbstractApiTests {
     LOG.info("Importing Done");
 
     testUserName = "api_v2_test_user" + System.currentTimeMillis();
-    createUser(adminToken, testUserName, REST_TEST_USER_PASSWORD);
+    createUser(adminToken, testUserName, REST_TEST_USER_PASSWORD, false);
 
     setGrantedRepositoryPermissions(
         adminToken,

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2IT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/rest/v2/RestControllerV2IT.java
@@ -84,7 +84,7 @@ class RestControllerV2IT extends AbstractApiTests {
     LOG.info("Importing Done");
 
     testUsername = "rest_test_v2" + System.currentTimeMillis();
-    createUser(adminToken, testUsername, REST_TEST_USER_PASSWORD);
+    createUser(adminToken, testUsername, REST_TEST_USER_PASSWORD, false);
 
     ImmutableMap.Builder<String, Permission> permissionsBuilder = ImmutableMap.builder();
     permissionsBuilder

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/security/AccountControllerIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/security/AccountControllerIT.java
@@ -1,0 +1,69 @@
+package org.molgenis.api.tests.security;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.molgenis.api.tests.utils.RestTestUtils.X_WWW_FORM_URLENCODED;
+import static org.molgenis.api.tests.utils.RestTestUtils.createUser;
+import static org.molgenis.api.tests.utils.RestTestUtils.waitForIndexJobs;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.molgenis.api.tests.AbstractApiTests;
+import org.molgenis.api.tests.utils.RestTestUtils;
+
+@TestMethodOrder(OrderAnnotation.class)
+class AccountControllerIT extends AbstractApiTests {
+
+  private static final String password = "password";
+  private static String testUserName;
+  private static final String baseUri = "/account";
+
+  @BeforeAll
+  protected static void setUpBeforeClass() {
+    testUserName = "account_test_user" + System.currentTimeMillis();
+    AbstractApiTests.setUpBeforeClass();
+
+    String adminToken = AbstractApiTests.getAdminToken();
+
+    createUser(adminToken, testUserName, password, true);
+
+    waitForIndexJobs(adminToken);
+  }
+
+  @Test
+  void changePasswordUponLogin() {
+    var sessionId =
+        RestAssured.given()
+            .contentType(X_WWW_FORM_URLENCODED)
+            .body("username=" + testUserName + "&password=" + password)
+            .post("/login")
+            .then()
+            .statusCode(302)
+            .extract()
+            .sessionId();
+
+    var body = RestAssured.given().sessionId(sessionId).get("/").then().extract().body().asString();
+    assertTrue(
+        body.contains("change-password-modal"), "Login should redirect to change password modal");
+
+    var newPassword = "newpassword";
+    RestAssured.given()
+        .contentType(X_WWW_FORM_URLENCODED)
+        .body("password1=" + newPassword + "&password2=" + newPassword)
+        .sessionId(sessionId)
+        .post(baseUri + "/password/change")
+        .then()
+        .statusCode(302);
+
+    var bodyAfterChange =
+        RestAssured.given().sessionId(sessionId).get("/").then().extract().body().asString();
+    assertFalse(
+        bodyAfterChange.contains("change-password-modal"),
+        "Login should no longer redirect to change password modal");
+
+    RestTestUtils.login(testUserName, newPassword);
+  }
+}

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/twofactor/TwoFactorAuthenticationAPIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/twofactor/TwoFactorAuthenticationAPIIT.java
@@ -42,7 +42,7 @@ class TwoFactorAuthenticationAPIIT extends AbstractApiTests {
     adminToken = AbstractApiTests.getAdminToken();
 
     testUsername = "two_fa_auth_test_user" + System.currentTimeMillis();
-    createUser(adminToken, testUsername, TWO_FA_AUTH_TEST_USER_PASSWORD);
+    createUser(adminToken, testUsername, TWO_FA_AUTH_TEST_USER_PASSWORD, false);
   }
 
   @Test

--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/utils/RestTestUtils.java
@@ -82,15 +82,17 @@ public class RestTestUtils {
    * @param adminToken the token to use for login
    * @param username the name of the user to create
    * @param password the password of the user to create
+   * @param changePassword should the user change their password when they log in
    */
-  public static void createUser(String adminToken, String username, String password) {
+  public static void createUser(
+      String adminToken, String username, String password, boolean changePassword) {
     if (adminToken != null) {
       JSONObject createTestUserBody = new JSONObject();
       createTestUserBody.put("active", true);
       createTestUserBody.put("username", username);
       createTestUserBody.put("password_", password);
       createTestUserBody.put("superuser", false);
-      createTestUserBody.put("changePassword", false);
+      createTestUserBody.put("changePassword", changePassword);
       createTestUserBody.put("Email", username + "@example.com");
 
       given()


### PR DESCRIPTION
The validator for the password change request is a bit exotic.
Add an API IT to make sure it still works.

#### Checklist
- Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- [x] (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- Added Feature/Fix to release notes
