### PR TITLE
Fix #9386: introduce custom _all field for searchAll behaviour

### DIFF
--- a/molgenis-api-tests/src/test/java/org/molgenis/api/tests/search/SearchAPIIT.java
+++ b/molgenis-api-tests/src/test/java/org/molgenis/api/tests/search/SearchAPIIT.java
@@ -12,7 +12,6 @@ import static org.molgenis.api.tests.utils.RestTestUtils.X_MOLGENIS_TOKEN;
 import static org.molgenis.api.tests.utils.RestTestUtils.removePackages;
 import static org.molgenis.api.tests.utils.RestTestUtils.uploadEmxFile;
 import static org.molgenis.api.tests.utils.RestTestUtils.waitForIndexJobs;
-import static org.slf4j.LoggerFactory.getLogger;
 
 import io.restassured.response.ValidatableResponse;
 import java.io.File;
@@ -32,11 +31,9 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.molgenis.api.tests.AbstractApiTests;
-import org.slf4j.Logger;
 
 @TestMethodOrder(OrderAnnotation.class)
 class SearchAPIIT extends AbstractApiTests {
-  private static final Logger LOG = getLogger(SearchAPIIT.class);
   private static String adminToken;
 
   private static File createEMX() {

--- a/molgenis-api-tests/src/test/resources/org/molgenis/api/tests/search/search_disease_types-cases.tsv
+++ b/molgenis-api-tests/src/test/resources/org/molgenis/api/tests/search/search_disease_types-cases.tsv
@@ -15,6 +15,7 @@
 "DT014"	"code"	"LIKE"	"ORPHA:100"	"45"	"ORPHA:100,ORPHA:1000,ORPHA:100008"	"Finds substrings at the start"
 "DT015"	"label"	"LIKE"	"lvé"	"2"	"ORPHA:2380,urn:miriam:icd:M91.1"	"Finds substrings with accents"
 "DT016"	"label"	"LIKE"	"calve"	"0"		"Postgres ILIKE does not do ascii folding [SHOULD FIND MATCHES]"
-"DT017"	"*"	"SEARCH_QUERY"	"E26* -unspecified"	"4"	"urn:miriam:icd:E26,urn:miriam:icd:E26.0"	"Simple query string search query searches across fields"
+"DT017"	"*"	"SEARCH_QUERY"	"E26* -unspecified"	"4"	"urn:miriam:icd:E26.0,urn:miriam:icd:E20-E35"	"Simple query string search query searches across fields"
 "DT018"	"label"	"SEARCH_QUERY"	"aciduria type 3"	"3"		"without quotes, is independent of order"
 "DT019"	"label"	"SEARCH_QUERY"	"aciduria ""type 3"""	"1"		"with quotes, is phrase query"
+"DT020"	"*"	"SEARCH_QUERY"	"aciduria ""type 3"""	"1"		"with quotes, is phrase query"

--- a/molgenis-api-tests/src/test/resources/org/molgenis/api/tests/search/search_mutations-cases.tsv
+++ b/molgenis-api-tests/src/test/resources/org/molgenis/api/tests/search/search_mutations-cases.tsv
@@ -9,7 +9,7 @@
 "MUT008"	"*"	"SEARCH"	"c.6187C>G"	"1"	"M18"	"Finds only the exact mutation"
 "MUT009"	"*"	"SEARCH"	"c.6081_6082dup"	"1"	"M104"	"Finds only the exact mutation"
 "MUT010"	"*"	"SEARCH"	"c.6082G>T"	"1"	"M657"	"Finds only the exact mutation"
-"MUT011"	"*"	"SEARCH"	"C>T"	"0"	""	"Search all is consistent with field search"
+"MUT011"	"*"	"SEARCH"	"C>T"	"143"	"M922"	"C>T also finds the c. in c.5318G>T"
 "MUT012"	"*"	"SEARCH"	"c.6082"	"0"		"Does not find substrings [SHOULD FIND MATHCES]"
 "MUT013"	"cdna_notation"	"LIKE"	"c.6082"	"2"	"M67,M657"	"LIKE finds substrings at the start"
 "MUT014"	"cdna_notation"	"LIKE"	"6082"	"3"	"M67,M657,M104"	"LIKE finds substrings in the middle"

--- a/molgenis-api-tests/src/test/resources/org/molgenis/api/tests/search/search_servers-cases.tsv
+++ b/molgenis-api-tests/src/test/resources/org/molgenis/api/tests/search/search_servers-cases.tsv
@@ -3,7 +3,7 @@
 "SRV002"	"*"	"SEARCH"	"8.3"	"0"		"Search does not find partial matches [SHOULD FIND MATCHES]"
 "SRV003"	"*"	"SEARCH"	"molgenis"	"1"	"molgenis23"	"Finds molgenis in server name"
 "SRV004"	"*"	"SEARCH"	"https://molgenis.org/demo"	"1"	"molgenis09"	"Finds server by exact URL"
-"SRV005"	"*"	"SEARCH"	"SNAPSHOT"	"0"	""	"Searching in all fields is consistent with single field"
+"SRV005"	"*"	"SEARCH"	"SNAPSHOT"	"1"	"molgenis19"	"Tokenizer splits token field when it gets copied to all field"
 "SRV006"	"version"	"SEARCH"	"8.3.11"	"1"	"molgenis09"	"Finds exact match of the server version"
 "SRV007"	"version"	"SEARCH"	"8.3"	"0"		"Search does not find partial matches [SHOULD FIND MATCHES]"
 "SRV008"	"name"	"SEARCH"	"molgenis"	"1"	"molgenis23"	"Finds molgenis in server name"

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchQueryGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchQueryGenerator.java
@@ -33,7 +33,8 @@ class QueryClauseSearchQueryGenerator extends BaseQueryClauseGenerator {
 
   private QueryBuilder createQueryClauseSearchAll(QueryRule queryRule) {
     return QueryBuilders.simpleQueryStringQuery(queryRule.getValue().toString())
-        .defaultOperator(org.elasticsearch.index.query.Operator.AND);
+        .defaultOperator(org.elasticsearch.index.query.Operator.AND)
+        .field("_all");
   }
 
   private QueryBuilder createQueryClauseSearchAttribute(

--- a/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryGenerator.java
+++ b/molgenis-data-elasticsearch/src/main/java/org/molgenis/data/elasticsearch/generator/QueryGenerator.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 /** Generates Elasticsearch queries from MOLGENIS queries. */
 @Component
 public class QueryGenerator {
+
   static final String ATTRIBUTE_SEPARATOR = ".";
 
   private final EnumMap<Operator, QueryClauseGenerator> queryClauseGeneratorMap;
@@ -83,8 +84,9 @@ public class QueryGenerator {
         } else if (i + 1 < nrQueryRules) {
           QueryRule occurQueryRule = queryRules.get(i + 1);
           QueryRule.Operator occurOperator = occurQueryRule.getOperator();
-          if (occurOperator == null)
+          if (occurOperator == null) {
             throw new MolgenisQueryException("Missing expected occur operator");
+          }
 
           //noinspection EnumSwitchStatementWhichMissesCases
           switch (occurOperator) {
@@ -103,7 +105,9 @@ public class QueryGenerator {
         }
 
         QueryBuilder queryPartBuilder = createQueryClause(queryRule, entityType);
-        if (queryPartBuilder == null) continue; // skip SHOULD and DIS_MAX query rules
+        if (queryPartBuilder == null) {
+          continue; // skip SHOULD and DIS_MAX query rules
+        }
 
         //noinspection ConstantConditions
         if (occur == null) {
@@ -142,8 +146,7 @@ public class QueryGenerator {
       case AND:
       case OR:
       case NOT:
-        throw new MolgenisQueryException(
-            format("Unexpected query operator [%s]", queryOperator.toString()));
+        throw new MolgenisQueryException(format("Unexpected query operator [%s]", queryOperator));
       default:
         QueryClauseGenerator queryClauseGenerator = queryClauseGeneratorMap.get(queryOperator);
         if (queryClauseGenerator == null) {

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/client/MappingContentBuilderTest.java
@@ -3,7 +3,6 @@ package org.molgenis.data.elasticsearch.client;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -40,7 +39,7 @@ class MappingContentBuilderTest {
 
   @ParameterizedTest
   @MethodSource("createMappingProvider")
-  void testCreateMapping(MappingType mappingType, String expectedJson) throws IOException {
+  void testCreateMapping(MappingType mappingType, String expectedJson) {
     Mapping mapping =
         createMapping(FieldMapping.builder().setName("field").setType(mappingType).build());
     XContentBuilder xContentBuilder = mappingContentBuilder.createMapping(mapping);
@@ -48,7 +47,7 @@ class MappingContentBuilderTest {
   }
 
   @Test
-  void testCreateMappingKeywordCaseSensitive() throws IOException {
+  void testCreateMappingKeywordCaseSensitive() {
     Mapping mapping =
         createMapping(
             FieldMapping.builder()
@@ -62,7 +61,7 @@ class MappingContentBuilderTest {
   }
 
   @Test
-  void testCreateMappingNested() throws IOException {
+  void testCreateMappingNested() {
     FieldMapping nestedFieldMapping =
         FieldMapping.builder().setName("nestedField").setType(MappingType.BOOLEAN).build();
     Mapping mapping =
@@ -81,23 +80,23 @@ class MappingContentBuilderTest {
   }
 
   private static final String JSON_BOOLEAN =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"boolean\"}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"boolean\",\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_DATE =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"date\",\"format\":\"date\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"date\",\"format\":\"date\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}},\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_DATE_TIME =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"date\",\"format\":\"date_time_no_millis\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"date\",\"format\":\"date_time_no_millis\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}},\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_DOUBLE =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"double\"}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"double\",\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_INTEGER =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"integer\",\"doc_values\":true}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"integer\",\"doc_values\":true,\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_LONG =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"long\"}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"long\",\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_TEXT =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"text\",\"norms\":true,\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true,\"ignore_above\":8191}}}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"text\",\"norms\":true,\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true,\"ignore_above\":8191}},\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_KEYWORD =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"keyword\",\"normalizer\":\"lowercase_asciifold\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"keyword\",\"normalizer\":\"lowercase_asciifold\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}},\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_KEYWORD_CASE_SENSITIVE =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"keyword\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}}}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"keyword\",\"fields\":{\"raw\":{\"type\":\"keyword\",\"index\":true}},\"copy_to\":\"_all\"},\"_all\":{\"type\":\"text\"}}}";
   private static final String JSON_NESTED =
-      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"nested\",\"properties\":{\"nestedField\":{\"type\":\"boolean\"}}}}}";
+      "{\"_source\":{\"enabled\":false},\"properties\":{\"field\":{\"type\":\"nested\",\"properties\":{\"nestedField\":{\"type\":\"boolean\",\"copy_to\":\"_all\"}}},\"_all\":{\"type\":\"text\"}}}";
 }

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchGeneratorTest.java
@@ -1,16 +1,11 @@
 package org.molgenis.data.elasticsearch.generator;
 
-import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
-import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.molgenis.data.elasticsearch.generator.QueryBuilderAssertions.assertQueryBuilderEquals;
 import static org.molgenis.data.meta.AttributeType.STRING;
-import static org.molgenis.data.meta.AttributeType.XREF;
 
-import java.util.List;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -24,6 +19,7 @@ import org.molgenis.data.meta.model.EntityType;
 import org.molgenis.test.AbstractMockitoTest;
 
 class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
+
   @Mock DocumentIdGenerator documentIdGenerator;
   @Mock Attribute attribute1;
   @Mock Attribute attribute2;
@@ -42,24 +38,7 @@ class QueryClauseSearchGeneratorTest extends AbstractMockitoTest {
     EntityType entityType = mock(EntityType.class);
 
     QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
-    QueryBuilder expectedQueryBuilder = boolQuery().should(multiMatchQuery("val"));
-    assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
-  }
-
-  @Test
-  void mapQueryRuleAllAttributeSearchesChildren() {
-    QueryRule queryRule = mock(QueryRule.class);
-    when(queryRule.getValue()).thenReturn("val");
-
-    EntityType entityType = mock(EntityType.class);
-    when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute1, attribute2));
-    when(attribute1.getDataType()).thenReturn(STRING);
-    when(attribute2.getDataType()).thenReturn(XREF);
-    when(documentIdGenerator.generateId(attribute2)).thenReturn("child");
-
-    QueryBuilder queryBuilder = queryClauseSearchGenerator.mapQueryRule(queryRule, entityType);
-    var expectedQueryBuilder = boolQuery().should(multiMatchQuery("val"));
-    expectedQueryBuilder.should().add(nestedQuery("child", multiMatchQuery("val"), ScoreMode.Max));
+    QueryBuilder expectedQueryBuilder = QueryBuilders.matchPhraseQuery("_all", "val").slop(10);
     assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
   }
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchQueryGeneratorTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryClauseSearchQueryGeneratorTest.java
@@ -22,6 +22,7 @@ import org.molgenis.data.meta.model.EntityType;
 
 @ExtendWith(MockitoExtension.class)
 class QueryClauseSearchQueryGeneratorTest {
+
   @Mock DocumentIdGenerator documentIdGenerator;
   @Mock QueryRule queryRule;
   @Mock EntityType entityType;
@@ -40,7 +41,8 @@ class QueryClauseSearchQueryGeneratorTest {
   void mapQueryRuleAllAttributeSearch() {
     when(queryRule.getValue()).thenReturn("val");
     QueryBuilder queryBuilder = searchQueryGenerator.mapQueryRule(queryRule, entityType);
-    QueryBuilder expectedQueryBuilder = simpleQueryStringQuery("val").defaultOperator(AND);
+    QueryBuilder expectedQueryBuilder =
+        simpleQueryStringQuery("val").defaultOperator(AND).field("_all");
     assertQueryBuilderEquals(expectedQueryBuilder, queryBuilder);
   }
 

--- a/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIntegrationTest.java
+++ b/molgenis-data-elasticsearch/src/test/java/org/molgenis/data/elasticsearch/generator/QueryGeneratorIntegrationTest.java
@@ -5,8 +5,8 @@ import static org.elasticsearch.index.query.QueryBuilders.boolQuery;
 import static org.elasticsearch.index.query.QueryBuilders.constantScoreQuery;
 import static org.elasticsearch.index.query.QueryBuilders.existsQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchPhrasePrefixQuery;
+import static org.elasticsearch.index.query.QueryBuilders.matchPhraseQuery;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
-import static org.elasticsearch.index.query.QueryBuilders.multiMatchQuery;
 import static org.elasticsearch.index.query.QueryBuilders.nestedQuery;
 import static org.elasticsearch.index.query.QueryBuilders.rangeQuery;
 import static org.elasticsearch.index.query.QueryBuilders.termQuery;
@@ -1566,12 +1566,7 @@ class QueryGeneratorIntegrationTest extends AbstractMolgenisSpringTest {
     String value = "my text";
     Query<Entity> q = new QueryImpl<>().search(value);
     QueryBuilder query = queryGenerator.createQueryBuilder(q, entityType);
-    QueryBuilder expectedQuery =
-        boolQuery()
-            .should(multiMatchQuery("my text"))
-            .should(nestedQuery("xcategorical", multiMatchQuery("my text"), ScoreMode.Max))
-            .should(nestedQuery("xmref", multiMatchQuery("my text"), ScoreMode.Max))
-            .should(nestedQuery("xxref", multiMatchQuery("my text"), ScoreMode.Max));
+    QueryBuilder expectedQuery = matchPhraseQuery("_all", value).slop(10);
     assertQueryBuilderEquals(expectedQuery, query);
   }
 


### PR DESCRIPTION
In ElasticSearch 7 the `_all` field has been removed. In the upgrade to ES7 done in #8998, the search-all behaviour was refactored to use a multi-match query instead of the `_all` field. We have since found out that this does not perform well enough and in some cases even breaks (see issue #9386).

This PR reimplements the search-all behaviour by introducing a custom `_all` field. All other fields copy their values to this field using the `copy_to` parameter. Search behaviour should now be identical to pre-10.0 versions again. That means that issue #8505 will probably be reopened.

#### Checklist
- [x] Functionality works & meets specifications
- [x] Code reviewed
- [x] Code unit/integration/system tested
- Migration step added in case of breaking change
- User documentation updated
- (If you have changed REST API interface) view-swagger.ftl updated
- Test plan template updated
- [x] Clean commits
- [ ] Added Feature/Fix to release notes
