### PR TITLE
Data Explorer mref filter uses LIKE instead of SEARCH

### DIFF
--- a/molgenis-core-ui/src/main/resources/js/jquery.molgenis.xrefmrefsearch.js
+++ b/molgenis-core-ui/src/main/resources/js/jquery.molgenis.xrefmrefsearch.js
@@ -19,7 +19,7 @@
     var restApi = new molgenis.RestClient();
 
     function getInexactQueryOperator(fieldType) {
-        var operator = 'SEARCH';
+        var operator = 'LIKE';
         switch (fieldType) {
             case 'INT':
             case 'LONG':


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [x] Added Feature/Fix to release notes
