### PR TITLE
Fix: jenkins skips release branches >9

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -98,7 +98,7 @@ pipeline {
         }
         stage('Steps [ x.x ]') {
             when {
-                expression { BRANCH_NAME ==~ /[0-9]\.[0-9]/ }
+                expression { BRANCH_NAME ==~ /[0-9]+\.[0-9]+/ }
                 beforeAgent true
             }
             agent {


### PR DESCRIPTION
#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
