### PR TITLE
Bump spring-boot-starter-parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.8</version>
+    <version>2.5.12</version>
   </parent>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Bumps `spring-boot-starter-parent` to [2.5.12](https://github.com/spring-projects/spring-boot/releases/tag/v2.5.12), which contains an upgrade to Spring Framework 5.3.18 which contains a fix for [CVE-2022-22965](https://tanzu.vmware.com/security/cve-2022-22965)

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
