### PR TITLE
Fix #9376: molgenis no longer waits for elasticsearch

### DIFF
--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/ClientFactory.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/client/ClientFactory.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.http.HttpHost;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestHighLevelClient;
@@ -65,7 +66,7 @@ class ClientFactory {
                 "Failed to connect to Elasticsearch cluster on %s. Is Elasticsearch running?",
                 hostnames));
       }
-    } catch (IOException e) {
+    } catch (ElasticsearchException | IOException e) {
       LOG.error(
           "Failed to connect to Elasticsearch cluster on {}. Retry count = {}",
           hostnames,


### PR DESCRIPTION
#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [ ] Added Feature/Fix to release notes
