### PR TITLE
Build reports are not always needed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
     <molgenis-expressions.version>0.21.1</molgenis-expressions.version>
     <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
     <maven-site-plugin.version>3.10.0</maven-site-plugin.version>
+  	<closeTestReports>true</closeTestReports>
   </properties>
 
   <distributionManagement>
@@ -614,6 +615,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+        	<disableXmlReport>${closeTestReports}</disableXmlReport>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <molgenis-expressions.version>0.21.1</molgenis-expressions.version>
     <maven-project-info-reports-plugin.version>3.1.2</maven-project-info-reports-plugin.version>
     <maven-site-plugin.version>3.10.0</maven-site-plugin.version>
-  	<closeTestReports>true</closeTestReports>
+    <closeTestReports>true</closeTestReports>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
