### PR TITLE
feat: have compounds be visible by default in the dataexplorer

### DIFF
--- a/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
+++ b/molgenis-dataexplorer/src/main/resources/js/dataexplorer.js
@@ -354,7 +354,7 @@ $.when($,
                     // If the state is empty or undefined, or is set to
                     // 'none', return null. All attributes will be shown
                     if (state.attrs === undefined || state.attrs === null) {
-                        if (attribute.fieldType !== 'COMPOUND') selectedAttributes.push(attribute);
+                        selectedAttributes.push(attribute);
                     } else if (state.attrs === 'none') {
                         selectedAttributes = [];
                     } else {


### PR DESCRIPTION
https://trac.molgeniscloud.org/ticket/8659

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
