### PR TITLE
feat(util): integer scramble

### DIFF
--- a/molgenis-util/src/main/java/org/molgenis/util/IntScrambler.java
+++ b/molgenis-util/src/main/java/org/molgenis/util/IntScrambler.java
@@ -1,0 +1,64 @@
+package org.molgenis.util;
+
+import static java.lang.Integer.remainderUnsigned;
+import static java.lang.Math.round;
+import static java.lang.Math.sqrt;
+
+import java.math.BigInteger;
+import java.text.DecimalFormat;
+import java.util.regex.Pattern;
+
+/**
+ * Scrambles the integers in the space <code>0,...,M-1</code> using <a
+ * href="https://en.wikipedia.org/wiki/Hash_function#Fibonacci_hashing" target="_top">Fibonacci
+ * hashing</a>.
+ *
+ * <p>We want to scramble, not hash, so we set <code>W = M = 2^m</code>. This removes the range
+ * reducing bit shift at the end of the operation. The scramble function then is simply <code>
+ * k -> ak mod M</code> This scramble version can be inverted, which means that a scrambled sequence
+ * of unique numbers is still unique.
+ */
+public class IntScrambler {
+
+  // the golden ratio
+  private static final double PHI = (1 + sqrt(5)) / 2;
+  private final int a;
+  private final int M;
+
+  /**
+   * Create a new scrambler.
+   *
+   * @param m the maximum number of bits the scrambled ints will have
+   */
+  IntScrambler(int m) {
+    M = 2 << m;
+    // Choose a close to W / phi
+    // but make sure a and M are relatively prime
+    int aCandidate = (int) round(M / PHI);
+    while (!bigIntegerRelativelyPrime(aCandidate, M)) {
+      aCandidate++;
+    }
+    a = aCandidate;
+  }
+
+  public static IntScrambler forDecimalFormat(DecimalFormat decimalFormat) {
+    var matcher = Pattern.compile("0+").matcher(decimalFormat.toPattern());
+    matcher.find();
+    var zeroes = matcher.group(0).length();
+    var maxValue = (int) Math.pow(10, zeroes);
+    var m = 30 - Integer.numberOfLeadingZeros(maxValue - 1);
+    return new IntScrambler(m);
+  }
+
+  private boolean bigIntegerRelativelyPrime(int a, int b) {
+    return BigInteger.valueOf(a).gcd(BigInteger.valueOf(b)).equals(BigInteger.ONE);
+  }
+
+  public int scramble(int k) {
+    return remainderUnsigned(k * a, M);
+  }
+
+  public int getMaxValue() {
+    return M - 1;
+  }
+}

--- a/molgenis-util/src/test/java/org/molgenis/util/IntScramblerTest.java
+++ b/molgenis-util/src/test/java/org/molgenis/util/IntScramblerTest.java
@@ -1,0 +1,42 @@
+package org.molgenis.util;
+
+import static java.util.stream.Collectors.toSet;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.text.DecimalFormat;
+import java.util.stream.IntStream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class IntScramblerTest {
+
+  @ParameterizedTest
+  @ValueSource(ints = {5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19})
+  void scramble(int m) {
+    var scrambler = new IntScrambler(m);
+    final var M = scrambler.getMaxValue() + 1;
+    var values = IntStream.range(0, M).boxed().collect(toSet());
+    var scrambled = values.stream().map(scrambler::scramble).collect(toSet());
+    assertEquals(values, scrambled);
+  }
+
+  public static Object[][] forDecimalFormat() {
+    return new Object[][] {
+      {"GEN'-'0", 9},
+      {"GEN'-'0000", 9999},
+      {"GEN'-'0000000", 9999999}
+    };
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void forDecimalFormat(String formatString, int maxmax) {
+    var format = new DecimalFormat(formatString);
+    var scrambler = IntScrambler.forDecimalFormat(format);
+    var maxValue = scrambler.getMaxValue();
+    assertTrue(maxValue < maxmax);
+    assertTrue(maxValue > maxmax / 2);
+  }
+}


### PR DESCRIPTION
Scrambles integers from 0..2^m-1

This was going to be used to generate non-sequential pseudonyms but is no longer needed there.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- [NA] Migration step added in case of breaking change
- [NA] User documentation updated
- [NA] (If you have changed REST API interface) view-swagger.ftl updated
- [NA] Test plan template updated
- [x] Clean commits
- [NA] Added Feature/Fix to release notes
