### PR TITLE
feat(api-fair): adds management for ONE_TO_MANY data type when creating the RDF model

### DIFF
--- a/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriterV2.java
+++ b/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/EntityModelWriterV2.java
@@ -1,0 +1,299 @@
+package org.molgenis.api.fair.controller;
+
+import static com.google.common.collect.Iterables.contains;
+import static java.util.Arrays.stream;
+import static java.util.Objects.requireNonNull;
+import static org.molgenis.api.fair.controller.FairControllerV2.BASE_URI;
+
+import com.google.common.collect.Streams;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+import org.eclipse.rdf4j.model.BNode;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.molgenis.data.Entity;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.IllegalAttributeTypeException;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.semantic.LabeledResource;
+import org.molgenis.data.semantic.Relation;
+import org.molgenis.data.semantic.SemanticTag;
+import org.molgenis.semanticsearch.service.TagService;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Component
+public class EntityModelWriterV2 {
+
+  public static final String NS_DCAT = "http://www.w3.org/ns/dcat#";
+  public static final String NS_FDP = "https://w3id.org/fdp/fdp-o#";
+  public static final String NS_DATACITE = "http://purl.org/spar/datacite/";
+  public static final String NS_DCT = "http://purl.org/dc/terms/";
+  public static final String NS_RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+  public static final String NS_LDP = "http://www.w3.org/ns/ldp#";
+  static final String DCAT_RESOURCE = NS_DCAT + "Resource";
+  static final String LDP_DIRECT_CONTAINER = NS_LDP + "DirectContainer";
+  private static final String KEYWORD = NS_DCAT + "keyword";
+  private static final DatatypeFactory DATATYPE_FACTORY;
+
+  static {
+    try {
+      DATATYPE_FACTORY = DatatypeFactory.newInstance();
+    } catch (DatatypeConfigurationException e) {
+      throw new Error("Could not instantiate javax.xml.datatype.DatatypeFactory", e);
+    }
+  }
+
+  private final IRI rdfTypePredicate;
+  private final IRI dctIdentifier;
+  private final IRI dataciteIdentifier;
+  private final IRI fdpMetadataIdentifier;
+  private final IRI ldpDirectContainer;
+
+  private final SimpleValueFactory valueFactory;
+  private final TagService<LabeledResource, LabeledResource> tagService;
+
+  public EntityModelWriterV2(
+      TagService<LabeledResource, LabeledResource> tagService, SimpleValueFactory valueFactory) {
+    this.valueFactory = requireNonNull(valueFactory);
+    this.tagService = requireNonNull(tagService);
+    rdfTypePredicate = valueFactory.createIRI(NS_RDF, "type");
+    dctIdentifier = valueFactory.createIRI(NS_DCT, "identifier");
+    dataciteIdentifier = valueFactory.createIRI(NS_DATACITE, "Identifier");
+    fdpMetadataIdentifier = valueFactory.createIRI(NS_FDP, "metadataIdentifier");
+    ldpDirectContainer = valueFactory.createIRI(NS_LDP, "DirectContainer");
+  }
+
+  private void setNamespacePrefixes(Model model) {
+    model.setNamespace("rdf", NS_RDF);
+    model.setNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
+    model.setNamespace("dcat", NS_DCAT);
+    model.setNamespace("xsd", "http://www.w3.org/2001/XMLSchema#");
+    model.setNamespace("owl", "http://www.w3.org/2002/07/owl#");
+    model.setNamespace("dct", NS_DCT);
+    model.setNamespace("lang", "http://id.loc.gov/vocabulary/iso639-1/");
+    model.setNamespace("fdp-o", NS_FDP);
+    model.setNamespace("foaf", "http://xmlns.com/foaf/0.1/");
+    model.setNamespace("orcid", "http://orcid.org/");
+    model.setNamespace("sio", "http://semanticscience.org/resource/");
+    model.setNamespace("datacite", NS_DATACITE);
+    model.setNamespace("mlga", "http://molgenis.org/audit/");
+    model.setNamespace("ldp", NS_LDP);
+  }
+
+  public Model createRdfModel(Entity objectEntity) {
+    Model model = createEmptyModel();
+    Resource subject = createResource(objectEntity);
+    addEntityToModel(subject, objectEntity, model);
+    // If it contains children, the ldp navigation information are included
+    if (objectEntity.getString("hasMemberRelation") != null) {
+      createNavigationResource(objectEntity, subject, model);
+    }
+    return model;
+  }
+
+  /** Creates navigation information using LDP ontology */
+  private void createNavigationResource(Entity objectEntity, Resource subject, Model model) {
+    IRI hasMemberRelation = valueFactory.createIRI(NS_LDP + "hasMemberRelation");
+    IRI membershipResource = valueFactory.createIRI(NS_LDP + "membershipResource");
+    IRI ldpContains = valueFactory.createIRI(NS_LDP + "contains");
+    IRI dctermsTitle = valueFactory.createIRI(NS_DCT + "title");
+    IRI memberRelation = valueFactory.createIRI(objectEntity.getString("hasMemberRelation"));
+
+    Resource directContainer = valueFactory.createIRI(subject + "/dc");
+    model.add(
+        directContainer,
+        dctermsTitle,
+        valueFactory.createLiteral(objectEntity.getString("directContainerTitle")));
+    model.add(directContainer, rdfTypePredicate, ldpDirectContainer);
+    model.add(directContainer, membershipResource, subject);
+    model.add(directContainer, hasMemberRelation, memberRelation);
+    for (Statement child : model.filter(subject, memberRelation, null)) {
+      model.add(directContainer, ldpContains, child.getObject());
+    }
+  }
+
+  public Model createEmptyModel() {
+    Model model = new LinkedHashModel();
+    setNamespacePrefixes(model);
+    return model;
+  }
+
+  public void addEntityToModel(Resource subject, Entity objectEntity, Model model) {
+    EntityType entityType = objectEntity.getEntityType();
+    addStatementsForAttributeTags(objectEntity, model, subject, entityType);
+    addStatementsForEntity(model, subject, objectEntity);
+  }
+
+  private void addStatementsForAttributeTags(
+      Entity objectEntity, Model model, Resource subject, EntityType entityType) {
+    for (Attribute objectAttribute : entityType.getAtomicAttributes()) {
+      Object value = objectEntity.get(objectAttribute.getName());
+      if (value == null) {
+        continue;
+      }
+      for (LabeledResource tag :
+          tagService
+              .getTagsForAttribute(entityType, objectAttribute)
+              .get(Relation.isAssociatedWith)) {
+        IRI predicate = valueFactory.createIRI(tag.getIri());
+        addRelationForAttribute(model, subject, predicate, objectEntity, objectAttribute);
+      }
+    }
+  }
+
+  void addStatementsForEntity(Model model, Resource subject, Entity entity) {
+    for (SemanticTag<EntityType, LabeledResource, LabeledResource> tag :
+        tagService.getTagsForEntity(entity.getEntityType())) {
+      if (tag.getRelation() == Relation.isAssociatedWith) {
+        LabeledResource object = tag.getObject();
+        model.add(subject, rdfTypePredicate, valueFactory.createIRI(object.getIri()));
+        if (DCAT_RESOURCE.equals(object.getIri())) {
+          model.add(subject, fdpMetadataIdentifier, createDataciteIdentifierNode(model, subject));
+        }
+      }
+    }
+  }
+
+  private BNode createDataciteIdentifierNode(Model model, Resource identifier) {
+    BNode result = valueFactory.createBNode();
+    model.add(result, rdfTypePredicate, dataciteIdentifier);
+    model.add(result, dctIdentifier, identifier);
+    return result;
+  }
+
+  private void addRelationForAttribute(
+      Model model,
+      Resource subject,
+      IRI predicate,
+      Entity objectEntity,
+      Attribute objectAttribute) {
+    String name = objectAttribute.getName();
+
+    AttributeType attributeType = objectAttribute.getDataType();
+    switch (attributeType) {
+      case MREF:
+      case CATEGORICAL_MREF:
+      case ONE_TO_MANY:
+        addRelationForMrefTypeAttribute(model, subject, predicate, objectEntity.getEntities(name));
+        break;
+      case BOOL:
+        model.add(subject, predicate, valueFactory.createLiteral(objectEntity.getBoolean(name)));
+        break;
+      case DATE:
+        XMLGregorianCalendar calendar =
+            DATATYPE_FACTORY.newXMLGregorianCalendar(objectEntity.getLocalDate(name).toString());
+        model.add(subject, predicate, valueFactory.createLiteral(calendar));
+        break;
+      case DATE_TIME:
+        calendar =
+            DATATYPE_FACTORY.newXMLGregorianCalendar(objectEntity.getInstant(name).toString());
+        model.add(subject, predicate, valueFactory.createLiteral(calendar));
+        break;
+      case DECIMAL:
+        model.add(subject, predicate, valueFactory.createLiteral(objectEntity.getDouble(name)));
+        break;
+      case LONG:
+        model.add(subject, predicate, valueFactory.createLiteral(objectEntity.getLong(name)));
+        break;
+      case INT:
+        model.add(subject, predicate, valueFactory.createLiteral(objectEntity.getInt(name)));
+        break;
+      case ENUM:
+      case EMAIL:
+      case HTML:
+      case TEXT:
+      case SCRIPT:
+      case STRING:
+        addRelationForStringTypeAttribute(model, subject, predicate, objectEntity.getString(name));
+        break;
+      case HYPERLINK:
+        model.add(subject, predicate, valueFactory.createIRI(objectEntity.getString(name)));
+        break;
+      case XREF:
+      case CATEGORICAL:
+      case FILE:
+        addRelationForXrefTypeAttribute(model, subject, predicate, objectEntity.getEntity(name));
+        break;
+      default:
+        throw new IllegalAttributeTypeException(attributeType);
+    }
+  }
+
+  private void addRelationForStringTypeAttribute(
+      Model model, Resource subject, IRI predicate, String value) {
+    if (predicate.stringValue().equals(KEYWORD)) {
+      stream(value.split(","))
+          .map(String::trim)
+          .forEach(keyword -> model.add(subject, predicate, valueFactory.createLiteral(keyword)));
+    } else {
+      model.add(subject, predicate, valueFactory.createLiteral(value));
+    }
+  }
+
+  private void addRelationForMrefTypeAttribute(
+      Model model, Resource subject, IRI predicate, Iterable<Entity> objectEntities) {
+    for (Entity objectEntity : objectEntities) {
+      addRelationForXrefTypeAttribute(model, subject, predicate, objectEntity);
+    }
+  }
+
+  private void addRelationForXrefTypeAttribute(
+      Model model, Resource subject, IRI predicate, Entity objectEntity) {
+    var objectIRI = createResource(objectEntity);
+    model.add(subject, predicate, objectIRI);
+    if (objectIRI instanceof BNode) {
+      addEntityToModel(objectIRI, objectEntity, model);
+    }
+  }
+
+  public boolean isADcatResource(EntityType entityType) {
+    var tagsForEntity = tagService.getTagsForEntity(entityType);
+    return Streams.stream(tagsForEntity)
+        .filter(tag -> tag.getRelation() == Relation.isAssociatedWith)
+        .map(SemanticTag::getObject)
+        .map(LabeledResource::getIri)
+        .anyMatch(DCAT_RESOURCE::equals);
+  }
+
+  /**
+   * Create a resource. For the resources served by the Controller, give the controller URI as IRI.
+   * For entities with an IRI attribute, give the value of that attribute. Otherwise, create a blank
+   * node.
+   *
+   * @param entity the entity to create a resource for
+   * @return Resource
+   */
+  private Resource createResource(Entity entity) {
+    var entityType = entity.getEntityType();
+    if (contains(entity.getEntityType().getAttributeNames(), "IRI")) {
+      return valueFactory.createIRI(entity.getString("IRI"));
+    }
+
+    if ("fdp_Metadata".equals(entityType.getId())) {
+      return valueFactory.createIRI(getServletUriComponentsBuilder().build().toUriString());
+    }
+
+    if (isADcatResource(entityType)) {
+      var iri =
+          getServletUriComponentsBuilder()
+              .pathSegment(entityType.getId(), entity.getIdValue().toString())
+              .build()
+              .toUriString();
+      return valueFactory.createIRI(iri);
+    }
+    return valueFactory.createBNode(
+        String.format("%s_%s", entity.getEntityType().getId(), entity.getIdValue().toString()));
+  }
+
+  UriComponentsBuilder getServletUriComponentsBuilder() {
+    return ServletUriComponentsBuilder.fromCurrentContextPath().path(BASE_URI);
+  }
+}

--- a/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/FairControllerV2.java
+++ b/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/FairControllerV2.java
@@ -33,12 +33,12 @@ public class FairControllerV2 {
 
   private final DataService dataService;
   private final MetaDataService metaDataService;
-  private final EntityModelWriter entityModelWriter;
+  private final EntityModelWriterV2 entityModelWriter;
 
   FairControllerV2(
       DataService dataService,
       MetaDataService metaDataService,
-      EntityModelWriter entityModelWriter) {
+      EntityModelWriterV2 entityModelWriter) {
     this.dataService = requireNonNull(dataService);
     this.metaDataService = requireNonNull(metaDataService);
     this.entityModelWriter = requireNonNull(entityModelWriter);

--- a/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/FairControllerV2.java
+++ b/molgenis-api-fair/src/main/java/org/molgenis/api/fair/controller/FairControllerV2.java
@@ -1,0 +1,78 @@
+package org.molgenis.api.fair.controller;
+
+import static java.util.Objects.requireNonNull;
+import static org.molgenis.core.ui.converter.RDFMediaType.TEXT_TURTLE_VALUE;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.molgenis.api.ApiNamespace;
+import org.molgenis.data.DataService;
+import org.molgenis.data.Entity;
+import org.molgenis.data.UnknownEntityException;
+import org.molgenis.data.meta.MetaDataService;
+import org.molgenis.data.support.QueryImpl;
+import org.molgenis.security.core.runas.RunAsSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/** Serves metadata for the molgenis FAIR DataPoint. */
+@Controller
+@RequestMapping(FairControllerV2.BASE_URI)
+public class FairControllerV2 {
+  private static final Logger LOG = LoggerFactory.getLogger(FairControllerV2.class);
+
+  static final String BASE_URI = ApiNamespace.API_PATH + "/fdp/v2";
+
+  private final DataService dataService;
+  private final MetaDataService metaDataService;
+  private final EntityModelWriter entityModelWriter;
+
+  FairControllerV2(
+      DataService dataService,
+      MetaDataService metaDataService,
+      EntityModelWriter entityModelWriter) {
+    this.dataService = requireNonNull(dataService);
+    this.metaDataService = requireNonNull(metaDataService);
+    this.entityModelWriter = requireNonNull(entityModelWriter);
+  }
+
+  @GetMapping(produces = TEXT_TURTLE_VALUE)
+  @ResponseBody
+  @RunAsSystem
+  public Model getMetadata() {
+    Entity subjectEntity = dataService.findOne("fdp_Metadata", new QueryImpl<>());
+    return entityModelWriter.createRdfModel(subjectEntity);
+  }
+
+  @GetMapping(produces = TEXT_TURTLE_VALUE, value = "/{entityType}/{entity}")
+  @ResponseBody
+  @RunAsSystem
+  public Model getResource(
+      @PathVariable("entityType") String entityType, @PathVariable("entity") String entity) {
+    var type = metaDataService.getEntityType(entityType).filter(entityModelWriter::isADcatResource);
+    if (!type.isPresent()) {
+      throw new IllegalArgumentException("Entitytype is not a resource");
+    }
+    Entity subjectEntity = dataService.findOneById(entityType, entity);
+    if (subjectEntity == null) {
+      throw new UnknownEntityException(entityType, entity);
+    }
+    return entityModelWriter.createRdfModel(subjectEntity);
+  }
+
+  @ExceptionHandler(UnknownEntityException.class)
+  @ResponseBody
+  @ResponseStatus(BAD_REQUEST)
+  public Model handleUnknownEntityException(UnknownEntityException e) {
+    LOG.warn(e.getMessage(), e);
+    return new LinkedHashModel();
+  }
+}

--- a/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/EntityModelWriterV2Test.java
+++ b/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/EntityModelWriterV2Test.java
@@ -1,0 +1,472 @@
+package org.molgenis.api.fair.controller;
+
+import static com.google.common.collect.Lists.newArrayList;
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.rdf4j.model.vocabulary.RDF.TYPE;
+import static org.eclipse.rdf4j.rio.RDFFormat.TURTLE;
+import static org.eclipse.rdf4j.rio.helpers.BasicWriterSettings.INLINE_BLANK_NODES;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.molgenis.api.fair.controller.EntityModelWriter.DCAT_RESOURCE;
+import static org.molgenis.data.meta.AttributeType.BOOL;
+import static org.molgenis.data.meta.AttributeType.DATE;
+import static org.molgenis.data.meta.AttributeType.DATE_TIME;
+import static org.molgenis.data.meta.AttributeType.DECIMAL;
+import static org.molgenis.data.meta.AttributeType.HYPERLINK;
+import static org.molgenis.data.meta.AttributeType.INT;
+import static org.molgenis.data.meta.AttributeType.LONG;
+import static org.molgenis.data.meta.AttributeType.MREF;
+import static org.molgenis.data.meta.AttributeType.STRING;
+import static org.molgenis.data.meta.AttributeType.XREF;
+import static org.molgenis.data.semantic.Relation.isAssociatedWith;
+
+import com.google.common.collect.ImmutableMultimap;
+import com.google.common.collect.Multimap;
+import java.io.StringWriter;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.Resource;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.WriterConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.molgenis.data.Entity;
+import org.molgenis.data.meta.AttributeType;
+import org.molgenis.data.meta.model.Attribute;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.data.semantic.LabeledResource;
+import org.molgenis.data.semantic.Relation;
+import org.molgenis.data.semantic.SemanticTag;
+import org.molgenis.semanticsearch.service.TagService;
+import org.molgenis.test.AbstractMockitoTest;
+import org.springframework.web.util.UriComponentsBuilder;
+
+class EntityModelWriterV2Test extends AbstractMockitoTest {
+
+  @Mock private TagService<LabeledResource, LabeledResource> tagService;
+  @Mock private Entity objectEntity;
+  @Mock private Entity refEntity;
+  @Mock private EntityType entityType;
+  @Mock private EntityType refEntityType;
+  @Mock private Attribute attribute;
+  @Mock private SemanticTag<EntityType, LabeledResource, LabeledResource> entityTag;
+  @Mock private SemanticTag<EntityType, LabeledResource, LabeledResource> entityTag2;
+  @Mock private LabeledResource labeledResource;
+  @Mock private LabeledResource labeledResource2;
+  private EntityModelWriter writer;
+  private SimpleValueFactory valueFactory = SimpleValueFactory.getInstance();
+
+  static Object[][] createStatementForAttributeProvider() {
+    return new Object[][] {
+      new Object[] {
+        STRING,
+        "value",
+        (Consumer<Entity>)
+            objectEntity -> when(objectEntity.getString("attributeName")).thenReturn("value"),
+        "<http://example.org/iri> \"value\""
+      },
+      new Object[] {
+        INT,
+        2,
+        (Consumer<Entity>) objectEntity -> when(objectEntity.getInt("attributeName")).thenReturn(2),
+        "<http://example.org/iri> \"2\"^^xsd:int"
+      },
+      new Object[] {
+        BOOL,
+        false,
+        (Consumer<Entity>)
+            objectEntity -> when(objectEntity.getBoolean("attributeName")).thenReturn(false),
+        "<http://example.org/iri> false"
+      },
+      new Object[] {
+        DATE,
+        LocalDate.parse("2020-05-09"),
+        (Consumer<Entity>)
+            objectEntity ->
+                when(objectEntity.getLocalDate("attributeName"))
+                    .thenReturn(LocalDate.parse("2020-05-09")),
+        "<http://example.org/iri> \"2020-05-09\"^^xsd:date"
+      },
+      new Object[] {
+        DATE_TIME,
+        Instant.parse("2011-12-03T10:15:30Z"),
+        (Consumer<Entity>)
+            objectEntity ->
+                when(objectEntity.getInstant("attributeName"))
+                    .thenReturn(Instant.parse("2011-12-03T10:15:30Z")),
+        "<http://example.org/iri> \"2011-12-03T10:15:30Z\"^^xsd:dateTime"
+      },
+      new Object[] {
+        DECIMAL,
+        2.18,
+        (Consumer<Entity>)
+            objectEntity -> when(objectEntity.getDouble("attributeName")).thenReturn(2.18),
+        "<http://example.org/iri> 2.18E0"
+      },
+      new Object[] {
+        LONG,
+        987654321L,
+        (Consumer<Entity>)
+            objectEntity -> when(objectEntity.getLong("attributeName")).thenReturn(987654321L),
+        "<http://example.org/iri> \"987654321\"^^xsd:long"
+      },
+      new Object[] {
+        HYPERLINK,
+        "http://example.org/",
+        (Consumer<Entity>)
+            objectEntity ->
+                when(objectEntity.getString("attributeName")).thenReturn("http://example.org"),
+        "<http://example.org/iri> <http://example.org>"
+      }
+    };
+  }
+
+  @SuppressWarnings("unchecked")
+  @BeforeEach
+  void beforeMethod() {
+    writer =
+        new EntityModelWriter(tagService, valueFactory) {
+          @Override
+          UriComponentsBuilder getServletUriComponentsBuilder() {
+            return UriComponentsBuilder.fromUriString("http://example.org/api/fdp/v2");
+          }
+        };
+  }
+
+  @Test
+  void testCreateRfdModelForEntity() {
+    List<Attribute> attributeList = singletonList(attribute);
+
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("catalogId");
+    when(objectEntity.get("attributeName1")).thenReturn("value1");
+    when(objectEntity.getString("attributeName1")).thenReturn("value1");
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    when(entityType.getAtomicAttributes()).thenReturn(attributeList);
+
+    when(attribute.getName()).thenReturn("attributeName1");
+    when(attribute.getDataType()).thenReturn(STRING);
+
+    when(tagService.getTagsForEntity(entityType)).thenReturn(List.of(entityTag, entityTag2));
+    when(entityTag.getRelation()).thenReturn(isAssociatedWith);
+    when(entityTag.getObject()).thenReturn(labeledResource);
+    when(labeledResource.getIri()).thenReturn(DCAT_RESOURCE);
+
+    LabeledResource tag1 = new LabeledResource("http://IRI1.nl", "tag1Label");
+    Multimap<Relation, LabeledResource> tags = ImmutableMultimap.of(isAssociatedWith, tag1);
+    when(tagService.getTagsForAttribute(entityType, attribute)).thenReturn(tags);
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(9, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://IRI1.nl> \"value1\";")
+        .contains(
+            "fdp-o:metadataIdentifier [ a datacite:Identifier;\n"
+                + "      dct:identifier <http://example.org/api/fdp/v2/fdp_Catalog/catalogId>\n"
+                + "    ]")
+        .contains("<http://example.org/api/fdp/v2/fdp_Catalog/catalogId/dc> a ldp:DirectContainer");
+  }
+
+  @Test
+  void testCreateRfdModelForEntityWithoutNagivationInfo() {
+    List<Attribute> attributeList = singletonList(attribute);
+
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("catalogId");
+    when(objectEntity.get("attributeName1")).thenReturn("value1");
+    when(objectEntity.getString("attributeName1")).thenReturn("value1");
+    when(objectEntity.getString("hasMemberRelation")).thenReturn(null);
+
+    when(entityType.getAtomicAttributes()).thenReturn(attributeList);
+
+    when(attribute.getName()).thenReturn("attributeName1");
+    when(attribute.getDataType()).thenReturn(STRING);
+
+    when(tagService.getTagsForEntity(entityType)).thenReturn(List.of(entityTag, entityTag2));
+    when(entityTag.getRelation()).thenReturn(isAssociatedWith);
+    when(entityTag.getObject()).thenReturn(labeledResource);
+    when(labeledResource.getIri()).thenReturn(DCAT_RESOURCE);
+
+    LabeledResource tag1 = new LabeledResource("http://IRI1.nl", "tag1Label");
+    Multimap<Relation, LabeledResource> tags = ImmutableMultimap.of(isAssociatedWith, tag1);
+    when(tagService.getTagsForAttribute(entityType, attribute)).thenReturn(tags);
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(5, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://IRI1.nl> \"value1\";")
+        .contains(
+            "fdp-o:metadataIdentifier [ a datacite:Identifier;\n"
+                + "      dct:identifier <http://example.org/api/fdp/v2/fdp_Catalog/catalogId>\n"
+                + "    ]")
+        .doesNotContain(
+            "<http://example.org/api/fdp/v2/fdp_Catalog/catalogId/dc> a ldp:DirectContainer");
+  }
+
+  @Test
+  void testCreateRfdModelWithCustomIRI() {
+
+    List<Attribute> attributeList = singletonList(attribute);
+
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    //    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getString("IRI")).thenReturn("http://purl.org/example/catalog_id");
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    when(entityType.getAttributeNames()).thenReturn(singletonList("IRI"));
+    when(entityType.getAtomicAttributes()).thenReturn(attributeList);
+
+    when(attribute.getName()).thenReturn("IRI");
+
+    when(tagService.getTagsForEntity(entityType)).thenReturn(List.of(entityTag, entityTag2));
+    when(entityTag.getRelation()).thenReturn(isAssociatedWith);
+    when(entityTag.getObject()).thenReturn(labeledResource);
+    when(labeledResource.getIri()).thenReturn(DCAT_RESOURCE);
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(8, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://purl.org/example/catalog_id> a dcat:Resource")
+        .contains(
+            "fdp-o:metadataIdentifier [ a datacite:Identifier;\n"
+                + "      dct:identifier <http://purl.org/example/catalog_id>\n"
+                + "    ]")
+        .contains("<http://purl.org/example/catalog_id/dc> a ldp:DirectContainer");
+  }
+
+  @ParameterizedTest
+  @MethodSource("createStatementForAttributeProvider")
+  void testCreateStatementForAttribute(
+      AttributeType attributeType, Object value, Consumer<Entity> consumer, String fragment) {
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
+    when(objectEntity.get("attributeName")).thenReturn(value);
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    consumer.accept(objectEntity);
+
+    when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute));
+
+    when(attribute.getName()).thenReturn("attributeName");
+    when(attribute.getDataType()).thenReturn(attributeType);
+
+    Multimap<Relation, LabeledResource> tags =
+        ImmutableMultimap.of(isAssociatedWith, labeledResource);
+    when(labeledResource.getIri()).thenReturn("http://example.org/iri");
+    when(tagService.getTagsForAttribute(entityType, attribute)).thenReturn(tags);
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString()).contains(fragment);
+  }
+
+  @Test
+  void testCreateRfdModelXREF() {
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
+    when(objectEntity.get("attributeName")).thenReturn(refEntity);
+    when(objectEntity.getEntity("attributeName")).thenReturn(refEntity);
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    when(refEntity.getEntityType()).thenReturn(refEntityType);
+    when(refEntityType.getAttributeNames()).thenReturn(List.of("IRI"));
+    when(refEntity.getString("IRI")).thenReturn("http://example.org/refEntity");
+
+    when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute));
+    when(attribute.getName()).thenReturn("attributeName");
+
+    when(attribute.getDataType()).thenReturn(XREF);
+
+    when(tagService.getTagsForAttribute(entityType, attribute))
+        .thenReturn(ImmutableMultimap.of(isAssociatedWith, labeledResource));
+    when(labeledResource.getIri()).thenReturn("http://example.org/relation");
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(5, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://example.org/relation> <http://example.org/refEntity>");
+  }
+
+  @Test
+  void testCreateRfdModelXREFMultipleTags() {
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
+    when(objectEntity.get("attributeName")).thenReturn(refEntity);
+    when(objectEntity.getEntity("attributeName")).thenReturn(refEntity);
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    when(refEntity.getEntityType()).thenReturn(refEntityType);
+    when(refEntity.getIdValue()).thenReturn("refEntityId");
+    when(refEntityType.getId()).thenReturn("refEntityType");
+    when(refEntityType.getAttributeNames()).thenReturn(new ArrayList<>());
+
+    when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute));
+    when(attribute.getName()).thenReturn("attributeName");
+
+    when(attribute.getDataType()).thenReturn(XREF);
+
+    when(tagService.getTagsForAttribute(entityType, attribute))
+        .thenReturn(
+            ImmutableMultimap.of(
+                isAssociatedWith, labeledResource, isAssociatedWith, labeledResource2));
+    when(labeledResource.getIri()).thenReturn("http://example.org/relation");
+    when(labeledResource2.getIri()).thenReturn("http://example.org/relation2");
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(6, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://example.org/relation> _:refEntityType_refEntityId")
+        .contains("<http://example.org/relation2> _:refEntityType_refEntityId");
+  }
+
+  @Test
+  void testCreateRfdModelMREF() {
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getId()).thenReturn("fdp_Catalog");
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
+    when(objectEntity.get("attributeName")).thenReturn(refEntity);
+    when(objectEntity.getEntities("attributeName")).thenReturn(List.of(refEntity));
+
+    when(refEntity.getEntityType()).thenReturn(refEntityType);
+    when(refEntityType.getAttributeNames()).thenReturn(List.of("IRI"));
+    when(refEntity.getString("IRI")).thenReturn("http://example.org/refEntity");
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute));
+    when(attribute.getName()).thenReturn("attributeName");
+
+    when(attribute.getDataType()).thenReturn(MREF);
+
+    when(tagService.getTagsForAttribute(entityType, attribute))
+        .thenReturn(ImmutableMultimap.of(isAssociatedWith, labeledResource));
+    when(labeledResource.getIri()).thenReturn("http://example.org/relation");
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(5, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+    assertThat(writer.toString())
+        .contains("<http://example.org/relation> <http://example.org/refEntity>");
+  }
+
+  @Test
+  void testCreateRfdModelSTRINGKeywords() {
+    Entity objectEntity = mock(Entity.class);
+    EntityType entityType = mock(EntityType.class);
+
+    Attribute attribute = mock(Attribute.class);
+    List<Attribute> attributeList = singletonList(attribute);
+
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    String value = "molgenis,genetics,fair";
+    when(objectEntity.getIdValue()).thenReturn("attributeName");
+    when(objectEntity.get("attributeName")).thenReturn(value);
+    when(objectEntity.getString("attributeName")).thenReturn(value);
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    when(entityType.getAtomicAttributes()).thenReturn(attributeList);
+    when(attribute.getName()).thenReturn("attributeName");
+
+    when(attribute.getDataType()).thenReturn(STRING);
+
+    LabeledResource tag = new LabeledResource("http://www.w3.org/ns/dcat#keyword", "keywords");
+    Multimap<Relation, LabeledResource> tags = ImmutableMultimap.of(isAssociatedWith, tag);
+    when(tagService.getTagsForAttribute(entityType, attribute)).thenReturn(tags);
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    assertEquals(7, result.size());
+    StringWriter writer = new StringWriter();
+    Rio.write(result, writer, TURTLE, new WriterConfig().set(INLINE_BLANK_NODES, true));
+
+    assertThat(writer.toString()).contains("dcat:keyword \"molgenis\", \"genetics\", \"fair\"");
+  }
+
+  @Test
+  void testCreateRfdModelNullValue() {
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(entityType.getAtomicAttributes()).thenReturn(List.of(attribute));
+    when(objectEntity.getIdValue()).thenReturn("attributeName1");
+    when(objectEntity.get("attributeName1")).thenReturn(null);
+    when(attribute.getName()).thenReturn("attributeName1");
+    when(objectEntity.getString("directContainerTitle")).thenReturn("Children");
+    when(objectEntity.getString("hasMemberRelation"))
+        .thenReturn("http://purl.org/fdp/fdp-o#relation");
+
+    Model result = writer.createRdfModel(objectEntity);
+
+    //    assertTrue(result.isEmpty());
+    assertEquals(4, result.size());
+  }
+
+  @Test
+  void testAddStatementsForEntityType() {
+    Model model = new LinkedHashModel();
+    Resource subject = valueFactory.createIRI("http://example.org/subject");
+    LabeledResource object = new LabeledResource("http://example.org/object", "object");
+    LabeledResource codeSystem = new LabeledResource("ex:object");
+
+    SemanticTag<EntityType, LabeledResource, LabeledResource> tag =
+        new SemanticTag<>("tagId", entityType, isAssociatedWith, object, codeSystem);
+
+    when(objectEntity.getEntityType()).thenReturn(entityType);
+    when(tagService.getTagsForEntity(entityType)).thenReturn(List.of(tag));
+
+    writer.addStatementsForEntity(model, subject, objectEntity);
+
+    Statement statement =
+        valueFactory.createStatement(
+            subject, TYPE, valueFactory.createIRI("http://example.org/object"));
+    assertEquals(singletonList(statement), newArrayList(model));
+  }
+}

--- a/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/FairControllerV2Test.java
+++ b/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/FairControllerV2Test.java
@@ -1,0 +1,87 @@
+package org.molgenis.api.fair.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.molgenis.core.ui.converter.RdfConverter;
+import org.molgenis.data.DataService;
+import org.molgenis.data.Entity;
+import org.molgenis.data.meta.MetaDataService;
+import org.molgenis.data.meta.model.EntityType;
+import org.molgenis.test.AbstractMockitoSpringContextTests;
+import org.molgenis.web.converter.GsonWebConfig;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.FormHttpMessageConverter;
+import org.springframework.http.converter.json.GsonHttpMessageConverter;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.ForwardedHeaderFilter;
+
+@WebAppConfiguration
+@ContextConfiguration(classes = {GsonWebConfig.class})
+class FairControllerV2Test extends AbstractMockitoSpringContextTests {
+
+  @Mock private DataService dataService;
+  @Mock private MetaDataService metaDataService;
+  @Mock private EntityModelWriter entityModelWriter;
+  @Mock private EntityType catalogMeta;
+
+  private MockMvc mockMvc;
+
+  @Autowired private GsonHttpMessageConverter gsonHttpMessageConverter;
+
+  @BeforeEach
+  void beforeTest() {
+    FairControllerV2 controller =
+        new FairControllerV2(dataService, metaDataService, entityModelWriter);
+
+    mockMvc =
+        MockMvcBuilders.standaloneSetup(controller)
+            .setMessageConverters(
+                new FormHttpMessageConverter(), gsonHttpMessageConverter, new RdfConverter())
+            .addFilter(new ForwardedHeaderFilter())
+            .build();
+  }
+
+  @Test
+  void getCatalogTest() throws Exception {
+    Entity answer = mock(Entity.class);
+
+    when(metaDataService.getEntityType("fdp_Catalog")).thenReturn(Optional.of(catalogMeta));
+    when(entityModelWriter.isADcatResource(catalogMeta)).thenReturn(true);
+    when(dataService.findOneById("fdp_Catalog", "catalogID")).thenReturn(answer);
+
+    this.mockMvc
+        .perform(
+            get(URI.create(
+                    "http://molgenis01.gcc.rug.nl:8080/api/fdp/v2/fdp_Catalog/catalogID?blah=value"))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+        .andExpect(status().isOk());
+
+    Mockito.verify(entityModelWriter).createRdfModel(answer);
+  }
+
+  @Test
+  void getCatalogTestUnknownCatalog() throws Exception {
+    when(metaDataService.getEntityType("fdp_Catalog")).thenReturn(Optional.of(catalogMeta));
+    when(entityModelWriter.isADcatResource(catalogMeta)).thenReturn(true);
+
+    this.mockMvc
+        .perform(
+            get(URI.create(
+                    "http://molgenis01.gcc.rug.nl:8080/api/fdp/v2/fdp_Catalog/catalogID?blah=value"))
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED))
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/FairControllerV2Test.java
+++ b/molgenis-api-fair/src/test/java/org/molgenis/api/fair/controller/FairControllerV2Test.java
@@ -34,7 +34,7 @@ class FairControllerV2Test extends AbstractMockitoSpringContextTests {
 
   @Mock private DataService dataService;
   @Mock private MetaDataService metaDataService;
-  @Mock private EntityModelWriter entityModelWriter;
+  @Mock private EntityModelWriterV2 entityModelWriter;
   @Mock private EntityType catalogMeta;
 
   private MockMvc mockMvc;


### PR DESCRIPTION
Very simple PR that adds ONE_TO_MANY datatype handling when creating the RDF model.

It is handled as an MREF attribute

#### Checklist
- [ ] Functionality works & meets specifications
- [ ] Code reviewed
- [ ] Code unit/integration/system tested
- [ ] Migration step added in case of breaking change
- [ ] User documentation updated
- [ ] (If you have changed REST API interface) view-swagger.ftl updated
- [ ] Test plan template updated
- [ ] Clean commits
- [ ] Added Feature/Fix to release notes
